### PR TITLE
Fix get_task_counts inboxView filtering

### DIFF
--- a/Tests/OmniFocusIntegrationTests/OmniFocusIntegrationTests.swift
+++ b/Tests/OmniFocusIntegrationTests/OmniFocusIntegrationTests.swift
@@ -69,6 +69,23 @@ func bridgeTaskCountsLive() throws {
 }
 
 @Test
+func bridgeInboxViewCountsMatchListTasksLive() throws {
+    let env = ProcessInfo.processInfo.environment
+    guard env["FOCUS_RELAY_BRIDGE_TESTS"] == "1" else {
+        return
+    }
+
+    let client = BridgeClient()
+    let views = ["remaining", "available", "everything"]
+    for view in views {
+        let filter = TaskFilter(inboxView: view, inboxOnly: true, includeTotalCount: true)
+        let counts = try client.getTaskCounts(filter: filter)
+        let page = try client.listTasks(filter: filter, page: PageRequest(limit: 50), fields: ["id"])
+        #expect(counts.total == (page.totalCount ?? -1))
+    }
+}
+
+@Test
 func bridgeProjectCountsLive() throws {
     let env = ProcessInfo.processInfo.environment
     guard env["FOCUS_RELAY_BRIDGE_TESTS"] == "1" else {


### PR DESCRIPTION
## Summary
- Apply inboxView semantics to get_task_counts to match list_tasks
- Ensure completed/drop/parent-drop and default available filtering align with list_tasks
- Add live integration test to verify count consistency across inbox views

## Testing
- swift test
- FOCUS_RELAY_BRIDGE_TESTS=1 swift test