### PR TITLE
Fix stale list_tasks cursor pagination in bridge

### DIFF
--- a/Tests/OmniFocusIntegrationTests/OmniFocusIntegrationTests.swift
+++ b/Tests/OmniFocusIntegrationTests/OmniFocusIntegrationTests.swift
@@ -57,6 +57,25 @@ func bridgeListInboxLive() throws {
 }
 
 @Test
+func bridgeListInboxPagingCursorAdvancesLive() throws {
+    let env = ProcessInfo.processInfo.environment
+    guard env["FOCUS_RELAY_BRIDGE_TESTS"] == "1" else {
+        return
+    }
+
+    let client = BridgeClient()
+    let filter = TaskFilter(inboxOnly: true)
+    let first = try client.listTasks(filter: filter, page: PageRequest(limit: 5), fields: ["id", "name"])
+
+    guard first.items.count == 5, let cursor = first.nextCursor else {
+        return
+    }
+
+    let second = try client.listTasks(filter: filter, page: PageRequest(limit: 5, cursor: cursor), fields: ["id", "name"])
+    #expect(!second.items.isEmpty, "Expected non-empty second page when first page is full and returned nextCursor")
+}
+
+@Test
 func bridgeTaskCountsLive() throws {
     let env = ProcessInfo.processInfo.environment
     guard env["FOCUS_RELAY_BRIDGE_TESTS"] == "1" else {


### PR DESCRIPTION
## Summary
- fix `list_tasks` pagination semantics in `BridgeLibrary.js`
- apply cursor/limit after filtering and sorting, not before
- compute `nextCursor` from filtered result size so follow-up pages are valid
- add a live regression test that fails on stale cursor behavior

## Root cause
The bridge limited matches to `limit` before applying `cursor`. For inbox queries this produced `nextCursor: "5"` on page 1, then page 2 with `--cursor 5` returned no items because only 5 filtered records were retained.

## Repro
```bash
focusrelay list-tasks --inbox-only true --limit 5
focusrelay list-tasks --inbox-only true --limit 5 --cursor 5
```
Before: second call returned `{"items":[]}`.
After: second call returns the next items.

## Validation
- `FOCUS_RELAY_BRIDGE_TESTS=1 swift test --filter bridgeListInboxPagingCursorAdvancesLive`
- Manual CLI repro above now returns a non-empty second page in my dataset.
