### PR TITLE
Optimize documented read paths and keep plugin-url default

### DIFF
--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -880,6 +880,16 @@
         } else if (request.op === "get_task_counts") {
           const filter = request.filter || {};
           const debugTaskCounts = filter.search === "__debug_task_counts__";
+          const taskCountsDebug = debugTaskCounts ? {
+            requestId: requestId,
+            op: request.op,
+            marks: []
+          } : null;
+          const markTaskCounts = (label, extra) => {
+            if (!taskCountsDebug) { return; }
+            const entry = Object.assign({ label: label, ms: Date.now() - start }, extra || {});
+            taskCountsDebug.marks.push(entry);
+          };
 
           const inboxView = (typeof filter.inboxView === "string") ? filter.inboxView.toLowerCase() : "available";
           const isEverything = inboxView === "everything";
@@ -918,6 +928,7 @@
           // Use same filtering logic as list_tasks for consistency.
           // Task pool is selected from native OmniFocus collections first,
           // then filtered with the same semantics as list_tasks.
+          const poolStart = Date.now();
           let tasks = selectTaskPool();
           const debugInfo = debugTaskCounts ? {
             requestId: requestId,
@@ -926,38 +937,26 @@
             projectView: projectView,
             initialPoolCount: tasks.length
           } : null;
+          markTaskCounts("selected_base_pool", {
+            count: tasks.length,
+            durationMs: Date.now() - poolStart,
+            inboxOnly: filter.inboxOnly === true,
+            projectFilter: filter.project || null,
+            projectView: projectView,
+            availableOnly: availableOnly
+          });
 
-          function sampleTasks(list) {
-            return list.slice(0, 5).map(task => {
-              const project = safe(() => task.containingProject);
-              const parent = safe(() => task.parent);
-              return {
-                id: String(safe(() => task.id.primaryKey) || ""),
-                name: String(safe(() => task.name) || ""),
-                taskStatus: String(taskStatus(task)),
-                available: isTaskAvailable(task),
-                projectStatus: project ? String(safe(() => project.status) || "") : null,
-                parentStatus: parent ? String(taskStatus(parent)) : null
-              };
-            });
-          }
-
-          if (typeof filter.completed === "boolean") {
-            tasks = tasks.filter(t => isCompletedStatus(t) === filter.completed);
-          } else if (!isEverything) {
-            tasks = tasks.filter(t => isRemainingStatus(t));
-          }
-          if (debugInfo) {
-            debugInfo.afterCompletedFilterCount = tasks.length;
-            debugInfo.afterCompletedFilterSample = sampleTasks(tasks);
-          }
-
-          if (availableOnly) {
-            tasks = tasks.filter(t => isTaskAvailable(t));
-          }
-          if (debugInfo) {
-            debugInfo.afterAvailableFilterCount = tasks.length;
-            debugInfo.afterAvailableFilterSample = sampleTasks(tasks);
+          function sampleTask(task) {
+            const project = safe(() => task.containingProject);
+            const parent = safe(() => task.parent);
+            return {
+              id: String(safe(() => task.id.primaryKey) || ""),
+              name: String(safe(() => task.name) || ""),
+              taskStatus: String(taskStatus(task)),
+              available: isTaskAvailable(task),
+              projectStatus: project ? String(safe(() => project.status) || "") : null,
+              parentStatus: parent ? String(taskStatus(parent)) : null
+            };
           }
 
           // Parse filter dates
@@ -980,112 +979,134 @@
             minEstimatedMinutes: filter.minEstimatedMinutes
           };
 
-          // Apply filters
-          tasks = tasks.filter(t => {
+          const statusGateSample = [];
+          const availableGateSample = [];
+          const finalSample = [];
+          let afterStatusGateCount = 0;
+          let afterAvailableGateCount = 0;
+
+          const counts = { total: 0, completed: 0, available: 0, flagged: 0 };
+          const countPassStart = Date.now();
+          tasks.forEach(t => {
             const project = safe(() => t.containingProject);
+            const taskCompleted = isCompletedStatus(t);
+            const taskDropped = isDroppedStatus(t);
+            const taskRemaining = !taskCompleted && !taskDropped;
+            const taskAvailable = isTaskAvailable(t);
+            const taskFlagged = Boolean(t.flagged);
 
             if (filterState.completed !== undefined) {
-              const taskCompleted = isCompletedStatus(t);
-              if (taskCompleted !== filterState.completed) return false;
+              if (taskCompleted !== filterState.completed) return;
             } else if (!isEverything) {
-              if (!isRemainingStatus(t)) return false;
+              if (!taskRemaining) return;
             }
+            afterStatusGateCount += 1;
+            if (debugInfo && statusGateSample.length < 5) {
+              statusGateSample.push(sampleTask(t));
+            }
+
             if (filterState.flagged !== undefined) {
-              const taskFlagged = Boolean(t.flagged);
-              if (taskFlagged !== filterState.flagged) return false;
+              if (taskFlagged !== filterState.flagged) return;
             }
             if (filterState.availableOnly) {
-              if (!isTaskAvailable(t)) return false;
+              if (!taskAvailable) return;
             }
+            afterAvailableGateCount += 1;
+            if (debugInfo && availableGateSample.length < 5) {
+              availableGateSample.push(sampleTask(t));
+            }
+
             if (filterState.projectFilter) {
-              if (!project) return false;
+              if (!project) return;
               const pid = String(safe(() => project.id.primaryKey) || "");
               const pname = String(safe(() => project.name) || "");
-              if (pid !== filterState.projectFilter && pname !== filterState.projectFilter) return false;
+              if (pid !== filterState.projectFilter && pname !== filterState.projectFilter) return;
             }
             if (projectView) {
-              if (!projectMatchesView(project, projectView, true)) return false;
+              if (!projectMatchesView(project, projectView, true)) return;
             }
             if (filterState.dueBefore) {
               const due = getTaskDateTimestamp(t, task => task.dueDate);
-              if (due === null || due > filterState.dueBefore.getTime()) return false;
+              if (due === null || due > filterState.dueBefore.getTime()) return;
             }
             if (filterState.dueAfter) {
               const due = getTaskDateTimestamp(t, task => task.dueDate);
-              if (due === null || due < filterState.dueAfter.getTime()) return false;
+              if (due === null || due < filterState.dueAfter.getTime()) return;
             }
             if (filterState.deferBefore) {
               const defer = getTaskDateTimestamp(t, task => task.deferDate);
-              if (defer === null || defer > filterState.deferBefore.getTime()) return false;
+              if (defer === null || defer > filterState.deferBefore.getTime()) return;
             }
             if (filterState.deferAfter) {
               const defer = getTaskDateTimestamp(t, task => task.deferDate);
-              if (defer === null || defer < filterState.deferAfter.getTime()) return false;
+              if (defer === null || defer < filterState.deferAfter.getTime()) return;
             }
             if (filterState.plannedBefore) {
               const planned = getTaskDateTimestamp(t, task => task.plannedDate);
-              if (planned === null || planned > filterState.plannedBefore.getTime()) return false;
+              if (planned === null || planned > filterState.plannedBefore.getTime()) return;
             }
             if (filterState.plannedAfter) {
               const planned = getTaskDateTimestamp(t, task => task.plannedDate);
-              if (planned === null || planned < filterState.plannedAfter.getTime()) return false;
+              if (planned === null || planned < filterState.plannedAfter.getTime()) return;
             }
             if (filterState.completedBefore) {
               const completed = getTaskDateTimestamp(t, task => task.completionDate);
-              if (completed === null || completed > filterState.completedBefore.getTime()) return false;
+              if (completed === null || completed > filterState.completedBefore.getTime()) return;
             }
             if (filterState.completedAfter) {
               const completed = getTaskDateTimestamp(t, task => task.completionDate);
-              if (completed === null || completed < filterState.completedAfter.getTime()) return false;
+              if (completed === null || completed < filterState.completedAfter.getTime()) return;
             }
             if (filterState.maxEstimatedMinutes !== undefined) {
               const minutes = safe(() => t.estimatedMinutes);
-              if (minutes === null || minutes === undefined || minutes > filterState.maxEstimatedMinutes) return false;
+              if (minutes === null || minutes === undefined || minutes > filterState.maxEstimatedMinutes) return;
             }
             if (filterState.minEstimatedMinutes !== undefined) {
               const minutes = safe(() => t.estimatedMinutes);
-              if (minutes === null || minutes === undefined || minutes < filterState.minEstimatedMinutes) return false;
+              if (minutes === null || minutes === undefined || minutes < filterState.minEstimatedMinutes) return;
             }
             if (filterState.tags) {
               const tags = safe(() => t.tags) || [];
               if (filterState.untaggedOnly) {
-                if (tags.length > 0) return false;
+                if (tags.length > 0) return;
               } else {
                 const hasMatchingTag = tags.some(tag => {
                   const tagId = String(safe(() => tag.id.primaryKey) || "");
                   const tagName = String(safe(() => tag.name) || "");
                   return filterState.tags.some(filterTag => tagId === filterTag || tagName === filterTag);
                 });
-                if (!hasMatchingTag) return false;
+                if (!hasMatchingTag) return;
               }
             }
-            return true;
+            counts.total += 1;
+            if (taskCompleted) { counts.completed += 1; }
+            if (taskAvailable) { counts.available += 1; }
+            if (taskFlagged) { counts.flagged += 1; }
+            if (debugInfo && finalSample.length < 5) {
+              finalSample.push(sampleTask(t));
+            }
+          });
+          markTaskCounts("after_count_pass", {
+            count: counts.total,
+            durationMs: Date.now() - countPassStart,
+            afterStatusGateCount: afterStatusGateCount,
+            afterAvailableGateCount: afterAvailableGateCount,
+            counts: counts
           });
           if (debugInfo) {
-            debugInfo.afterAllFiltersCount = tasks.length;
-            debugInfo.afterAllFiltersSample = sampleTasks(tasks);
+            debugInfo.afterCompletedFilterCount = afterStatusGateCount;
+            debugInfo.afterCompletedFilterSample = statusGateSample;
+            debugInfo.afterAvailableFilterCount = afterAvailableGateCount;
+            debugInfo.afterAvailableFilterSample = availableGateSample;
+            debugInfo.afterAllFiltersCount = counts.total;
+            debugInfo.afterAllFiltersSample = finalSample;
           }
-
-          // Sort by completion date descending when filtering by completion
-          if (filterState.completed === true || filterState.completedAfter || filterState.completedBefore) {
-            tasks.sort((a, b) => {
-              const dateA = getTaskDateTimestamp(a, t => t.completionDate) || 0;
-              const dateB = getTaskDateTimestamp(b, t => t.completionDate) || 0;
-              return dateB - dateA;
-            });
-          }
-
-          const counts = { total: 0, completed: 0, available: 0, flagged: 0 };
-          tasks.forEach(t => {
-            counts.total += 1;
-            if (isCompletedStatus(t)) { counts.completed += 1; }
-            if (isTaskAvailable(t)) { counts.available += 1; }
-            if (Boolean(t.flagged)) { counts.flagged += 1; }
-          });
           if (debugInfo) {
             debugInfo.counts = counts;
+            taskCountsDebug.debugInfo = debugInfo;
+            taskCountsDebug.totalTimingMs = Date.now() - start;
             try {
-              writeJSON(basePath + "/logs/get_task_counts_debug_" + requestId + ".json", debugInfo);
+              writeJSON(basePath + "/logs/get_task_counts_debug_" + requestId + ".json", taskCountsDebug);
             } catch (debugError) {}
           }
 

--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -1113,6 +1113,17 @@
           response.data = counts;
 } else if (request.op === "get_project_counts") {
           const filter = request.filter || {};
+          const debugProjectCounts = filter.search === "__debug_project_counts__";
+          const projectCountsDebug = debugProjectCounts ? {
+            requestId: requestId,
+            op: request.op,
+            marks: []
+          } : null;
+          const markProjectCounts = (label, extra) => {
+            if (!projectCountsDebug) { return; }
+            const entry = Object.assign({ label: label, ms: Date.now() - start }, extra || {});
+            projectCountsDebug.marks.push(entry);
+          };
           
           // Check if this is a completion date query
           const completedAfter = filter.completedAfter ? parseFilterDate(filter.completedAfter, response.warnings) : null;
@@ -1121,6 +1132,7 @@
           
           if (completedOnly || completedAfter || completedBefore) {
             // Count completed projects by completion date
+            const completedProjectsStart = Date.now();
             let projects = flattenedProjects.filter(p => {
               const status = safe(() => p.status);
               // Only include completed projects (status = Done), exclude dropped
@@ -1134,27 +1146,36 @@
               
               return true;
             });
+            markProjectCounts("selected_completed_projects", {
+              count: projects.length,
+              durationMs: Date.now() - completedProjectsStart
+            });
             
             const projectCount = projects.length;
             
             // Count completed tasks in those projects
             const projectIds = new Set(projects.map(p => String(safe(() => p.id.primaryKey) || "")));
             let completedTaskCount = 0;
+            const completedTaskCountStart = Date.now();
             
             flattenedTasks.forEach(t => {
               const project = safe(() => t.containingProject);
-              if (!project) return;
+              if (!project) { return; }
               const pid = String(safe(() => project.id.primaryKey) || "");
               if (projectIds.has(pid) && isCompletedStatus(t)) {
                 const taskCompletionDate = getTaskDateTimestamp(t, task => task.completionDate);
-                if (taskCompletionDate !== null) {
-                  // Only count tasks completed in the same window
-                  if ((!completedAfter || taskCompletionDate >= completedAfter.getTime()) &&
-                      (!completedBefore || taskCompletionDate < completedBefore.getTime())) {
-                    completedTaskCount++;
-                  }
+                if (taskCompletionDate === null) { return; }
+                // Only count tasks completed in the same window
+                if ((!completedAfter || taskCompletionDate >= completedAfter.getTime()) &&
+                    (!completedBefore || taskCompletionDate < completedBefore.getTime())) {
+                  completedTaskCount++;
                 }
               }
+            });
+            markProjectCounts("counted_completed_tasks", {
+              durationMs: Date.now() - completedTaskCountStart,
+              projectCount: projectCount,
+              actionCount: completedTaskCount
             });
             
             response.data = { projects: projectCount, actions: completedTaskCount };
@@ -1192,9 +1213,27 @@
             if (filter.project && !project) {
               tasks = [];
             } else if (project) {
+              const poolStart = Date.now();
               tasks = toTaskArray(safe(() => project.flattenedTasks));
+              markProjectCounts("selected_base_pool", {
+                count: tasks.length,
+                durationMs: Date.now() - poolStart,
+                projectFilter: filter.project,
+                projectView: rawProjectView,
+                availableOnly: derivedAvailableOnly,
+                completed: derivedCompleted
+              });
             } else {
+              const poolStart = Date.now();
               tasks = toTaskArray(safe(() => flattenedTasks));
+              markProjectCounts("selected_base_pool", {
+                count: tasks.length,
+                durationMs: Date.now() - poolStart,
+                projectFilter: null,
+                projectView: rawProjectView,
+                availableOnly: derivedAvailableOnly,
+                completed: derivedCompleted
+              });
             }
 
             const filterState = {
@@ -1217,97 +1256,105 @@
               minEstimatedMinutes: filter.minEstimatedMinutes
             };
 
-            tasks = tasks.filter(t => {
+            const projectIds = new Set();
+            let actionCount = 0;
+            const countPassStart = Date.now();
+            tasks.forEach(t => {
               const project = safe(() => t.containingProject);
-              if (!project) { return false; }
+              if (!project) { return; }
 
               if (filterState.completed !== undefined) {
-                if (isCompletedStatus(t) !== filterState.completed) return false;
+                if (isCompletedStatus(t) !== filterState.completed) return;
               } else if (rawProjectView !== "everything") {
-                if (!isRemainingStatus(t)) return false;
+                if (!isRemainingStatus(t)) return;
               }
 
               if (filterState.flagged !== undefined) {
-                if (Boolean(t.flagged) !== filterState.flagged) return false;
+                if (Boolean(t.flagged) !== filterState.flagged) return;
               }
               if (filterState.availableOnly) {
-                if (!isTaskAvailable(t)) return false;
+                if (!isTaskAvailable(t)) return;
               }
               if (filterState.projectFilter) {
                 const pid = String(safe(() => project.id.primaryKey) || "");
                 const pname = String(safe(() => project.name) || "");
-                if (pid !== filterState.projectFilter && pname !== filterState.projectFilter) return false;
+                if (pid !== filterState.projectFilter && pname !== filterState.projectFilter) return;
               }
               if (filterState.projectView) {
-                if (!projectMatchesView(project, filterState.projectView, true)) return false;
+                if (!projectMatchesView(project, filterState.projectView, true)) return;
               }
               if (filterState.dueBefore) {
                 const due = getTaskDateTimestamp(t, task => task.dueDate);
-                if (due === null || due > filterState.dueBefore.getTime()) return false;
+                if (due === null || due > filterState.dueBefore.getTime()) return;
               }
               if (filterState.dueAfter) {
                 const due = getTaskDateTimestamp(t, task => task.dueDate);
-                if (due === null || due < filterState.dueAfter.getTime()) return false;
+                if (due === null || due < filterState.dueAfter.getTime()) return;
               }
               if (filterState.deferBefore) {
                 const defer = getTaskDateTimestamp(t, task => task.deferDate);
-                if (defer === null || defer > filterState.deferBefore.getTime()) return false;
+                if (defer === null || defer > filterState.deferBefore.getTime()) return;
               }
               if (filterState.deferAfter) {
                 const defer = getTaskDateTimestamp(t, task => task.deferDate);
-                if (defer === null || defer < filterState.deferAfter.getTime()) return false;
+                if (defer === null || defer < filterState.deferAfter.getTime()) return;
               }
               if (filterState.plannedBefore) {
                 const planned = getTaskDateTimestamp(t, task => task.plannedDate);
-                if (planned === null || planned > filterState.plannedBefore.getTime()) return false;
+                if (planned === null || planned > filterState.plannedBefore.getTime()) return;
               }
               if (filterState.plannedAfter) {
                 const planned = getTaskDateTimestamp(t, task => task.plannedDate);
-                if (planned === null || planned < filterState.plannedAfter.getTime()) return false;
+                if (planned === null || planned < filterState.plannedAfter.getTime()) return;
               }
               if (filterState.completedBefore) {
                 const completed = getTaskDateTimestamp(t, task => task.completionDate);
-                if (completed === null || completed > filterState.completedBefore.getTime()) return false;
+                if (completed === null || completed > filterState.completedBefore.getTime()) return;
               }
               if (filterState.completedAfter) {
                 const completed = getTaskDateTimestamp(t, task => task.completionDate);
-                if (completed === null || completed < filterState.completedAfter.getTime()) return false;
+                if (completed === null || completed < filterState.completedAfter.getTime()) return;
               }
               if (filterState.maxEstimatedMinutes !== undefined) {
                 const minutes = safe(() => t.estimatedMinutes);
-                if (minutes === null || minutes === undefined || minutes > filterState.maxEstimatedMinutes) return false;
+                if (minutes === null || minutes === undefined || minutes > filterState.maxEstimatedMinutes) return;
               }
               if (filterState.minEstimatedMinutes !== undefined) {
                 const minutes = safe(() => t.estimatedMinutes);
-                if (minutes === null || minutes === undefined || minutes < filterState.minEstimatedMinutes) return false;
+                if (minutes === null || minutes === undefined || minutes < filterState.minEstimatedMinutes) return;
               }
               if (filterState.tags) {
                 const tags = safe(() => t.tags) || [];
                 if (filterState.untaggedOnly) {
-                  if (tags.length > 0) return false;
+                  if (tags.length > 0) return;
                 } else {
                   const hasMatchingTag = tags.some(tag => {
                     const tagId = String(safe(() => tag.id.primaryKey) || "");
                     const tagName = String(safe(() => tag.name) || "");
                     return filterState.tags.some(filterTag => tagId === filterTag || tagName === filterTag);
                   });
-                  if (!hasMatchingTag) return false;
+                  if (!hasMatchingTag) return;
                 }
               }
-              return true;
-            });
-
-            const projectIds = new Set();
-            let actionCount = 0;
-            tasks.forEach(t => {
-              const project = safe(() => t.containingProject);
-              if (!project) { return; }
               const pid = String(safe(() => project.id.primaryKey) || "");
               if (pid) { projectIds.add(pid); }
               actionCount += 1;
             });
+            markProjectCounts("after_count_pass", {
+              durationMs: Date.now() - countPassStart,
+              count: actionCount,
+              projectCount: projectIds.size,
+              actionCount: actionCount
+            });
 
             response.data = { projects: projectIds.size, actions: actionCount };
+          }
+          if (projectCountsDebug) {
+            projectCountsDebug.totalTimingMs = Date.now() - start;
+            projectCountsDebug.responseData = response.data;
+            try {
+              writeJSON(basePath + "/logs/get_project_counts_debug_" + requestId + ".json", projectCountsDebug);
+            } catch (debugError) {}
           }
         } else {
           response.ok = false;

--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -149,16 +149,22 @@
       return safe(() => task.taskStatus);
     }
 
-    function isCompletedStatus(task) {
-      const st = taskStatus(task);
+    function isCompletedStatusValue(st) {
       if (st === Task.Status.Completed) { return true; }
       return String(st).includes("Completed");
     }
 
-    function isDroppedStatus(task) {
-      const st = taskStatus(task);
+    function isCompletedStatus(task) {
+      return isCompletedStatusValue(taskStatus(task));
+    }
+
+    function isDroppedStatusValue(st) {
       if (st === Task.Status.Dropped) { return true; }
       return String(st).includes("Dropped");
+    }
+
+    function isDroppedStatus(task) {
+      return isDroppedStatusValue(taskStatus(task));
     }
 
     /**
@@ -167,7 +173,8 @@
      * @returns {boolean} True if task is remaining
      */
     function isRemainingStatus(task) {
-      return !isCompletedStatus(task) && !isDroppedStatus(task);
+      const st = taskStatus(task);
+      return !isCompletedStatusValue(st) && !isDroppedStatusValue(st);
     }
 
     /**
@@ -176,12 +183,15 @@
      * @param {Task} task - OmniFocus task object
      * @returns {boolean} True if task has an available status
      */
-    function isAvailableStatus(task) {
-      const st = taskStatus(task);
+    function isAvailableStatusValue(st) {
       return st === Task.Status.Available ||
         st === Task.Status.DueSoon ||
         st === Task.Status.Next ||
         st === Task.Status.Overdue;
+    }
+
+    function isAvailableStatus(task) {
+      return isAvailableStatusValue(taskStatus(task));
     }
 
     /**
@@ -226,8 +236,8 @@
      * @param {Task} task - OmniFocus task object
      * @returns {boolean} True if task is available for action
      */
-    function isTaskAvailable(task) {
-      const project = safe(() => task.containingProject);
+    function isTaskAvailableWithStatus(task, taskStatusValue, knownProject) {
+      const project = knownProject === undefined ? safe(() => task.containingProject) : knownProject;
       if (project) {
         const status = safe(() => project.status);
         if (status === Project.Status.OnHold) { return false; }
@@ -247,7 +257,11 @@
         if (isDroppedStatus(parent)) { return false; }
       }
 
-      return isAvailableStatus(task);
+      return isAvailableStatusValue(taskStatusValue);
+    }
+
+    function isTaskAvailable(task) {
+      return isTaskAvailableWithStatus(task, taskStatus(task), undefined);
     }
 
     // ============================================================
@@ -965,14 +979,14 @@
             flagged: filter.flagged,
             availableOnly: availableOnly,
             projectFilter: filter.project,
-            dueBefore: filter.dueBefore ? parseFilterDate(filter.dueBefore, response.warnings) : null,
-            dueAfter: filter.dueAfter ? parseFilterDate(filter.dueAfter, response.warnings) : null,
-            plannedBefore: filter.plannedBefore ? parseFilterDate(filter.plannedBefore, response.warnings) : null,
-            plannedAfter: filter.plannedAfter ? parseFilterDate(filter.plannedAfter, response.warnings) : null,
-            deferBefore: filter.deferBefore ? parseFilterDate(filter.deferBefore, response.warnings) : null,
-            deferAfter: filter.deferAfter ? parseFilterDate(filter.deferAfter, response.warnings) : null,
-            completedBefore: filter.completedBefore ? parseFilterDate(filter.completedBefore, response.warnings) : null,
-            completedAfter: filter.completedAfter ? parseFilterDate(filter.completedAfter, response.warnings) : null,
+            dueBeforeTs: filter.dueBefore ? safe(() => parseFilterDate(filter.dueBefore, response.warnings).getTime()) : null,
+            dueAfterTs: filter.dueAfter ? safe(() => parseFilterDate(filter.dueAfter, response.warnings).getTime()) : null,
+            plannedBeforeTs: filter.plannedBefore ? safe(() => parseFilterDate(filter.plannedBefore, response.warnings).getTime()) : null,
+            plannedAfterTs: filter.plannedAfter ? safe(() => parseFilterDate(filter.plannedAfter, response.warnings).getTime()) : null,
+            deferBeforeTs: filter.deferBefore ? safe(() => parseFilterDate(filter.deferBefore, response.warnings).getTime()) : null,
+            deferAfterTs: filter.deferAfter ? safe(() => parseFilterDate(filter.deferAfter, response.warnings).getTime()) : null,
+            completedBeforeTs: filter.completedBefore ? safe(() => parseFilterDate(filter.completedBefore, response.warnings).getTime()) : null,
+            completedAfterTs: filter.completedAfter ? safe(() => parseFilterDate(filter.completedAfter, response.warnings).getTime()) : null,
             tags: Array.isArray(filter.tags) ? filter.tags : null,
             untaggedOnly: Array.isArray(filter.tags) && filter.tags.length === 0,
             maxEstimatedMinutes: filter.maxEstimatedMinutes,
@@ -985,107 +999,225 @@
           let afterStatusGateCount = 0;
           let afterAvailableGateCount = 0;
 
+          const hasProjectScopedFilters = Boolean(filterState.projectFilter) || Boolean(projectView);
+          const hasScheduleFilters =
+            filterState.dueBeforeTs !== null ||
+            filterState.dueAfterTs !== null ||
+            filterState.deferBeforeTs !== null ||
+            filterState.deferAfterTs !== null ||
+            filterState.plannedBeforeTs !== null ||
+            filterState.plannedAfterTs !== null;
+          const hasTagOrEstimateFilters =
+            Boolean(filterState.tags) ||
+            filterState.maxEstimatedMinutes !== undefined ||
+            filterState.minEstimatedMinutes !== undefined;
+          const useSimpleAvailableFastPath =
+            filterState.availableOnly &&
+            filterState.completed !== true &&
+            !hasProjectScopedFilters &&
+            !hasScheduleFilters &&
+            filterState.completedBeforeTs === null &&
+            filterState.completedAfterTs === null &&
+            !hasTagOrEstimateFilters;
+          const useSimpleCompletedFastPath =
+            filterState.completed === true &&
+            !filterState.availableOnly &&
+            !hasProjectScopedFilters &&
+            !hasScheduleFilters &&
+            !hasTagOrEstimateFilters;
+
           const counts = { total: 0, completed: 0, available: 0, flagged: 0 };
           const countPassStart = Date.now();
-          tasks.forEach(t => {
-            const project = safe(() => t.containingProject);
-            const taskCompleted = isCompletedStatus(t);
-            const taskDropped = isDroppedStatus(t);
-            const taskRemaining = !taskCompleted && !taskDropped;
-            const taskAvailable = isTaskAvailable(t);
-            const taskFlagged = Boolean(t.flagged);
-
-            if (filterState.completed !== undefined) {
-              if (taskCompleted !== filterState.completed) return;
-            } else if (!isEverything) {
-              if (!taskRemaining) return;
-            }
-            afterStatusGateCount += 1;
-            if (debugInfo && statusGateSample.length < 5) {
-              statusGateSample.push(sampleTask(t));
-            }
-
-            if (filterState.flagged !== undefined) {
-              if (taskFlagged !== filterState.flagged) return;
-            }
-            if (filterState.availableOnly) {
-              if (!taskAvailable) return;
-            }
-            afterAvailableGateCount += 1;
-            if (debugInfo && availableGateSample.length < 5) {
-              availableGateSample.push(sampleTask(t));
-            }
-
-            if (filterState.projectFilter) {
-              if (!project) return;
-              const pid = String(safe(() => project.id.primaryKey) || "");
-              const pname = String(safe(() => project.name) || "");
-              if (pid !== filterState.projectFilter && pname !== filterState.projectFilter) return;
-            }
-            if (projectView) {
-              if (!projectMatchesView(project, projectView, true)) return;
-            }
-            if (filterState.dueBefore) {
-              const due = getTaskDateTimestamp(t, task => task.dueDate);
-              if (due === null || due > filterState.dueBefore.getTime()) return;
-            }
-            if (filterState.dueAfter) {
-              const due = getTaskDateTimestamp(t, task => task.dueDate);
-              if (due === null || due < filterState.dueAfter.getTime()) return;
-            }
-            if (filterState.deferBefore) {
-              const defer = getTaskDateTimestamp(t, task => task.deferDate);
-              if (defer === null || defer > filterState.deferBefore.getTime()) return;
-            }
-            if (filterState.deferAfter) {
-              const defer = getTaskDateTimestamp(t, task => task.deferDate);
-              if (defer === null || defer < filterState.deferAfter.getTime()) return;
-            }
-            if (filterState.plannedBefore) {
-              const planned = getTaskDateTimestamp(t, task => task.plannedDate);
-              if (planned === null || planned > filterState.plannedBefore.getTime()) return;
-            }
-            if (filterState.plannedAfter) {
-              const planned = getTaskDateTimestamp(t, task => task.plannedDate);
-              if (planned === null || planned < filterState.plannedAfter.getTime()) return;
-            }
-            if (filterState.completedBefore) {
-              const completed = getTaskDateTimestamp(t, task => task.completionDate);
-              if (completed === null || completed > filterState.completedBefore.getTime()) return;
-            }
-            if (filterState.completedAfter) {
-              const completed = getTaskDateTimestamp(t, task => task.completionDate);
-              if (completed === null || completed < filterState.completedAfter.getTime()) return;
-            }
-            if (filterState.maxEstimatedMinutes !== undefined) {
-              const minutes = safe(() => t.estimatedMinutes);
-              if (minutes === null || minutes === undefined || minutes > filterState.maxEstimatedMinutes) return;
-            }
-            if (filterState.minEstimatedMinutes !== undefined) {
-              const minutes = safe(() => t.estimatedMinutes);
-              if (minutes === null || minutes === undefined || minutes < filterState.minEstimatedMinutes) return;
-            }
-            if (filterState.tags) {
-              const tags = safe(() => t.tags) || [];
-              if (filterState.untaggedOnly) {
-                if (tags.length > 0) return;
-              } else {
-                const hasMatchingTag = tags.some(tag => {
-                  const tagId = String(safe(() => tag.id.primaryKey) || "");
-                  const tagName = String(safe(() => tag.name) || "");
-                  return filterState.tags.some(filterTag => tagId === filterTag || tagName === filterTag);
-                });
-                if (!hasMatchingTag) return;
+          if (useSimpleAvailableFastPath) {
+            tasks.forEach(t => {
+              const taskStatusValue = taskStatus(t);
+              const taskCompleted = isCompletedStatusValue(taskStatusValue);
+              const taskDropped = isDroppedStatusValue(taskStatusValue);
+              if (taskCompleted || taskDropped) { return; }
+              afterStatusGateCount += 1;
+              if (debugInfo && statusGateSample.length < 5) {
+                statusGateSample.push(sampleTask(t));
               }
-            }
-            counts.total += 1;
-            if (taskCompleted) { counts.completed += 1; }
-            if (taskAvailable) { counts.available += 1; }
-            if (taskFlagged) { counts.flagged += 1; }
-            if (debugInfo && finalSample.length < 5) {
-              finalSample.push(sampleTask(t));
-            }
-          });
+              if (!isAvailableStatusValue(taskStatusValue)) { return; }
+
+              let taskFlagged = null;
+              if (filterState.flagged !== undefined) {
+                taskFlagged = Boolean(t.flagged);
+                if (taskFlagged !== filterState.flagged) { return; }
+              }
+
+              if (!isTaskAvailableWithStatus(t, taskStatusValue, undefined)) { return; }
+              afterAvailableGateCount += 1;
+              if (debugInfo && availableGateSample.length < 5) {
+                availableGateSample.push(sampleTask(t));
+              }
+
+              counts.total += 1;
+              counts.available += 1;
+              if (taskFlagged === null) {
+                taskFlagged = Boolean(t.flagged);
+              }
+              if (taskFlagged) { counts.flagged += 1; }
+              if (debugInfo && finalSample.length < 5) {
+                finalSample.push(sampleTask(t));
+              }
+            });
+          } else if (useSimpleCompletedFastPath) {
+            tasks.forEach(t => {
+              const taskStatusValue = taskStatus(t);
+              if (!isCompletedStatusValue(taskStatusValue)) { return; }
+              afterStatusGateCount += 1;
+              if (debugInfo && statusGateSample.length < 5) {
+                statusGateSample.push(sampleTask(t));
+              }
+
+              if (filterState.completedBeforeTs !== null) {
+                const completed = getTaskDateTimestamp(t, task => task.completionDate);
+                if (completed === null || completed > filterState.completedBeforeTs) return;
+              }
+              if (filterState.completedAfterTs !== null) {
+                const completed = getTaskDateTimestamp(t, task => task.completionDate);
+                if (completed === null || completed < filterState.completedAfterTs) return;
+              }
+
+              let taskFlagged = null;
+              if (filterState.flagged !== undefined) {
+                taskFlagged = Boolean(t.flagged);
+                if (taskFlagged !== filterState.flagged) { return; }
+              }
+
+              afterAvailableGateCount += 1;
+              if (debugInfo && availableGateSample.length < 5) {
+                availableGateSample.push(sampleTask(t));
+              }
+
+              counts.total += 1;
+              counts.completed += 1;
+              if (taskFlagged === null) {
+                taskFlagged = Boolean(t.flagged);
+              }
+              if (taskFlagged) { counts.flagged += 1; }
+              if (debugInfo && finalSample.length < 5) {
+                finalSample.push(sampleTask(t));
+              }
+            });
+          } else {
+            tasks.forEach(t => {
+              const taskStatusValue = taskStatus(t);
+              const taskCompleted = isCompletedStatusValue(taskStatusValue);
+              const taskDropped = isDroppedStatusValue(taskStatusValue);
+              const taskRemaining = !taskCompleted && !taskDropped;
+              let taskFlagged = null;
+
+              if (filterState.completed !== undefined) {
+                if (taskCompleted !== filterState.completed) return;
+              } else if (!isEverything) {
+                if (!taskRemaining) return;
+              }
+              afterStatusGateCount += 1;
+              if (debugInfo && statusGateSample.length < 5) {
+                statusGateSample.push(sampleTask(t));
+              }
+
+              if (filterState.flagged !== undefined) {
+                taskFlagged = Boolean(t.flagged);
+                if (taskFlagged !== filterState.flagged) return;
+              }
+              let project = null;
+              if (filterState.projectFilter) {
+                project = safe(() => t.containingProject);
+                if (!project) return;
+                const pid = String(safe(() => project.id.primaryKey) || "");
+                const pname = String(safe(() => project.name) || "");
+                if (pid !== filterState.projectFilter && pname !== filterState.projectFilter) return;
+              }
+              if (projectView) {
+                if (project === null) {
+                  project = safe(() => t.containingProject);
+                }
+                if (!projectMatchesView(project, projectView, true)) return;
+              }
+              if (filterState.dueBeforeTs !== null) {
+                const due = getTaskDateTimestamp(t, task => task.dueDate);
+                if (due === null || due > filterState.dueBeforeTs) return;
+              }
+              if (filterState.dueAfterTs !== null) {
+                const due = getTaskDateTimestamp(t, task => task.dueDate);
+                if (due === null || due < filterState.dueAfterTs) return;
+              }
+              if (filterState.deferBeforeTs !== null) {
+                const defer = getTaskDateTimestamp(t, task => task.deferDate);
+                if (defer === null || defer > filterState.deferBeforeTs) return;
+              }
+              if (filterState.deferAfterTs !== null) {
+                const defer = getTaskDateTimestamp(t, task => task.deferDate);
+                if (defer === null || defer < filterState.deferAfterTs) return;
+              }
+              if (filterState.plannedBeforeTs !== null) {
+                const planned = getTaskDateTimestamp(t, task => task.plannedDate);
+                if (planned === null || planned > filterState.plannedBeforeTs) return;
+              }
+              if (filterState.plannedAfterTs !== null) {
+                const planned = getTaskDateTimestamp(t, task => task.plannedDate);
+                if (planned === null || planned < filterState.plannedAfterTs) return;
+              }
+              if (filterState.completedBeforeTs !== null) {
+                const completed = getTaskDateTimestamp(t, task => task.completionDate);
+                if (completed === null || completed > filterState.completedBeforeTs) return;
+              }
+              if (filterState.completedAfterTs !== null) {
+                const completed = getTaskDateTimestamp(t, task => task.completionDate);
+                if (completed === null || completed < filterState.completedAfterTs) return;
+              }
+              if (filterState.maxEstimatedMinutes !== undefined) {
+                const minutes = safe(() => t.estimatedMinutes);
+                if (minutes === null || minutes === undefined || minutes > filterState.maxEstimatedMinutes) return;
+              }
+              if (filterState.minEstimatedMinutes !== undefined) {
+                const minutes = safe(() => t.estimatedMinutes);
+                if (minutes === null || minutes === undefined || minutes < filterState.minEstimatedMinutes) return;
+              }
+              if (filterState.tags) {
+                const tags = safe(() => t.tags) || [];
+                if (filterState.untaggedOnly) {
+                  if (tags.length > 0) return;
+                } else {
+                  const hasMatchingTag = tags.some(tag => {
+                    const tagId = String(safe(() => tag.id.primaryKey) || "");
+                    const tagName = String(safe(() => tag.name) || "");
+                    return filterState.tags.some(filterTag => tagId === filterTag || tagName === filterTag);
+                  });
+                  if (!hasMatchingTag) return;
+                }
+              }
+
+              let taskAvailable = false;
+              if (filterState.availableOnly || isAvailableStatusValue(taskStatusValue)) {
+                taskAvailable = isTaskAvailableWithStatus(t, taskStatusValue, project === null ? undefined : project);
+              }
+              if (filterState.availableOnly && !taskAvailable) return;
+
+              afterAvailableGateCount += 1;
+              if (debugInfo && availableGateSample.length < 5) {
+                availableGateSample.push(sampleTask(t));
+              }
+
+              counts.total += 1;
+              if (taskCompleted) { counts.completed += 1; }
+              if (filterState.availableOnly) {
+                counts.available += 1;
+              } else if (taskAvailable) {
+                counts.available += 1;
+              }
+              if (taskFlagged === null) {
+                taskFlagged = Boolean(t.flagged);
+              }
+              if (taskFlagged) { counts.flagged += 1; }
+              if (debugInfo && finalSample.length < 5) {
+                finalSample.push(sampleTask(t));
+              }
+            });
+          }
           markTaskCounts("after_count_pass", {
             count: counts.total,
             durationMs: Date.now() - countPassStart,

--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -448,7 +448,7 @@
           const projectView = (typeof filter.projectView === "string") ? filter.projectView.toLowerCase() : null;
 
           // Helper function to check if a task matches all filters
-          function taskMatchesFilters(t, knownTaskStatus, knownProject) {
+          function taskMatchesFilters(t, knownTaskStatus, knownProject, knownCompletionTs) {
             const taskStatusValue = knownTaskStatus === undefined ? taskStatus(t) : knownTaskStatus;
             // Status checks
             if (filterState.completed !== undefined) {
@@ -511,11 +511,11 @@
             
             // Completion date checks
             if (filterState.completedBeforeTs !== null) {
-              const completed = getTaskDateTimestamp(t, task => task.completionDate);
+              const completed = knownCompletionTs === undefined ? getTaskDateTimestamp(t, task => task.completionDate) : knownCompletionTs;
               if (completed === null || completed > filterState.completedBeforeTs) return false;
             }
             if (filterState.completedAfterTs !== null) {
-              const completed = getTaskDateTimestamp(t, task => task.completionDate);
+              const completed = knownCompletionTs === undefined ? getTaskDateTimestamp(t, task => task.completionDate) : knownCompletionTs;
               if (completed === null || completed < filterState.completedAfterTs) return false;
             }
             
@@ -571,6 +571,7 @@
             !requiresCompletionSort &&
             filterState.availableOnly &&
             !hasAdvancedFilters;
+          const useCompletionTopKPath = requiresCompletionSort;
 
           if (useStreamedSimplePath) {
             const fastPathStart = Date.now();
@@ -650,6 +651,89 @@
 
             const returnedCount = items.length;
             const nextCursor = hasMore ? String(safeOffset + items.length) : null;
+            response.data = { items: items, nextCursor: nextCursor, returnedCount: returnedCount };
+            if (includeTotalCount) {
+              response.data.totalCount = totalCount;
+            }
+            if (listTasksDebug) {
+              listTasksDebug.totalTimingMs = Date.now() - start;
+              try {
+                writeJSON(basePath + "/logs/list_tasks_debug_" + requestId + ".json", listTasksDebug);
+              } catch (debugError) {}
+            }
+          } else if (useCompletionTopKPath) {
+            const completionPathStart = Date.now();
+            const windowSize = Math.max(limit + 1, safeOffset + limit + 1);
+            const rankedEntries = [];
+            let matchedCount = 0;
+
+            function compareCompletionEntries(a, b) {
+              if (a.sortCompletionTs !== b.sortCompletionTs) {
+                return b.sortCompletionTs - a.sortCompletionTs;
+              }
+              return a.scanIndex - b.scanIndex;
+            }
+
+            function insertCompletionEntry(entry) {
+              let insertAt = rankedEntries.length;
+              while (insertAt > 0 && compareCompletionEntries(entry, rankedEntries[insertAt - 1]) < 0) {
+                insertAt -= 1;
+              }
+              rankedEntries.splice(insertAt, 0, entry);
+              if (rankedEntries.length > windowSize) {
+                rankedEntries.pop();
+              }
+            }
+
+            for (let i = 0; i < tasks.length; i += 1) {
+              const t = tasks[i];
+              const completionTs = getTaskDateTimestamp(t, task => task.completionDate);
+              if (!taskMatchesFilters(t, undefined, undefined, completionTs)) {
+                continue;
+              }
+
+              matchedCount += 1;
+              const entry = {
+                task: t,
+                completionTs: completionTs,
+                sortCompletionTs: completionTs === null ? 0 : completionTs,
+                scanIndex: i
+              };
+
+              if (rankedEntries.length < windowSize) {
+                insertCompletionEntry(entry);
+                continue;
+              }
+
+              const worstEntry = rankedEntries[rankedEntries.length - 1];
+              if (compareCompletionEntries(entry, worstEntry) >= 0) {
+                continue;
+              }
+              insertCompletionEntry(entry);
+            }
+
+            markListTasks("after_completion_topk", {
+              matchedCount: matchedCount,
+              retainedCount: rankedEntries.length,
+              durationMs: Date.now() - completionPathStart,
+              offset: safeOffset,
+              limit: limit,
+              windowSize: windowSize
+            });
+
+            const totalCount = includeTotalCount ? matchedCount : null;
+            const pageTasks = rankedEntries.slice(safeOffset, safeOffset + limit).map(entry => entry.task);
+            const payloadStart = Date.now();
+            const items = pageTasks.map(t => taskToPayload(t, fields));
+            markListTasks("after_payload_map", {
+              returnedCount: items.length,
+              durationMs: Date.now() - payloadStart
+            });
+
+            const returnedCount = items.length;
+            const hasMore = (safeOffset + items.length) < matchedCount;
+            const nextCursor = hasMore ? String(safeOffset + items.length) : null;
+
             response.data = { items: items, nextCursor: nextCursor, returnedCount: returnedCount };
             if (includeTotalCount) {
               response.data.totalCount = totalCount;

--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -567,13 +567,12 @@
             filterState.minEstimatedMinutes !== undefined ||
             Boolean(filterState.tags) ||
             Boolean(filter.search);
-          const useAvailableStreamFastPath =
-            !includeTotalCount &&
+          const useStreamedSimplePath =
             !requiresCompletionSort &&
             filterState.availableOnly &&
             !hasAdvancedFilters;
 
-          if (useAvailableStreamFastPath) {
+          if (useStreamedSimplePath) {
             const fastPathStart = Date.now();
             const pageTasks = [];
             let matchedCount = 0;
@@ -615,8 +614,17 @@
                 continue;
               }
 
-              hasMore = true;
-              break;
+              if (!includeTotalCount) {
+                hasMore = true;
+                break;
+              }
+
+              matchedCount += 1;
+            }
+
+            const totalCount = includeTotalCount ? matchedCount : null;
+            if (includeTotalCount) {
+              hasMore = (safeOffset + pageTasks.length) < matchedCount;
             }
 
             markListTasks("after_stream_fast_path", {
@@ -628,7 +636,9 @@
               durationMs: Date.now() - fastPathStart,
               offset: safeOffset,
               limit: limit,
-              hasMore: hasMore
+              hasMore: hasMore,
+              includeTotalCount: includeTotalCount,
+              totalCount: totalCount
             });
 
             const payloadStart = Date.now();
@@ -641,6 +651,9 @@
             const returnedCount = items.length;
             const nextCursor = hasMore ? String(safeOffset + items.length) : null;
             response.data = { items: items, nextCursor: nextCursor, returnedCount: returnedCount };
+            if (includeTotalCount) {
+              response.data.totalCount = totalCount;
+            }
             if (listTasksDebug) {
               listTasksDebug.totalTimingMs = Date.now() - start;
               try {

--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -427,14 +427,14 @@
             projectFilter: filter.project,
             
             // Date filters (pre-parsed)
-            dueBefore: filter.dueBefore ? parseFilterDate(filter.dueBefore, response.warnings) : null,
-            dueAfter: filter.dueAfter ? parseFilterDate(filter.dueAfter, response.warnings) : null,
-            plannedBefore: filter.plannedBefore ? parseFilterDate(filter.plannedBefore, response.warnings) : null,
-            plannedAfter: filter.plannedAfter ? parseFilterDate(filter.plannedAfter, response.warnings) : null,
-            deferBefore: filter.deferBefore ? parseFilterDate(filter.deferBefore, response.warnings) : null,
-            deferAfter: filter.deferAfter ? parseFilterDate(filter.deferAfter, response.warnings) : null,
-            completedBefore: filter.completedBefore ? parseFilterDate(filter.completedBefore, response.warnings) : null,
-            completedAfter: filter.completedAfter ? parseFilterDate(filter.completedAfter, response.warnings) : null,
+            dueBeforeTs: filter.dueBefore ? safe(() => parseFilterDate(filter.dueBefore, response.warnings).getTime()) : null,
+            dueAfterTs: filter.dueAfter ? safe(() => parseFilterDate(filter.dueAfter, response.warnings).getTime()) : null,
+            plannedBeforeTs: filter.plannedBefore ? safe(() => parseFilterDate(filter.plannedBefore, response.warnings).getTime()) : null,
+            plannedAfterTs: filter.plannedAfter ? safe(() => parseFilterDate(filter.plannedAfter, response.warnings).getTime()) : null,
+            deferBeforeTs: filter.deferBefore ? safe(() => parseFilterDate(filter.deferBefore, response.warnings).getTime()) : null,
+            deferAfterTs: filter.deferAfter ? safe(() => parseFilterDate(filter.deferAfter, response.warnings).getTime()) : null,
+            completedBeforeTs: filter.completedBefore ? safe(() => parseFilterDate(filter.completedBefore, response.warnings).getTime()) : null,
+            completedAfterTs: filter.completedAfter ? safe(() => parseFilterDate(filter.completedAfter, response.warnings).getTime()) : null,
             
             // Duration filters
             maxEstimatedMinutes: filter.maxEstimatedMinutes,
@@ -446,71 +446,77 @@
           };
           
           const projectView = (typeof filter.projectView === "string") ? filter.projectView.toLowerCase() : null;
-          const isEverythingView = projectView === "everything";
 
           // Helper function to check if a task matches all filters
-          function taskMatchesFilters(t) {
+          function taskMatchesFilters(t, knownTaskStatus, knownProject) {
+            const taskStatusValue = knownTaskStatus === undefined ? taskStatus(t) : knownTaskStatus;
             // Status checks
             if (filterState.completed !== undefined) {
-              const taskCompleted = isCompletedStatus(t);
+              const taskCompleted = isCompletedStatusValue(taskStatusValue);
               if (taskCompleted !== filterState.completed) return false;
             } else if (!isEverything) {
-              if (!isRemainingStatus(t)) return false;
+              if (isCompletedStatusValue(taskStatusValue) || isDroppedStatusValue(taskStatusValue)) return false;
             }
             if (filterState.flagged !== undefined) {
               const taskFlagged = Boolean(t.flagged);
               if (taskFlagged !== filterState.flagged) return false;
             }
+            let project = knownProject === undefined ? null : knownProject;
             if (filterState.availableOnly) {
-              if (!isTaskAvailable(t)) return false;
+              if (!isTaskAvailableWithStatus(t, taskStatusValue, project === null ? undefined : project)) return false;
             }
             
             // Project check
-            const project = safe(() => t.containingProject);
             if (filterState.projectFilter) {
+              if (project === null) {
+                project = safe(() => t.containingProject);
+              }
               if (!project) return false;
               const pid = String(safe(() => project.id.primaryKey) || "");
               const pname = String(safe(() => project.name) || "");
               if (pid !== filterState.projectFilter && pname !== filterState.projectFilter) return false;
             }
             if (projectView) {
+              if (project === null) {
+                project = safe(() => t.containingProject);
+              }
               if (!projectMatchesView(project, projectView, true)) return false;
             }
             
             // Date checks
-            if (filterState.dueBefore) {
+            if (filterState.dueBeforeTs !== null) {
               const due = getTaskDateTimestamp(t, task => task.dueDate);
-              if (due === null || due > filterState.dueBefore.getTime()) return false;
+              if (due === null || due > filterState.dueBeforeTs) return false;
             }
-            if (filterState.dueAfter) {
+            if (filterState.dueAfterTs !== null) {
               const due = getTaskDateTimestamp(t, task => task.dueDate);
-              if (due === null || due < filterState.dueAfter.getTime()) return false;
+              if (due === null || due < filterState.dueAfterTs) return false;
             }
-            if (filterState.deferBefore) {
+            if (filterState.deferBeforeTs !== null) {
               const defer = getTaskDateTimestamp(t, task => task.deferDate);
-              if (defer === null || defer > filterState.deferBefore.getTime()) return false;
+              if (defer === null || defer > filterState.deferBeforeTs) return false;
             }
-            if (filterState.deferAfter) {
+            if (filterState.deferAfterTs !== null) {
               const defer = getTaskDateTimestamp(t, task => task.deferDate);
-              if (defer === null || defer < filterState.deferAfter.getTime()) return false;
+              if (defer === null || defer < filterState.deferAfterTs) return false;
             }
-            if (filterState.plannedBefore) {
+            if (filterState.plannedBeforeTs !== null) {
               const planned = getTaskDateTimestamp(t, task => task.plannedDate);
-              if (planned === null || planned > filterState.plannedBefore.getTime()) return false;
+              if (planned === null || planned > filterState.plannedBeforeTs) return false;
             }
-            if (filterState.plannedAfter) {
+            if (filterState.plannedAfterTs !== null) {
               const planned = getTaskDateTimestamp(t, task => task.plannedDate);
-              if (planned === null || planned < filterState.plannedAfter.getTime()) return false;
+              if (planned === null || planned < filterState.plannedAfterTs) return false;
             }
             
             // Completion date checks
-            if (filterState.completedBefore) {
+            if (filterState.completedBeforeTs !== null) {
               const completed = getTaskDateTimestamp(t, task => task.completionDate);
-              if (completed === null || completed > filterState.completedBefore.getTime()) return false;
+              if (completed === null || completed > filterState.completedBeforeTs) return false;
             }
-            if (filterState.completedAfter) {
+            if (filterState.completedAfterTs !== null) {
               const completed = getTaskDateTimestamp(t, task => task.completionDate);
-              if (completed === null || completed < filterState.completedAfter.getTime()) return false;
+              if (completed === null || completed < filterState.completedAfterTs) return false;
             }
             
             // Duration checks
@@ -544,65 +550,163 @@
           const includeTotalCount = filter.includeTotalCount === true;
           const limit = request.page && request.page.limit ? request.page.limit : 50;
           const offset = request.page && request.page.cursor ? parseInt(request.page.cursor, 10) : 0;
-
-          // Filter first, then apply pagination. Cursor semantics are based on the
-          // filtered/sorted result set, not the original OmniFocus flattened list.
-          const filterPassStart = Date.now();
-          tasks = tasks.filter(taskMatchesFilters);
-          markListTasks("after_filter_pass", {
-            count: tasks.length,
-            durationMs: Date.now() - filterPassStart
-          });
-          const totalCount = includeTotalCount ? tasks.length : null;
-
-          // Sort by completion date descending when filtering by completed tasks
-          // This matches OmniFocus Completed perspective behavior
-          if (filterState.completed === true || filterState.completedAfter || filterState.completedBefore) {
-            const sortStart = Date.now();
-            tasks.sort((a, b) => {
-              const dateA = getTaskDateTimestamp(a, t => t.completionDate) || 0;
-              const dateB = getTaskDateTimestamp(b, t => t.completionDate) || 0;
-              return dateB - dateA;
-            });
-            markListTasks("after_completion_sort", {
-              count: tasks.length,
-              durationMs: Date.now() - sortStart
-            });
-          }
-
-          // Apply offset + limit to the filtered/sorted task list.
           const safeOffset = Number.isFinite(offset) && offset > 0 ? offset : 0;
-          const pageTasks = tasks.slice(safeOffset, safeOffset + limit);
-          markListTasks("after_paging", {
-            pageCount: pageTasks.length,
-            totalCount: totalCount,
-            offset: safeOffset,
-            limit: limit
-          });
-          const payloadStart = Date.now();
-          const items = pageTasks.map(t => taskToPayload(t, fields));
-          markListTasks("after_payload_map", {
-            returnedCount: items.length,
-            durationMs: Date.now() - payloadStart
-          });
-          
-          // Calculate returned count (actual items in this response)
-          const returnedCount = items.length;
-          
-          // Calculate pagination cursor
-          const hasMore = (safeOffset + items.length) < tasks.length;
-          const nextCursor = hasMore ? String(safeOffset + items.length) : null;
-          
-          // Build response with both counts
-          response.data = { items: items, nextCursor: nextCursor, returnedCount: returnedCount };
-          if (includeTotalCount) {
-            response.data.totalCount = totalCount;
-          }
-          if (listTasksDebug) {
-            listTasksDebug.totalTimingMs = Date.now() - start;
-            try {
-              writeJSON(basePath + "/logs/list_tasks_debug_" + requestId + ".json", listTasksDebug);
-            } catch (debugError) {}
+          const requiresCompletionSort = filterState.completed === true || filterState.completedAfterTs !== null || filterState.completedBeforeTs !== null;
+          const hasScheduleFilters =
+            filterState.dueBeforeTs !== null ||
+            filterState.dueAfterTs !== null ||
+            filterState.deferBeforeTs !== null ||
+            filterState.deferAfterTs !== null ||
+            filterState.plannedBeforeTs !== null ||
+            filterState.plannedAfterTs !== null;
+          const hasAdvancedFilters =
+            Boolean(filterState.projectFilter) ||
+            Boolean(projectView) ||
+            hasScheduleFilters ||
+            filterState.maxEstimatedMinutes !== undefined ||
+            filterState.minEstimatedMinutes !== undefined ||
+            Boolean(filterState.tags) ||
+            Boolean(filter.search);
+          const useAvailableStreamFastPath =
+            !includeTotalCount &&
+            !requiresCompletionSort &&
+            filterState.availableOnly &&
+            !hasAdvancedFilters;
+
+          if (useAvailableStreamFastPath) {
+            const fastPathStart = Date.now();
+            const pageTasks = [];
+            let matchedCount = 0;
+            let afterStatusGateCount = 0;
+            let afterAvailableGateCount = 0;
+            let hasMore = false;
+
+            for (let i = 0; i < tasks.length; i += 1) {
+              const t = tasks[i];
+              const taskStatusValue = taskStatus(t);
+              if (isCompletedStatusValue(taskStatusValue) || isDroppedStatusValue(taskStatusValue)) {
+                continue;
+              }
+              afterStatusGateCount += 1;
+
+              if (filterState.flagged !== undefined) {
+                const taskFlagged = Boolean(t.flagged);
+                if (taskFlagged !== filterState.flagged) {
+                  continue;
+                }
+              }
+
+              if (!isAvailableStatusValue(taskStatusValue)) {
+                continue;
+              }
+              if (!isTaskAvailableWithStatus(t, taskStatusValue, undefined)) {
+                continue;
+              }
+
+              afterAvailableGateCount += 1;
+
+              if (matchedCount < safeOffset) {
+                matchedCount += 1;
+                continue;
+              }
+              if (pageTasks.length < limit) {
+                pageTasks.push(t);
+                matchedCount += 1;
+                continue;
+              }
+
+              hasMore = true;
+              break;
+            }
+
+            markListTasks("after_stream_fast_path", {
+              returnedCount: pageTasks.length,
+              scannedCount: tasks.length,
+              matchedCount: matchedCount,
+              afterStatusGateCount: afterStatusGateCount,
+              afterAvailableGateCount: afterAvailableGateCount,
+              durationMs: Date.now() - fastPathStart,
+              offset: safeOffset,
+              limit: limit,
+              hasMore: hasMore
+            });
+
+            const payloadStart = Date.now();
+            const items = pageTasks.map(t => taskToPayload(t, fields));
+            markListTasks("after_payload_map", {
+              returnedCount: items.length,
+              durationMs: Date.now() - payloadStart
+            });
+
+            const returnedCount = items.length;
+            const nextCursor = hasMore ? String(safeOffset + items.length) : null;
+            response.data = { items: items, nextCursor: nextCursor, returnedCount: returnedCount };
+            if (listTasksDebug) {
+              listTasksDebug.totalTimingMs = Date.now() - start;
+              try {
+                writeJSON(basePath + "/logs/list_tasks_debug_" + requestId + ".json", listTasksDebug);
+              } catch (debugError) {}
+            }
+          } else {
+
+            // Filter first, then apply pagination. Cursor semantics are based on the
+            // filtered/sorted result set, not the original OmniFocus flattened list.
+            const filterPassStart = Date.now();
+            tasks = tasks.filter(t => taskMatchesFilters(t, undefined, undefined));
+            markListTasks("after_filter_pass", {
+              count: tasks.length,
+              durationMs: Date.now() - filterPassStart
+            });
+            const totalCount = includeTotalCount ? tasks.length : null;
+
+            // Sort by completion date descending when filtering by completed tasks
+            // This matches OmniFocus Completed perspective behavior
+            if (requiresCompletionSort) {
+              const sortStart = Date.now();
+              tasks.sort((a, b) => {
+                const dateA = getTaskDateTimestamp(a, t => t.completionDate) || 0;
+                const dateB = getTaskDateTimestamp(b, t => t.completionDate) || 0;
+                return dateB - dateA;
+              });
+              markListTasks("after_completion_sort", {
+                count: tasks.length,
+                durationMs: Date.now() - sortStart
+              });
+            }
+
+            // Apply offset + limit to the filtered/sorted task list.
+            const pageTasks = tasks.slice(safeOffset, safeOffset + limit);
+            markListTasks("after_paging", {
+              pageCount: pageTasks.length,
+              totalCount: totalCount,
+              offset: safeOffset,
+              limit: limit
+            });
+            const payloadStart = Date.now();
+            const items = pageTasks.map(t => taskToPayload(t, fields));
+            markListTasks("after_payload_map", {
+              returnedCount: items.length,
+              durationMs: Date.now() - payloadStart
+            });
+
+            // Calculate returned count (actual items in this response)
+            const returnedCount = items.length;
+            
+            // Calculate pagination cursor
+            const hasMore = (safeOffset + items.length) < tasks.length;
+            const nextCursor = hasMore ? String(safeOffset + items.length) : null;
+            
+            // Build response with both counts
+            response.data = { items: items, nextCursor: nextCursor, returnedCount: returnedCount };
+            if (includeTotalCount) {
+              response.data.totalCount = totalCount;
+            }
+            if (listTasksDebug) {
+              listTasksDebug.totalTimingMs = Date.now() - start;
+              try {
+                writeJSON(basePath + "/logs/list_tasks_debug_" + requestId + ".json", listTasksDebug);
+              } catch (debugError) {}
+            }
           }
         } else if (request.op === "list_projects") {
           const fields = request.fields || [];

--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -323,6 +323,17 @@
           response.data = { ok: true, plugin: "FocusRelay Bridge", version: "0.1.0" };
         } else if (request.op === "list_inbox" || request.op === "list_tasks") {
           const filter = request.filter || {};
+          const debugListTasks = filter.search === "__debug_list_tasks__";
+          const listTasksDebug = debugListTasks ? {
+            requestId: requestId,
+            op: request.op,
+            marks: []
+          } : null;
+          const markListTasks = (label, extra) => {
+            if (!listTasksDebug) { return; }
+            const entry = Object.assign({ label: label, ms: Date.now() - start }, extra || {});
+            listTasksDebug.marks.push(entry);
+          };
           const fields = request.fields || [];
           const hasField = (name) => fields.length === 0 || fields.indexOf(name) !== -1;
 
@@ -333,6 +344,7 @@
           } else {
             tasks = flattenedTasks;
           }
+          markListTasks("selected_base_pool", { useInbox: useInbox, count: tasks.length });
 
           if (!useInbox && typeof filter.project === "string" && filter.project.length > 0) {
             const projectFilter = filter.project;
@@ -344,6 +356,7 @@
               return pid === projectFilter || pname === projectFilter;
             });
           }
+          markListTasks("after_project_scope", { count: tasks.length, projectFilter: filter.project || null });
           // Note: When inboxOnly is false and no project filter is specified,
           // we return tasks from all projects (flattenedTasks)
 
@@ -351,18 +364,15 @@
           const isEverything = inboxView === "everything";
           const isRemaining = inboxView === "remaining";
 
-          if (typeof filter.completed === "boolean") {
-            tasks = tasks.filter(t => isCompletedStatus(t) === filter.completed);
-          } else if (!isEverything) {
-            tasks = tasks.filter(t => isRemainingStatus(t));
-          }
-
           const availableOnly = (typeof filter.availableOnly === "boolean")
             ? filter.availableOnly
             : (filter.completed === true ? false : !isRemaining && !isEverything);
-          if (availableOnly) {
-            tasks = tasks.filter(t => isTaskAvailable(t));
-          }
+          markListTasks("derived_view_state", {
+            count: tasks.length,
+            completed: filter.completed,
+            inboxView: inboxView,
+            availableOnly: availableOnly
+          });
 
           // Timezone-aware date calculations
           // Get user's timezone from request, fallback to local
@@ -397,7 +407,7 @@
             // Status filters
             completed: filter.completed,
             flagged: filter.flagged,
-            availableOnly: filter.availableOnly,
+            availableOnly: availableOnly,
             
             // Project filter
             projectFilter: filter.project,
@@ -430,6 +440,8 @@
             if (filterState.completed !== undefined) {
               const taskCompleted = isCompletedStatus(t);
               if (taskCompleted !== filterState.completed) return false;
+            } else if (!isEverything) {
+              if (!isRemainingStatus(t)) return false;
             }
             if (filterState.flagged !== undefined) {
               const taskFlagged = Boolean(t.flagged);
@@ -521,23 +533,44 @@
 
           // Filter first, then apply pagination. Cursor semantics are based on the
           // filtered/sorted result set, not the original OmniFocus flattened list.
+          const filterPassStart = Date.now();
           tasks = tasks.filter(taskMatchesFilters);
+          markListTasks("after_filter_pass", {
+            count: tasks.length,
+            durationMs: Date.now() - filterPassStart
+          });
           const totalCount = includeTotalCount ? tasks.length : null;
 
           // Sort by completion date descending when filtering by completed tasks
           // This matches OmniFocus Completed perspective behavior
           if (filterState.completed === true || filterState.completedAfter || filterState.completedBefore) {
+            const sortStart = Date.now();
             tasks.sort((a, b) => {
               const dateA = getTaskDateTimestamp(a, t => t.completionDate) || 0;
               const dateB = getTaskDateTimestamp(b, t => t.completionDate) || 0;
               return dateB - dateA;
+            });
+            markListTasks("after_completion_sort", {
+              count: tasks.length,
+              durationMs: Date.now() - sortStart
             });
           }
 
           // Apply offset + limit to the filtered/sorted task list.
           const safeOffset = Number.isFinite(offset) && offset > 0 ? offset : 0;
           const pageTasks = tasks.slice(safeOffset, safeOffset + limit);
+          markListTasks("after_paging", {
+            pageCount: pageTasks.length,
+            totalCount: totalCount,
+            offset: safeOffset,
+            limit: limit
+          });
+          const payloadStart = Date.now();
           const items = pageTasks.map(t => taskToPayload(t, fields));
+          markListTasks("after_payload_map", {
+            returnedCount: items.length,
+            durationMs: Date.now() - payloadStart
+          });
           
           // Calculate returned count (actual items in this response)
           const returnedCount = items.length;
@@ -550,6 +583,12 @@
           response.data = { items: items, nextCursor: nextCursor, returnedCount: returnedCount };
           if (includeTotalCount) {
             response.data.totalCount = totalCount;
+          }
+          if (listTasksDebug) {
+            listTasksDebug.totalTimingMs = Date.now() - start;
+            try {
+              writeJSON(basePath + "/logs/list_tasks_debug_" + requestId + ".json", listTasksDebug);
+            } catch (debugError) {}
           }
         } else if (request.op === "list_projects") {
           const fields = request.fields || [];

--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -119,7 +119,7 @@
         plannedDate: hasField("plannedDate") && plannedDate ? plannedDate.toISOString() : null,
         deferDate: hasField("deferDate") && deferDate ? deferDate.toISOString() : null,
         completionDate: hasField("completionDate") ? (safe(() => t.completionDate) ? t.completionDate.toISOString() : null) : null,
-        completed: hasField("completed") ? Boolean(t.completed) : null,
+        completed: hasField("completed") ? isCompletedStatus(t) : null,
         flagged: hasField("flagged") ? Boolean(t.flagged) : null,
         estimatedMinutes: hasField("estimatedMinutes") ? t.estimatedMinutes : null,
         available: hasField("available") ? isTaskAvailable(t) : null
@@ -149,14 +149,25 @@
       return safe(() => task.taskStatus);
     }
 
+    function isCompletedStatus(task) {
+      const st = taskStatus(task);
+      if (st === Task.Status.Completed) { return true; }
+      return String(st).includes("Completed");
+    }
+
+    function isDroppedStatus(task) {
+      const st = taskStatus(task);
+      if (st === Task.Status.Dropped) { return true; }
+      return String(st).includes("Dropped");
+    }
+
     /**
      * Check if task is remaining (not completed or dropped)
      * @param {Task} task - OmniFocus task object  
      * @returns {boolean} True if task is remaining
      */
     function isRemainingStatus(task) {
-      const st = taskStatus(task);
-      return st !== Task.Status.Completed && st !== Task.Status.Dropped;
+      return !isCompletedStatus(task) && !isDroppedStatus(task);
     }
 
     /**
@@ -185,6 +196,7 @@
       if (!view || view === "all") { return true; }
 
       const normalizedView = view.toLowerCase();
+      if (normalizedView === "everything") { return true; }
       const allowOnHold = allowOnHoldInEverything && normalizedView === "everything";
 
       const status = safe(() => project.status);
@@ -215,7 +227,6 @@
      * @returns {boolean} True if task is available for action
      */
     function isTaskAvailable(task) {
-      // Check project status first
       const project = safe(() => task.containingProject);
       if (project) {
         const status = safe(() => project.status);
@@ -228,21 +239,14 @@
         if (statusStr.includes("OnHold")) { return false; }
         if (statusStr.includes("Dropped")) { return false; }
         if (statusStr.includes("Done")) { return false; }
-
-        // Additional safety checks
-        if (Boolean(safe(() => project.completed))) { return false; }
-        if (safe(() => project.dropDate)) { return false; }
-        if (Boolean(safe(() => project.onHold))) { return false; }
       }
 
-      // Check parent task status
       const parent = safe(() => task.parent);
       if (parent) {
-        if (Boolean(safe(() => parent.completed))) { return false; }
-        if (safe(() => parent.dropDate)) { return false; }
+        if (isCompletedStatus(parent)) { return false; }
+        if (isDroppedStatus(parent)) { return false; }
       }
 
-      // Finally check the task's own status
       return isAvailableStatus(task);
     }
 
@@ -348,7 +352,7 @@
           const isRemaining = inboxView === "remaining";
 
           if (typeof filter.completed === "boolean") {
-            tasks = tasks.filter(t => Boolean(t.completed) === filter.completed);
+            tasks = tasks.filter(t => isCompletedStatus(t) === filter.completed);
           } else if (!isEverything) {
             tasks = tasks.filter(t => isRemainingStatus(t));
           }
@@ -424,7 +428,7 @@
           function taskMatchesFilters(t) {
             // Status checks
             if (filterState.completed !== undefined) {
-              const taskCompleted = Boolean(t.completed);
+              const taskCompleted = isCompletedStatus(t);
               if (taskCompleted !== filterState.completed) return false;
             }
             if (filterState.flagged !== undefined) {
@@ -836,6 +840,7 @@
           }
         } else if (request.op === "get_task_counts") {
           const filter = request.filter || {};
+          const debugTaskCounts = filter.search === "__debug_task_counts__";
 
           const inboxView = (typeof filter.inboxView === "string") ? filter.inboxView.toLowerCase() : "available";
           const isEverything = inboxView === "everything";
@@ -856,51 +861,18 @@
           }
 
           function selectTaskPool() {
-            // Inbox scope uses native inbox collection and is naturally bounded.
             if (filter.inboxOnly === true) {
               return inboxTasksArray();
             }
 
-            // Project scope can use the project's native collections.
             const project = resolveProject(filter.project);
+            if (filter.project && !project) {
+              return [];
+            }
             if (project) {
-              if (filter.completed === true) {
-                const projectCompleted = safe(() => project.completedTasks);
-                if (projectCompleted !== null && projectCompleted !== undefined) { return toTaskArray(projectCompleted); }
-              }
-              if (availableOnly) {
-                const projectAvailable = safe(() => project.availableTasks);
-                if (projectAvailable !== null && projectAvailable !== undefined) { return toTaskArray(projectAvailable); }
-              }
-              if (filter.completed === false || isRemaining) {
-                const projectRemaining = safe(() => project.remainingTasks);
-                if (projectRemaining !== null && projectRemaining !== undefined) { return toTaskArray(projectRemaining); }
-              }
               return toTaskArray(safe(() => project.flattenedTasks));
             }
 
-            // Global scope: prefer native collections before full flattenedTasks.
-            if (filter.completed === true) {
-              const completed = safe(() => completedTasks);
-              if (completed !== null && completed !== undefined) { return toTaskArray(completed); }
-            }
-
-            if (availableOnly) {
-              const available = safe(() => availableTasks);
-              if (available !== null && available !== undefined) { return toTaskArray(available); }
-            }
-
-            if (filter.completed === false || isRemaining) {
-              const remaining = safe(() => remainingTasks);
-              if (remaining !== null && remaining !== undefined) { return toTaskArray(remaining); }
-            }
-
-            if (isEverything) {
-              return toTaskArray(safe(() => flattenedTasks));
-            }
-
-            const fallbackRemaining = safe(() => remainingTasks);
-            if (fallbackRemaining !== null && fallbackRemaining !== undefined) { return toTaskArray(fallbackRemaining); }
             return toTaskArray(safe(() => flattenedTasks));
           }
 
@@ -908,15 +880,45 @@
           // Task pool is selected from native OmniFocus collections first,
           // then filtered with the same semantics as list_tasks.
           let tasks = selectTaskPool();
+          const debugInfo = debugTaskCounts ? {
+            requestId: requestId,
+            availableOnly: availableOnly,
+            inboxView: inboxView,
+            projectView: projectView,
+            initialPoolCount: tasks.length
+          } : null;
+
+          function sampleTasks(list) {
+            return list.slice(0, 5).map(task => {
+              const project = safe(() => task.containingProject);
+              const parent = safe(() => task.parent);
+              return {
+                id: String(safe(() => task.id.primaryKey) || ""),
+                name: String(safe(() => task.name) || ""),
+                taskStatus: String(taskStatus(task)),
+                available: isTaskAvailable(task),
+                projectStatus: project ? String(safe(() => project.status) || "") : null,
+                parentStatus: parent ? String(taskStatus(parent)) : null
+              };
+            });
+          }
 
           if (typeof filter.completed === "boolean") {
-            tasks = tasks.filter(t => Boolean(t.completed) === filter.completed);
+            tasks = tasks.filter(t => isCompletedStatus(t) === filter.completed);
           } else if (!isEverything) {
             tasks = tasks.filter(t => isRemainingStatus(t));
+          }
+          if (debugInfo) {
+            debugInfo.afterCompletedFilterCount = tasks.length;
+            debugInfo.afterCompletedFilterSample = sampleTasks(tasks);
           }
 
           if (availableOnly) {
             tasks = tasks.filter(t => isTaskAvailable(t));
+          }
+          if (debugInfo) {
+            debugInfo.afterAvailableFilterCount = tasks.length;
+            debugInfo.afterAvailableFilterSample = sampleTasks(tasks);
           }
 
           // Parse filter dates
@@ -944,7 +946,7 @@
             const project = safe(() => t.containingProject);
 
             if (filterState.completed !== undefined) {
-              const taskCompleted = Boolean(t.completed);
+              const taskCompleted = isCompletedStatus(t);
               if (taskCompleted !== filterState.completed) return false;
             } else if (!isEverything) {
               if (!isRemainingStatus(t)) return false;
@@ -1020,6 +1022,10 @@
             }
             return true;
           });
+          if (debugInfo) {
+            debugInfo.afterAllFiltersCount = tasks.length;
+            debugInfo.afterAllFiltersSample = sampleTasks(tasks);
+          }
 
           // Sort by completion date descending when filtering by completion
           if (filterState.completed === true || filterState.completedAfter || filterState.completedBefore) {
@@ -1033,10 +1039,16 @@
           const counts = { total: 0, completed: 0, available: 0, flagged: 0 };
           tasks.forEach(t => {
             counts.total += 1;
-            if (Boolean(t.completed)) { counts.completed += 1; }
+            if (isCompletedStatus(t)) { counts.completed += 1; }
             if (isTaskAvailable(t)) { counts.available += 1; }
             if (Boolean(t.flagged)) { counts.flagged += 1; }
           });
+          if (debugInfo) {
+            debugInfo.counts = counts;
+            try {
+              writeJSON(basePath + "/logs/get_task_counts_debug_" + requestId + ".json", debugInfo);
+            } catch (debugError) {}
+          }
 
           response.data = counts;
 } else if (request.op === "get_project_counts") {
@@ -1073,7 +1085,7 @@
               const project = safe(() => t.containingProject);
               if (!project) return;
               const pid = String(safe(() => project.id.primaryKey) || "");
-              if (projectIds.has(pid) && Boolean(t.completed)) {
+              if (projectIds.has(pid) && isCompletedStatus(t)) {
                 const taskCompletionDate = getTaskDateTimestamp(t, task => task.completionDate);
                 if (taskCompletionDate !== null) {
                   // Only count tasks completed in the same window
@@ -1087,50 +1099,155 @@
             
             response.data = { projects: projectCount, actions: completedTaskCount };
           } else {
-            // Original behavior for non-completion queries
-            const view = (typeof filter.projectView === "string") ? filter.projectView.toLowerCase() : "remaining";
-            const isEverything = view === "everything";
-            const isAvailableView = view === "available";
+            const rawProjectView = (typeof filter.projectView === "string") ? filter.projectView.toLowerCase() : "remaining";
+            const projectStatusView = (
+              rawProjectView === "active" ||
+              rawProjectView === "onhold" ||
+              rawProjectView === "on_hold" ||
+              rawProjectView === "dropped" ||
+              rawProjectView === "done" ||
+              rawProjectView === "completed" ||
+              rawProjectView === "everything" ||
+              rawProjectView === "all"
+            ) ? rawProjectView : null;
 
-            function projectAllowed(p) {
-              if (!projectMatchesView(p, view, true)) { return false; }
-              if (Boolean(safe(() => p.completed))) { return false; }
-              if (safe(() => p.dropDate)) { return false; }
-              if (view !== "everything" && Boolean(safe(() => p.onHold))) { return false; }
-              return true;
+            const derivedCompleted = (typeof filter.completed === "boolean")
+              ? filter.completed
+              : (rawProjectView === "everything" ? undefined : false);
+            const derivedAvailableOnly = (typeof filter.availableOnly === "boolean")
+              ? filter.availableOnly
+              : (rawProjectView === "available");
+
+            function resolveProject(projectFilter) {
+              if (!projectFilter || typeof projectFilter !== "string") { return null; }
+              return (safe(() => flattenedProjects.find(p => {
+                const pid = String(safe(() => p.id.primaryKey) || "");
+                const pname = String(safe(() => p.name) || "");
+                return pid === projectFilter || pname === projectFilter;
+              })) || null);
             }
 
-            function parentAllowed(task) {
-              const parent = safe(() => task.parent);
-              if (!parent) { return true; }
-              if (Boolean(safe(() => parent.completed))) { return false; }
-              if (safe(() => parent.dropDate)) { return false; }
-              return true;
+            let tasks = [];
+            const project = resolveProject(filter.project);
+            if (filter.project && !project) {
+              tasks = [];
+            } else if (project) {
+              tasks = toTaskArray(safe(() => project.flattenedTasks));
+            } else {
+              tasks = toTaskArray(safe(() => flattenedTasks));
             }
 
-            let tasks = flattenedTasks;
+            const filterState = {
+              completed: derivedCompleted,
+              flagged: filter.flagged,
+              availableOnly: derivedAvailableOnly,
+              projectFilter: filter.project,
+              projectView: projectStatusView,
+              dueBefore: filter.dueBefore ? parseFilterDate(filter.dueBefore, response.warnings) : null,
+              dueAfter: filter.dueAfter ? parseFilterDate(filter.dueAfter, response.warnings) : null,
+              plannedBefore: filter.plannedBefore ? parseFilterDate(filter.plannedBefore, response.warnings) : null,
+              plannedAfter: filter.plannedAfter ? parseFilterDate(filter.plannedAfter, response.warnings) : null,
+              deferBefore: filter.deferBefore ? parseFilterDate(filter.deferBefore, response.warnings) : null,
+              deferAfter: filter.deferAfter ? parseFilterDate(filter.deferAfter, response.warnings) : null,
+              completedBefore: filter.completedBefore ? parseFilterDate(filter.completedBefore, response.warnings) : null,
+              completedAfter: filter.completedAfter ? parseFilterDate(filter.completedAfter, response.warnings) : null,
+              tags: Array.isArray(filter.tags) ? filter.tags : null,
+              untaggedOnly: Array.isArray(filter.tags) && filter.tags.length === 0,
+              maxEstimatedMinutes: filter.maxEstimatedMinutes,
+              minEstimatedMinutes: filter.minEstimatedMinutes
+            };
+
             tasks = tasks.filter(t => {
               const project = safe(() => t.containingProject);
-              return projectAllowed(project) && parentAllowed(t);
+              if (!project) { return false; }
+
+              if (filterState.completed !== undefined) {
+                if (isCompletedStatus(t) !== filterState.completed) return false;
+              } else if (rawProjectView !== "everything") {
+                if (!isRemainingStatus(t)) return false;
+              }
+
+              if (filterState.flagged !== undefined) {
+                if (Boolean(t.flagged) !== filterState.flagged) return false;
+              }
+              if (filterState.availableOnly) {
+                if (!isTaskAvailable(t)) return false;
+              }
+              if (filterState.projectFilter) {
+                const pid = String(safe(() => project.id.primaryKey) || "");
+                const pname = String(safe(() => project.name) || "");
+                if (pid !== filterState.projectFilter && pname !== filterState.projectFilter) return false;
+              }
+              if (filterState.projectView) {
+                if (!projectMatchesView(project, filterState.projectView, true)) return false;
+              }
+              if (filterState.dueBefore) {
+                const due = getTaskDateTimestamp(t, task => task.dueDate);
+                if (due === null || due > filterState.dueBefore.getTime()) return false;
+              }
+              if (filterState.dueAfter) {
+                const due = getTaskDateTimestamp(t, task => task.dueDate);
+                if (due === null || due < filterState.dueAfter.getTime()) return false;
+              }
+              if (filterState.deferBefore) {
+                const defer = getTaskDateTimestamp(t, task => task.deferDate);
+                if (defer === null || defer > filterState.deferBefore.getTime()) return false;
+              }
+              if (filterState.deferAfter) {
+                const defer = getTaskDateTimestamp(t, task => task.deferDate);
+                if (defer === null || defer < filterState.deferAfter.getTime()) return false;
+              }
+              if (filterState.plannedBefore) {
+                const planned = getTaskDateTimestamp(t, task => task.plannedDate);
+                if (planned === null || planned > filterState.plannedBefore.getTime()) return false;
+              }
+              if (filterState.plannedAfter) {
+                const planned = getTaskDateTimestamp(t, task => task.plannedDate);
+                if (planned === null || planned < filterState.plannedAfter.getTime()) return false;
+              }
+              if (filterState.completedBefore) {
+                const completed = getTaskDateTimestamp(t, task => task.completionDate);
+                if (completed === null || completed > filterState.completedBefore.getTime()) return false;
+              }
+              if (filterState.completedAfter) {
+                const completed = getTaskDateTimestamp(t, task => task.completionDate);
+                if (completed === null || completed < filterState.completedAfter.getTime()) return false;
+              }
+              if (filterState.maxEstimatedMinutes !== undefined) {
+                const minutes = safe(() => t.estimatedMinutes);
+                if (minutes === null || minutes === undefined || minutes > filterState.maxEstimatedMinutes) return false;
+              }
+              if (filterState.minEstimatedMinutes !== undefined) {
+                const minutes = safe(() => t.estimatedMinutes);
+                if (minutes === null || minutes === undefined || minutes < filterState.minEstimatedMinutes) return false;
+              }
+              if (filterState.tags) {
+                const tags = safe(() => t.tags) || [];
+                if (filterState.untaggedOnly) {
+                  if (tags.length > 0) return false;
+                } else {
+                  const hasMatchingTag = tags.some(tag => {
+                    const tagId = String(safe(() => tag.id.primaryKey) || "");
+                    const tagName = String(safe(() => tag.name) || "");
+                    return filterState.tags.some(filterTag => tagId === filterTag || tagName === filterTag);
+                  });
+                  if (!hasMatchingTag) return false;
+                }
+              }
+              return true;
             });
 
-            if (!isEverything) {
-              tasks = tasks.filter(t => isRemainingStatus(t));
-            }
-
-            if (isAvailableView) {
-              tasks = tasks.filter(t => isAvailableStatus(t));
-            }
-
             const projectIds = new Set();
+            let actionCount = 0;
             tasks.forEach(t => {
               const project = safe(() => t.containingProject);
               if (!project) { return; }
               const pid = String(safe(() => project.id.primaryKey) || "");
               if (pid) { projectIds.add(pid); }
+              actionCount += 1;
             });
 
-            response.data = { projects: projectIds.size, actions: tasks.length };
+            response.data = { projects: projectIds.size, actions: actionCount };
           }
         } else {
           response.ok = false;

--- a/Sources/FocusRelayCLI/BenchmarkGateCheckCommand.swift
+++ b/Sources/FocusRelayCLI/BenchmarkGateCheckCommand.swift
@@ -1,0 +1,298 @@
+import ArgumentParser
+import Foundation
+import OmniFocusAutomation
+import OmniFocusCore
+
+struct BenchmarkGateCheck: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "benchmark-gate-check",
+        abstract: "Run readiness, parity, and count-contract checks before benchmarks.",
+        aliases: ["benchmark_gate_check"]
+    )
+
+    @Option(name: .customLong("tool"), help: "Gate scope: all, task-counts, list-tasks, or project-counts.")
+    var tool: GateScope = .all
+
+    func run() async throws {
+        let bridge = OmniFocusBridgeService()
+        let jxa = OmniAutomationService()
+        var checks: [GateCheck] = []
+
+        checks.append(await checkBridgeHealth(using: bridge))
+        checks.append(await checkJXAProbe(using: jxa))
+
+        switch tool {
+        case .all:
+            checks.append(contentsOf: await taskCountContractChecks(using: bridge))
+            checks.append(contentsOf: await taskCountParityChecks(bridge: bridge, jxa: jxa))
+            checks.append(contentsOf: await listTaskParityChecks(bridge: bridge, jxa: jxa))
+            checks.append(await projectCountsBridgeActiveContractCheck(using: bridge))
+            checks.append(contentsOf: await projectCountParityChecks(bridge: bridge, jxa: jxa))
+        case .taskCounts:
+            checks.append(contentsOf: await taskCountContractChecks(using: bridge))
+            checks.append(contentsOf: await taskCountParityChecks(bridge: bridge, jxa: jxa))
+        case .listTasks:
+            checks.append(contentsOf: await listTaskParityChecks(bridge: bridge, jxa: jxa))
+        case .projectCounts:
+            checks.append(await projectCountsBridgeActiveContractCheck(using: bridge))
+            checks.append(contentsOf: await projectCountParityChecks(bridge: bridge, jxa: jxa))
+        }
+
+        let report = GateReport(
+            ok: checks.allSatisfy(\.ok),
+            tool: tool.rawValue,
+            generatedAt: gateISO8601(Date()),
+            dispatchTransport: ProcessInfo.processInfo.environment["FOCUS_RELAY_BRIDGE_DISPATCH_TRANSPORT"] ?? "url",
+            checks: checks
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(report)
+        FileHandle.standardOutput.write(data)
+        FileHandle.standardOutput.write(Data("\n".utf8))
+
+        if !report.ok {
+            throw ExitCode.failure
+        }
+    }
+}
+
+enum GateScope: String, ExpressibleByArgument {
+    case all = "all"
+    case taskCounts = "task-counts"
+    case listTasks = "list-tasks"
+    case projectCounts = "project-counts"
+}
+
+private struct GateReport: Codable {
+    let ok: Bool
+    let tool: String
+    let generatedAt: String
+    let dispatchTransport: String
+    let checks: [GateCheck]
+}
+
+private struct GateCheck: Codable {
+    let name: String
+    let ok: Bool
+    let detail: String
+}
+
+private struct GateTaskCountScenario {
+    let name: String
+    let filter: TaskFilter
+}
+
+private struct GateListTaskScenario {
+    let name: String
+    let filter: TaskFilter
+}
+
+private struct GateProjectCountScenario {
+    let name: String
+    let filter: TaskFilter
+}
+
+private func checkBridgeHealth(using service: OmniFocusBridgeService) async -> GateCheck {
+    do {
+        let result = try service.healthCheck()
+        return GateCheck(
+            name: "bridge_health",
+            ok: result.ok,
+            detail: result.ok ? "plugin=\(result.plugin ?? "unknown") version=\(result.version ?? "unknown")" : (result.error ?? "Bridge health check failed")
+        )
+    } catch {
+        return GateCheck(name: "bridge_health", ok: false, detail: error.localizedDescription)
+    }
+}
+
+private func checkJXAProbe(using service: OmniAutomationService) async -> GateCheck {
+    do {
+        let probe = try await service.debugInboxProbe()
+        return GateCheck(
+            name: "jxa_probe",
+            ok: true,
+            detail: "inboxTasks=\(probe.inboxTasksCount) inInbox=\(probe.inboxInInboxCount)"
+        )
+    } catch {
+        return GateCheck(name: "jxa_probe", ok: false, detail: error.localizedDescription)
+    }
+}
+
+private func taskCountContractChecks(using bridge: OmniFocusBridgeService) async -> [GateCheck] {
+    let scenarios = [
+        GateTaskCountScenario(name: "default", filter: TaskFilter(includeTotalCount: true)),
+        GateTaskCountScenario(name: "inbox_only", filter: TaskFilter(inboxOnly: true, includeTotalCount: true)),
+        GateTaskCountScenario(name: "available_only", filter: TaskFilter(availableOnly: true, includeTotalCount: true))
+    ]
+
+    return await scenarios.asyncMap { scenario in
+        do {
+            let counts = try await retryAsync(operation: "bridge task-counts contract \(scenario.name)") {
+                try await bridge.getTaskCounts(filter: scenario.filter)
+            }
+            let page = try await retryAsync(operation: "bridge list-tasks contract \(scenario.name)") {
+                try await bridge.listTasks(filter: scenario.filter, page: PageRequest(limit: 50), fields: ["id"])
+            }
+            guard let total = page.totalCount else {
+                return GateCheck(name: "task_counts_contract_\(scenario.name)", ok: false, detail: "list_tasks returned nil totalCount")
+            }
+            return GateCheck(
+                name: "task_counts_contract_\(scenario.name)",
+                ok: counts.total == total,
+                detail: "counts.total=\(counts.total) list.totalCount=\(total)"
+            )
+        } catch {
+            return GateCheck(name: "task_counts_contract_\(scenario.name)", ok: false, detail: error.localizedDescription)
+        }
+    }
+}
+
+private func taskCountParityChecks(bridge: OmniFocusBridgeService, jxa: OmniAutomationService) async -> [GateCheck] {
+    let scenarios = [
+        GateTaskCountScenario(name: "default", filter: TaskFilter()),
+        GateTaskCountScenario(name: "inbox_only", filter: TaskFilter(inboxOnly: true)),
+        GateTaskCountScenario(name: "available_only", filter: TaskFilter(availableOnly: true))
+    ]
+
+    return await scenarios.asyncMap { scenario in
+        do {
+            let bridgeCounts = try await retryAsync(operation: "bridge task-counts parity \(scenario.name)") {
+                try await bridge.getTaskCounts(filter: scenario.filter)
+            }
+            let jxaCounts = try await retryAsync(operation: "jxa task-counts parity \(scenario.name)") {
+                try await jxa.getTaskCounts(filter: scenario.filter)
+            }
+            let ok = bridgeCounts.total == jxaCounts.total
+                && bridgeCounts.completed == jxaCounts.completed
+                && bridgeCounts.available == jxaCounts.available
+                && bridgeCounts.flagged == jxaCounts.flagged
+            return GateCheck(
+                name: "task_counts_parity_\(scenario.name)",
+                ok: ok,
+                detail: "bridge=\(bridgeCounts) jxa=\(jxaCounts)"
+            )
+        } catch {
+            return GateCheck(name: "task_counts_parity_\(scenario.name)", ok: false, detail: error.localizedDescription)
+        }
+    }
+}
+
+private func listTaskParityChecks(bridge: OmniFocusBridgeService, jxa: OmniAutomationService) async -> [GateCheck] {
+    let scenarios = [
+        GateListTaskScenario(name: "default", filter: TaskFilter(includeTotalCount: true)),
+        GateListTaskScenario(name: "inbox_only", filter: TaskFilter(inboxOnly: true, includeTotalCount: true)),
+        GateListTaskScenario(name: "available_only", filter: TaskFilter(availableOnly: true, includeTotalCount: true))
+    ]
+    let fields = ["id", "name", "completed", "available", "completionDate"]
+
+    return await scenarios.asyncMap { scenario in
+        do {
+            let bridgePage = try await retryAsync(operation: "bridge list-tasks parity \(scenario.name)") {
+                try await bridge.listTasks(filter: scenario.filter, page: PageRequest(limit: 50), fields: fields)
+            }
+            let jxaPage = try await retryAsync(operation: "jxa list-tasks parity \(scenario.name)") {
+                try await jxa.listTasks(filter: scenario.filter, page: PageRequest(limit: 50), fields: fields)
+            }
+            let bridgeIDs = bridgePage.items.map(\.id)
+            let jxaIDs = jxaPage.items.map(\.id)
+            let ok = bridgePage.totalCount == jxaPage.totalCount
+                && bridgePage.returnedCount == jxaPage.returnedCount
+                && bridgePage.nextCursor == jxaPage.nextCursor
+                && bridgeIDs == jxaIDs
+            return GateCheck(
+                name: "list_tasks_parity_\(scenario.name)",
+                ok: ok,
+                detail: "bridge.total=\(bridgePage.totalCount.map(String.init) ?? "nil") jxa.total=\(jxaPage.totalCount.map(String.init) ?? "nil") bridge.returned=\(bridgePage.returnedCount) jxa.returned=\(jxaPage.returnedCount)"
+            )
+        } catch {
+            return GateCheck(name: "list_tasks_parity_\(scenario.name)", ok: false, detail: error.localizedDescription)
+        }
+    }
+}
+
+private func projectCountsBridgeActiveContractCheck(using bridge: OmniFocusBridgeService) async -> GateCheck {
+    let filter = TaskFilter(completed: false, availableOnly: false, projectView: "active", includeTotalCount: true)
+    do {
+        let counts = try await retryAsync(operation: "bridge project-counts active contract") {
+            try await bridge.getProjectCounts(filter: filter)
+        }
+        let page = try await retryAsync(operation: "bridge list-tasks active contract") {
+            try await bridge.listTasks(filter: filter, page: PageRequest(limit: 50), fields: ["id"])
+        }
+        guard let total = page.totalCount else {
+            return GateCheck(name: "project_counts_active_contract_bridge", ok: false, detail: "list_tasks returned nil totalCount")
+        }
+        return GateCheck(
+            name: "project_counts_active_contract_bridge",
+            ok: counts.actions == total,
+            detail: "counts.actions=\(counts.actions) list.totalCount=\(total)"
+        )
+    } catch {
+        return GateCheck(name: "project_counts_active_contract_bridge", ok: false, detail: error.localizedDescription)
+    }
+}
+
+private func projectCountParityChecks(bridge: OmniFocusBridgeService, jxa: OmniAutomationService) async -> [GateCheck] {
+    let scenarios = [
+        GateProjectCountScenario(name: "project_view_remaining", filter: TaskFilter(projectView: "remaining")),
+        GateProjectCountScenario(name: "project_view_active", filter: TaskFilter(projectView: "active"))
+    ]
+
+    return await scenarios.asyncMap { scenario in
+        do {
+            let bridgeCounts = try await retryAsync(operation: "bridge project-counts parity \(scenario.name)") {
+                try await bridge.getProjectCounts(filter: scenario.filter)
+            }
+            let jxaCounts = try await retryAsync(operation: "jxa project-counts parity \(scenario.name)") {
+                try await jxa.getProjectCounts(filter: scenario.filter)
+            }
+            let ok = bridgeCounts.projects == jxaCounts.projects && bridgeCounts.actions == jxaCounts.actions
+            return GateCheck(
+                name: "project_counts_parity_\(scenario.name)",
+                ok: ok,
+                detail: "bridge=\(bridgeCounts) jxa=\(jxaCounts)"
+            )
+        } catch {
+            return GateCheck(name: "project_counts_parity_\(scenario.name)", ok: false, detail: error.localizedDescription)
+        }
+    }
+}
+
+private func retryAsync<T>(operation: String, maxAttempts: Int = 2, delaySeconds: TimeInterval = 1.0, _ body: @escaping () async throws -> T) async throws -> T {
+    var attempt = 0
+    var lastError: Error?
+    while attempt < maxAttempts {
+        attempt += 1
+        do {
+            return try await body()
+        } catch {
+            lastError = error
+            let lower = error.localizedDescription.lowercased()
+            let retryable = lower.contains("timed out") || lower.contains("timeout")
+            if !retryable || attempt >= maxAttempts {
+                throw AutomationError.executionFailed("\(operation) failed on attempt \(attempt)/\(maxAttempts): \(error.localizedDescription)")
+            }
+            try? await Task.sleep(nanoseconds: UInt64(delaySeconds * 1_000_000_000))
+        }
+    }
+    throw lastError ?? AutomationError.executionFailed("\(operation) failed without a specific error")
+}
+
+private func gateISO8601(_ date: Date) -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter.string(from: date)
+}
+
+private extension Array {
+    func asyncMap<T>(_ transform: (Element) async -> T) async -> [T] {
+        var result: [T] = []
+        result.reserveCapacity(count)
+        for element in self {
+            result.append(await transform(element))
+        }
+        return result
+    }
+}

--- a/Sources/FocusRelayCLI/BenchmarkGateCheckCommand.swift
+++ b/Sources/FocusRelayCLI/BenchmarkGateCheckCommand.swift
@@ -182,8 +182,12 @@ private func taskCountParityChecks(bridge: OmniFocusBridgeService, jxa: OmniAuto
 private func listTaskParityChecks(bridge: OmniFocusBridgeService, jxa: OmniAutomationService) async -> [GateCheck] {
     let scenarios = [
         GateListTaskScenario(name: "default", filter: TaskFilter(includeTotalCount: true)),
+        GateListTaskScenario(name: "default_no_total", filter: TaskFilter(includeTotalCount: false)),
         GateListTaskScenario(name: "inbox_only", filter: TaskFilter(inboxOnly: true, includeTotalCount: true)),
-        GateListTaskScenario(name: "available_only", filter: TaskFilter(availableOnly: true, includeTotalCount: true))
+        GateListTaskScenario(name: "inbox_only_no_total", filter: TaskFilter(inboxOnly: true, includeTotalCount: false)),
+        GateListTaskScenario(name: "available_only", filter: TaskFilter(availableOnly: true, includeTotalCount: true)),
+        GateListTaskScenario(name: "available_only_no_total", filter: TaskFilter(availableOnly: true, includeTotalCount: false)),
+        GateListTaskScenario(name: "flagged_only_no_total", filter: TaskFilter(flagged: true, includeTotalCount: false))
     ]
     let fields = ["id", "name", "completed", "available", "completionDate"]
 
@@ -204,7 +208,7 @@ private func listTaskParityChecks(bridge: OmniFocusBridgeService, jxa: OmniAutom
             return GateCheck(
                 name: "list_tasks_parity_\(scenario.name)",
                 ok: ok,
-                detail: "bridge.total=\(bridgePage.totalCount.map(String.init) ?? "nil") jxa.total=\(jxaPage.totalCount.map(String.init) ?? "nil") bridge.returned=\(bridgePage.returnedCount) jxa.returned=\(jxaPage.returnedCount)"
+                detail: "bridge.total=\(bridgePage.totalCount.map(String.init) ?? "nil") jxa.total=\(jxaPage.totalCount.map(String.init) ?? "nil") bridge.returned=\(bridgePage.returnedCount) jxa.returned=\(jxaPage.returnedCount) bridge.next=\(bridgePage.nextCursor ?? "nil") jxa.next=\(jxaPage.nextCursor ?? "nil")"
             )
         } catch {
             return GateCheck(name: "list_tasks_parity_\(scenario.name)", ok: false, detail: error.localizedDescription)

--- a/Sources/FocusRelayCLI/BenchmarkListTasksCommand.swift
+++ b/Sources/FocusRelayCLI/BenchmarkListTasksCommand.swift
@@ -1,0 +1,356 @@
+import ArgumentParser
+import Foundation
+import OmniFocusAutomation
+import OmniFocusCore
+
+struct BenchmarkListTasks: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "benchmark-list-tasks",
+        abstract: "Benchmark list_tasks for plugin vs JXA transports.",
+        aliases: ["benchmark_list_tasks"]
+    )
+
+    @Option(name: .customLong("duration-hours"), help: "Measured phase duration in hours.")
+    var durationHours: Double = 3.0
+
+    @Option(name: .customLong("warmup-calls"), help: "Warmup calls per transport before measured runs.")
+    var warmupCalls: Int = 20
+
+    @Option(name: .customLong("interval-ms"), help: "Minimum start-to-start interval between calls in milliseconds.")
+    var intervalMS: Int = 1500
+
+    @Option(name: .customLong("cooldown-ms"), help: "Cooldown delay after failed/timeout calls in milliseconds.")
+    var cooldownMS: Int = 3000
+
+    @Option(name: .customLong("completed-after"), help: "Fixed ISO8601 anchor for completed-date scenario.")
+    var completedAfter: String = "2020-01-01T00:00:00Z"
+
+    @Option(name: .customLong("output-dir"), help: "Output directory. Defaults to docs/benchmarks/<timestamp>.")
+    var outputDir: String?
+
+    func run() async throws {
+        let completedAfterDate = try ISO8601DateParser.parse(completedAfter, argumentName: "--completed-after")
+        let scenarios = listTaskScenarios(completedAfter: completedAfterDate)
+        let outputURL = try listTaskBenchmarkOutputDirectory(customPath: outputDir)
+        let rawURL = outputURL.appendingPathComponent("raw.jsonl")
+        let summaryURL = outputURL.appendingPathComponent("summary.md")
+        FileManager.default.createFile(atPath: rawURL.path, contents: nil)
+
+        print("Benchmark output directory: \(outputURL.path)")
+        print("Scenarios: \(scenarios.map(\.name).joined(separator: ", "))")
+
+        let pluginService = OmniFocusBridgeService()
+        let jxaService = OmniAutomationService()
+
+        var callIndex = 0
+        var stats: [String: [String: ListTaskStats]] = [:]
+        var mismatches = 0
+
+        if warmupCalls > 0 {
+            for _ in 0..<warmupCalls {
+                let scenario = scenarios[callIndex % scenarios.count]
+                _ = try await listTaskBenchCall(
+                    transport: "plugin",
+                    scenario: scenario,
+                    phase: "warmup",
+                    service: pluginService,
+                    intervalMS: intervalMS,
+                    cooldownMS: cooldownMS,
+                    callIndex: &callIndex,
+                    rawURL: rawURL
+                )
+            }
+            for _ in 0..<warmupCalls {
+                let scenario = scenarios[callIndex % scenarios.count]
+                _ = try await listTaskBenchCall(
+                    transport: "jxa",
+                    scenario: scenario,
+                    phase: "warmup",
+                    service: jxaService,
+                    intervalMS: intervalMS,
+                    cooldownMS: cooldownMS,
+                    callIndex: &callIndex,
+                    rawURL: rawURL
+                )
+            }
+        }
+
+        let start = Date()
+        let end = start.addingTimeInterval(durationHours * 3600)
+        print("Measured phase started at \(listTaskISO8601(start)); ending at \(listTaskISO8601(end))")
+
+        while Date() < end {
+            let scenario = scenarios[callIndex % scenarios.count]
+
+            let pluginEvent = try await listTaskBenchCall(
+                transport: "plugin",
+                scenario: scenario,
+                phase: "measured",
+                service: pluginService,
+                intervalMS: intervalMS,
+                cooldownMS: cooldownMS,
+                callIndex: &callIndex,
+                rawURL: rawURL
+            )
+            ingestListTaskEvent(pluginEvent, into: &stats)
+            if pluginEvent.timeout {
+                await runListTaskTimeoutRecoveryGate()
+            }
+
+            let jxaEvent = try await listTaskBenchCall(
+                transport: "jxa",
+                scenario: scenario,
+                phase: "measured",
+                service: jxaService,
+                intervalMS: intervalMS,
+                cooldownMS: cooldownMS,
+                callIndex: &callIndex,
+                rawURL: rawURL
+            )
+            ingestListTaskEvent(jxaEvent, into: &stats)
+            if jxaEvent.timeout {
+                await runListTaskTimeoutRecoveryGate()
+            }
+
+            if pluginEvent.ok && jxaEvent.ok && pluginEvent.totalCount != jxaEvent.totalCount {
+                mismatches += 1
+            }
+        }
+
+        let summary = renderListTaskSummary(
+            startedAt: start,
+            endedAt: Date(),
+            scenarios: scenarios.map(\.name),
+            stats: stats,
+            mismatches: mismatches
+        )
+        try summary.write(to: summaryURL, atomically: true, encoding: .utf8)
+
+        print("Benchmark complete.")
+        print("Raw data: \(rawURL.path)")
+        print("Summary: \(summaryURL.path)")
+    }
+}
+
+private struct ListTaskScenario {
+    let name: String
+    let filter: TaskFilter
+}
+
+private struct ListTaskEvent: Codable {
+    let timestamp: String
+    let phase: String
+    let callIndex: Int
+    let transport: String
+    let scenario: String
+    let latencyMs: Double
+    let ok: Bool
+    let timeout: Bool
+    let error: String?
+    let returnedCount: Int?
+    let totalCount: Int?
+}
+
+private struct ListTaskStats {
+    var success: Int = 0
+    var errors: Int = 0
+    var timeouts: Int = 0
+    var latencies: [Double] = []
+
+    mutating func ingest(_ event: ListTaskEvent) {
+        if event.ok {
+            success += 1
+            latencies.append(event.latencyMs)
+        } else {
+            errors += 1
+            if event.timeout { timeouts += 1 }
+        }
+    }
+}
+
+private func listTaskScenarios(completedAfter: Date) -> [ListTaskScenario] {
+    [
+        ListTaskScenario(name: "default", filter: TaskFilter(includeTotalCount: true)),
+        ListTaskScenario(name: "inbox_only", filter: TaskFilter(inboxOnly: true, includeTotalCount: true)),
+        ListTaskScenario(name: "available_only", filter: TaskFilter(availableOnly: true, includeTotalCount: true)),
+        ListTaskScenario(name: "completed_after_anchor", filter: TaskFilter(completed: true, completedAfter: completedAfter, includeTotalCount: true)),
+        ListTaskScenario(name: "flagged_only", filter: TaskFilter(flagged: true, includeTotalCount: true))
+    ]
+}
+
+private func listTaskBenchCall(
+    transport: String,
+    scenario: ListTaskScenario,
+    phase: String,
+    service: any OmniFocusService,
+    intervalMS: Int,
+    cooldownMS: Int,
+    callIndex: inout Int,
+    rawURL: URL
+) async throws -> ListTaskEvent {
+    callIndex += 1
+    let started = Date()
+    do {
+        let page = try await service.listTasks(
+            filter: scenario.filter,
+            page: PageRequest(limit: 50),
+            fields: ["id", "name", "completed", "available", "completionDate"]
+        )
+        let elapsed = Date().timeIntervalSince(started) * 1000
+        try await listTaskEnforceInterval(started: started, intervalMS: intervalMS)
+        let event = ListTaskEvent(
+            timestamp: listTaskISO8601Now(),
+            phase: phase,
+            callIndex: callIndex,
+            transport: transport,
+            scenario: scenario.name,
+            latencyMs: elapsed,
+            ok: true,
+            timeout: false,
+            error: nil,
+            returnedCount: page.returnedCount,
+            totalCount: page.totalCount
+        )
+        try listTaskAppendJSONLine(event, to: rawURL)
+        return event
+    } catch {
+        let elapsed = Date().timeIntervalSince(started) * 1000
+        let timeout = listTaskIsTimeout(error)
+        try await listTaskEnforceInterval(started: started, intervalMS: intervalMS)
+        if cooldownMS > 0 {
+            try? await Task.sleep(nanoseconds: UInt64(cooldownMS) * 1_000_000)
+        }
+        let event = ListTaskEvent(
+            timestamp: listTaskISO8601Now(),
+            phase: phase,
+            callIndex: callIndex,
+            transport: transport,
+            scenario: scenario.name,
+            latencyMs: elapsed,
+            ok: false,
+            timeout: timeout,
+            error: error.localizedDescription,
+            returnedCount: nil,
+            totalCount: nil
+        )
+        try listTaskAppendJSONLine(event, to: rawURL)
+        return event
+    }
+}
+
+private func runListTaskTimeoutRecoveryGate() async {
+    let env = ProcessInfo.processInfo.environment
+    let recoveryMs = max(0, env["FOCUS_RELAY_TIMEOUT_RECOVERY_MS"].flatMap(Int.init) ?? 10_000)
+    if recoveryMs > 0 {
+        try? await Task.sleep(nanoseconds: UInt64(recoveryMs) * 1_000_000)
+    }
+    // Lightweight readiness probe before resuming to reduce timeout cascades.
+    _ = try? OmniFocusBridgeService().healthCheck()
+}
+
+private func ingestListTaskEvent(_ event: ListTaskEvent, into stats: inout [String: [String: ListTaskStats]]) {
+    guard event.phase == "measured" else { return }
+    var perScenario = stats[event.scenario] ?? [:]
+    var perTransport = perScenario[event.transport] ?? ListTaskStats()
+    perTransport.ingest(event)
+    perScenario[event.transport] = perTransport
+    stats[event.scenario] = perScenario
+}
+
+private func renderListTaskSummary(
+    startedAt: Date,
+    endedAt: Date,
+    scenarios: [String],
+    stats: [String: [String: ListTaskStats]],
+    mismatches: Int
+) -> String {
+    func p(_ values: [Double], _ q: Double) -> String {
+        guard !values.isEmpty else { return "n/a" }
+        let sorted = values.sorted()
+        let idx = Int(Double(sorted.count - 1) * q)
+        return String(format: "%.2f", sorted[idx])
+    }
+
+    var lines: [String] = []
+    lines.append("# list_tasks Benchmark Summary")
+    lines.append("")
+    lines.append("- Started: \(listTaskISO8601(startedAt))")
+    lines.append("- Ended: \(listTaskISO8601(endedAt))")
+    lines.append("- Scenarios: \(scenarios.joined(separator: ", "))")
+    lines.append("")
+    lines.append("## Scenario Stats")
+    lines.append("")
+    for scenario in scenarios {
+        lines.append("### \(scenario)")
+        let scoped = stats[scenario] ?? [:]
+        for transport in ["plugin", "jxa"] {
+            let s = scoped[transport] ?? ListTaskStats()
+            let total = s.success + s.errors
+            let errorRate = total > 0 ? (Double(s.errors) / Double(total)) * 100.0 : .nan
+            let timeoutRate = total > 0 ? (Double(s.timeouts) / Double(total)) * 100.0 : .nan
+            let er = errorRate.isFinite ? String(format: "%.2f%%", errorRate) : "n/a"
+            let tr = timeoutRate.isFinite ? String(format: "%.2f%%", timeoutRate) : "n/a"
+            lines.append("- \(transport): total=\(total), success=\(s.success), errors=\(s.errors), error_rate=\(er), timeouts=\(s.timeouts), timeout_rate=\(tr), p50_ms=\(p(s.latencies, 0.5)), p95_ms=\(p(s.latencies, 0.95)), p99_ms=\(p(s.latencies, 0.99))")
+        }
+        lines.append("")
+    }
+
+    lines.append("## Parity")
+    lines.append("")
+    lines.append("- Mismatch count: \(mismatches)")
+    return lines.joined(separator: "\n")
+}
+
+private func listTaskBenchmarkOutputDirectory(customPath: String?) throws -> URL {
+    if let customPath, !customPath.isEmpty {
+        let url = URL(fileURLWithPath: customPath, relativeTo: URL(fileURLWithPath: FileManager.default.currentDirectoryPath)).standardizedFileURL
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.dateFormat = "yyyyMMdd-HHmmss"
+    let timestamp = formatter.string(from: Date())
+    let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        .appendingPathComponent("docs", isDirectory: true)
+        .appendingPathComponent("benchmarks", isDirectory: true)
+        .appendingPathComponent("list-tasks-\(timestamp)", isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+}
+
+private func listTaskAppendJSONLine<T: Encodable>(_ value: T, to url: URL) throws {
+    let encoder = JSONEncoder()
+    let data = try encoder.encode(value)
+    guard var line = String(data: data, encoding: .utf8) else { return }
+    line.append("\n")
+    let handle = try FileHandle(forWritingTo: url)
+    defer { try? handle.close() }
+    try handle.seekToEnd()
+    try handle.write(contentsOf: Data(line.utf8))
+}
+
+private func listTaskIsTimeout(_ error: Error) -> Bool {
+    let message = error.localizedDescription.lowercased()
+    return message.contains("timed out") || message.contains("timeout")
+}
+
+private func listTaskEnforceInterval(started: Date, intervalMS: Int) async throws {
+    guard intervalMS > 0 else { return }
+    let elapsed = Date().timeIntervalSince(started)
+    let target = Double(intervalMS) / 1000.0
+    if elapsed < target {
+        try await Task.sleep(nanoseconds: UInt64((target - elapsed) * 1_000_000_000))
+    }
+}
+
+private func listTaskISO8601Now() -> String {
+    listTaskISO8601(Date())
+}
+
+private func listTaskISO8601(_ date: Date) -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter.string(from: date)
+}

--- a/Sources/FocusRelayCLI/BenchmarkListTasksCommand.swift
+++ b/Sources/FocusRelayCLI/BenchmarkListTasksCommand.swift
@@ -33,8 +33,10 @@ struct BenchmarkListTasks: AsyncParsableCommand {
         let scenarios = listTaskScenarios(completedAfter: completedAfterDate)
         let outputURL = try listTaskBenchmarkOutputDirectory(customPath: outputDir)
         let rawURL = outputURL.appendingPathComponent("raw.jsonl")
+        let timeoutDiagnosticsURL = outputURL.appendingPathComponent("timeout-diagnostics.jsonl")
         let summaryURL = outputURL.appendingPathComponent("summary.md")
         FileManager.default.createFile(atPath: rawURL.path, contents: nil)
+        FileManager.default.createFile(atPath: timeoutDiagnosticsURL.path, contents: nil)
 
         print("Benchmark output directory: \(outputURL.path)")
         print("Scenarios: \(scenarios.map(\.name).joined(separator: ", "))")
@@ -49,29 +51,37 @@ struct BenchmarkListTasks: AsyncParsableCommand {
         if warmupCalls > 0 {
             for _ in 0..<warmupCalls {
                 let scenario = scenarios[callIndex % scenarios.count]
-                _ = try await listTaskBenchCall(
+                let event = try await listTaskBenchCall(
                     transport: "plugin",
                     scenario: scenario,
                     phase: "warmup",
                     service: pluginService,
+                    timeoutDiagnosticsURL: timeoutDiagnosticsURL,
                     intervalMS: intervalMS,
                     cooldownMS: cooldownMS,
                     callIndex: &callIndex,
                     rawURL: rawURL
                 )
+                if event.timeout {
+                    await runListTaskTimeoutRecoveryGate()
+                }
             }
             for _ in 0..<warmupCalls {
                 let scenario = scenarios[callIndex % scenarios.count]
-                _ = try await listTaskBenchCall(
+                let event = try await listTaskBenchCall(
                     transport: "jxa",
                     scenario: scenario,
                     phase: "warmup",
                     service: jxaService,
+                    timeoutDiagnosticsURL: timeoutDiagnosticsURL,
                     intervalMS: intervalMS,
                     cooldownMS: cooldownMS,
                     callIndex: &callIndex,
                     rawURL: rawURL
                 )
+                if event.timeout {
+                    await runListTaskTimeoutRecoveryGate()
+                }
             }
         }
 
@@ -87,6 +97,7 @@ struct BenchmarkListTasks: AsyncParsableCommand {
                 scenario: scenario,
                 phase: "measured",
                 service: pluginService,
+                timeoutDiagnosticsURL: timeoutDiagnosticsURL,
                 intervalMS: intervalMS,
                 cooldownMS: cooldownMS,
                 callIndex: &callIndex,
@@ -102,6 +113,7 @@ struct BenchmarkListTasks: AsyncParsableCommand {
                 scenario: scenario,
                 phase: "measured",
                 service: jxaService,
+                timeoutDiagnosticsURL: timeoutDiagnosticsURL,
                 intervalMS: intervalMS,
                 cooldownMS: cooldownMS,
                 callIndex: &callIndex,
@@ -122,7 +134,8 @@ struct BenchmarkListTasks: AsyncParsableCommand {
             endedAt: Date(),
             scenarios: scenarios.map(\.name),
             stats: stats,
-            mismatches: mismatches
+            mismatches: mismatches,
+            timeoutDiagnosticCount: listTaskCountLines(in: timeoutDiagnosticsURL)
         )
         try summary.write(to: summaryURL, atomically: true, encoding: .utf8)
 
@@ -168,6 +181,45 @@ private struct ListTaskStats {
     }
 }
 
+private struct ListTaskTimeoutQueueSnapshot: Codable {
+    let basePath: String
+    let requestsCount: Int
+    let locksCount: Int
+    let responsesCount: Int
+    let requestExists: Bool?
+    let lockExists: Bool?
+    let responseExists: Bool?
+    let sampleRequests: [String]
+    let sampleLocks: [String]
+    let sampleResponses: [String]
+}
+
+private struct ListTaskTimeoutProcessSnapshot: Codable {
+    let process: String
+    let pid: Int32?
+    let rssKB: Int?
+}
+
+private struct ListTaskTimeoutBridgeHealthSnapshot: Codable {
+    let ok: Bool
+    let detail: String
+}
+
+private struct ListTaskTimeoutDiagnostic: Codable {
+    let timestamp: String
+    let transport: String
+    let scenario: String
+    let phase: String
+    let callIndex: Int
+    let latencyMs: Double
+    let error: String
+    let requestId: String?
+    let queue: ListTaskTimeoutQueueSnapshot
+    let omniFocus: ListTaskTimeoutProcessSnapshot
+    let focusrelay: ListTaskTimeoutProcessSnapshot
+    let bridgeHealth: ListTaskTimeoutBridgeHealthSnapshot?
+}
+
 private func listTaskScenarios(completedAfter: Date) -> [ListTaskScenario] {
     [
         ListTaskScenario(name: "default", filter: TaskFilter(includeTotalCount: true)),
@@ -183,6 +235,7 @@ private func listTaskBenchCall(
     scenario: ListTaskScenario,
     phase: String,
     service: any OmniFocusService,
+    timeoutDiagnosticsURL: URL,
     intervalMS: Int,
     cooldownMS: Int,
     callIndex: inout Int,
@@ -219,6 +272,17 @@ private func listTaskBenchCall(
         try await listTaskEnforceInterval(started: started, intervalMS: intervalMS)
         if cooldownMS > 0 {
             try? await Task.sleep(nanoseconds: UInt64(cooldownMS) * 1_000_000)
+        }
+        if timeout {
+            let diagnostic = captureListTaskTimeoutDiagnostic(
+                transport: transport,
+                scenario: scenario,
+                phase: phase,
+                callIndex: callIndex,
+                latencyMs: elapsed,
+                errorMessage: error.localizedDescription
+            )
+            try? listTaskAppendJSONLine(diagnostic, to: timeoutDiagnosticsURL)
         }
         let event = ListTaskEvent(
             timestamp: listTaskISO8601Now(),
@@ -262,7 +326,8 @@ private func renderListTaskSummary(
     endedAt: Date,
     scenarios: [String],
     stats: [String: [String: ListTaskStats]],
-    mismatches: Int
+    mismatches: Int,
+    timeoutDiagnosticCount: Int
 ) -> String {
     func p(_ values: [Double], _ q: Double) -> String {
         guard !values.isEmpty else { return "n/a" }
@@ -298,6 +363,10 @@ private func renderListTaskSummary(
     lines.append("## Parity")
     lines.append("")
     lines.append("- Mismatch count: \(mismatches)")
+    lines.append("")
+    lines.append("## Timeout Diagnostics")
+    lines.append("")
+    lines.append("- Diagnostic entries: \(timeoutDiagnosticCount)")
     return lines.joined(separator: "\n")
 }
 
@@ -329,6 +398,182 @@ private func listTaskAppendJSONLine<T: Encodable>(_ value: T, to url: URL) throw
     defer { try? handle.close() }
     try handle.seekToEnd()
     try handle.write(contentsOf: Data(line.utf8))
+}
+
+private func captureListTaskTimeoutDiagnostic(
+    transport: String,
+    scenario: ListTaskScenario,
+    phase: String,
+    callIndex: Int,
+    latencyMs: Double,
+    errorMessage: String
+) -> ListTaskTimeoutDiagnostic {
+    let requestID = listTaskExtractRequestID(from: errorMessage)
+    let baseURL = listTaskDefaultIPCBaseURL()
+    let requestsURL = baseURL.appendingPathComponent("requests", isDirectory: true)
+    let locksURL = baseURL.appendingPathComponent("locks", isDirectory: true)
+    let responsesURL = baseURL.appendingPathComponent("responses", isDirectory: true)
+    let queue = ListTaskTimeoutQueueSnapshot(
+        basePath: baseURL.path,
+        requestsCount: listTaskDirectoryEntryCount(requestsURL),
+        locksCount: listTaskDirectoryEntryCount(locksURL),
+        responsesCount: listTaskDirectoryEntryCount(responsesURL),
+        requestExists: requestID.map { FileManager.default.fileExists(atPath: requestsURL.appendingPathComponent("\($0).json").path) },
+        lockExists: requestID.map { FileManager.default.fileExists(atPath: locksURL.appendingPathComponent("\($0).lock").path) },
+        responseExists: requestID.map { FileManager.default.fileExists(atPath: responsesURL.appendingPathComponent("\($0).json").path) },
+        sampleRequests: listTaskDirectoryEntrySamples(requestsURL),
+        sampleLocks: listTaskDirectoryEntrySamples(locksURL),
+        sampleResponses: listTaskDirectoryEntrySamples(responsesURL)
+    )
+    let omniPID = listTaskCurrentOmniFocusPID()
+    let benchmarkPID = ProcessInfo.processInfo.processIdentifier
+    let bridgeHealth: ListTaskTimeoutBridgeHealthSnapshot?
+    if transport == "plugin" {
+        if let result = try? OmniFocusBridgeService().healthCheck() {
+            bridgeHealth = ListTaskTimeoutBridgeHealthSnapshot(
+                ok: result.ok,
+                detail: "plugin=\(result.plugin ?? "unknown") version=\(result.version ?? "unknown")"
+            )
+        } else {
+            bridgeHealth = ListTaskTimeoutBridgeHealthSnapshot(
+                ok: false,
+                detail: "bridge-health-check failed after timeout"
+            )
+        }
+    } else {
+        bridgeHealth = nil
+    }
+
+    return ListTaskTimeoutDiagnostic(
+        timestamp: listTaskISO8601Now(),
+        transport: transport,
+        scenario: scenario.name,
+        phase: phase,
+        callIndex: callIndex,
+        latencyMs: latencyMs,
+        error: errorMessage,
+        requestId: requestID,
+        queue: queue,
+        omniFocus: ListTaskTimeoutProcessSnapshot(
+            process: "OmniFocus",
+            pid: omniPID,
+            rssKB: omniPID.flatMap(listTaskReadRSSKilobytes(pid:))
+        ),
+        focusrelay: ListTaskTimeoutProcessSnapshot(
+            process: "focusrelay",
+            pid: benchmarkPID,
+            rssKB: listTaskReadRSSKilobytes(pid: benchmarkPID)
+        ),
+        bridgeHealth: bridgeHealth
+    )
+}
+
+private func listTaskExtractRequestID(from message: String) -> String? {
+    let pattern = #"requestId=([A-F0-9-]+)"#
+    guard let regex = try? NSRegularExpression(pattern: pattern) else {
+        return nil
+    }
+    let range = NSRange(message.startIndex..<message.endIndex, in: message)
+    guard let match = regex.firstMatch(in: message, range: range),
+          let matchRange = Range(match.range(at: 1), in: message) else {
+        return nil
+    }
+    return String(message[matchRange])
+}
+
+private func listTaskDirectoryEntryCount(_ url: URL) -> Int {
+    guard let contents = try? FileManager.default.contentsOfDirectory(atPath: url.path) else {
+        return 0
+    }
+    return contents.count
+}
+
+private func listTaskDirectoryEntrySamples(_ url: URL, limit: Int = 5) -> [String] {
+    guard let contents = try? FileManager.default.contentsOfDirectory(atPath: url.path) else {
+        return []
+    }
+    return Array(contents.sorted().prefix(limit))
+}
+
+private func listTaskDefaultIPCBaseURL() -> URL {
+    let home = FileManager.default.homeDirectoryForCurrentUser
+    let container = home
+        .appendingPathComponent("Library", isDirectory: true)
+        .appendingPathComponent("Containers", isDirectory: true)
+        .appendingPathComponent("com.omnigroup.OmniFocus4", isDirectory: true)
+        .appendingPathComponent("Data", isDirectory: true)
+        .appendingPathComponent("Documents", isDirectory: true)
+        .appendingPathComponent("FocusRelayIPC", isDirectory: true)
+
+    if FileManager.default.fileExists(atPath: container.deletingLastPathComponent().path) {
+        return container
+    }
+
+    return home
+        .appendingPathComponent("Library", isDirectory: true)
+        .appendingPathComponent("Caches", isDirectory: true)
+        .appendingPathComponent("focusrelay", isDirectory: true)
+}
+
+private func listTaskCurrentOmniFocusPID() -> Int32? {
+    guard let output = try? listTaskRunProcess(
+        executable: "/usr/bin/pgrep",
+        arguments: ["-x", "OmniFocus"],
+        timeout: 3
+    ) else {
+        return nil
+    }
+    let firstLine = output.split(separator: "\n").first
+    return firstLine.flatMap { Int32($0) }
+}
+
+private func listTaskReadRSSKilobytes(pid: Int32) -> Int? {
+    guard let output = try? listTaskRunProcess(
+        executable: "/bin/ps",
+        arguments: ["-o", "rss=", "-p", String(pid)],
+        timeout: 3
+    ) else {
+        return nil
+    }
+    return Int(output.trimmingCharacters(in: .whitespacesAndNewlines))
+}
+
+@discardableResult
+private func listTaskRunProcess(executable: String, arguments: [String], timeout: TimeInterval = 15) throws -> String {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: executable)
+    process.arguments = arguments
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = pipe
+    try process.run()
+
+    let deadline = Date().addingTimeInterval(timeout)
+    while process.isRunning && Date() < deadline {
+        Thread.sleep(forTimeInterval: 0.05)
+    }
+
+    if process.isRunning {
+        process.terminate()
+        throw AutomationError.executionFailed("Process \(executable) timed out after \(Int(timeout))s")
+    }
+
+    process.waitUntilExit()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    let output = String(decoding: data, as: UTF8.self)
+    if process.terminationStatus != 0 {
+        throw AutomationError.executionFailed("Process \(executable) failed: \(output)")
+    }
+    return output
+}
+
+private func listTaskCountLines(in url: URL) -> Int {
+    guard let data = try? Data(contentsOf: url),
+          let text = String(data: data, encoding: .utf8),
+          !text.isEmpty else {
+        return 0
+    }
+    return text.split(separator: "\n").count
 }
 
 private func listTaskIsTimeout(_ error: Error) -> Bool {

--- a/Sources/FocusRelayCLI/BenchmarkListTasksCommand.swift
+++ b/Sources/FocusRelayCLI/BenchmarkListTasksCommand.swift
@@ -124,7 +124,7 @@ struct BenchmarkListTasks: AsyncParsableCommand {
                 await runListTaskTimeoutRecoveryGate()
             }
 
-            if pluginEvent.ok && jxaEvent.ok && pluginEvent.totalCount != jxaEvent.totalCount {
+            if pluginEvent.ok && jxaEvent.ok && !listTaskEventsMatch(pluginEvent, jxaEvent) {
                 mismatches += 1
             }
         }
@@ -162,6 +162,9 @@ private struct ListTaskEvent: Codable {
     let error: String?
     let returnedCount: Int?
     let totalCount: Int?
+    let nextCursor: String?
+    let firstItemID: String?
+    let lastItemID: String?
 }
 
 private struct ListTaskStats {
@@ -223,10 +226,14 @@ private struct ListTaskTimeoutDiagnostic: Codable {
 private func listTaskScenarios(completedAfter: Date) -> [ListTaskScenario] {
     [
         ListTaskScenario(name: "default", filter: TaskFilter(includeTotalCount: true)),
+        ListTaskScenario(name: "default_no_total", filter: TaskFilter(includeTotalCount: false)),
         ListTaskScenario(name: "inbox_only", filter: TaskFilter(inboxOnly: true, includeTotalCount: true)),
+        ListTaskScenario(name: "inbox_only_no_total", filter: TaskFilter(inboxOnly: true, includeTotalCount: false)),
         ListTaskScenario(name: "available_only", filter: TaskFilter(availableOnly: true, includeTotalCount: true)),
+        ListTaskScenario(name: "available_only_no_total", filter: TaskFilter(availableOnly: true, includeTotalCount: false)),
         ListTaskScenario(name: "completed_after_anchor", filter: TaskFilter(completed: true, completedAfter: completedAfter, includeTotalCount: true)),
-        ListTaskScenario(name: "flagged_only", filter: TaskFilter(flagged: true, includeTotalCount: true))
+        ListTaskScenario(name: "flagged_only", filter: TaskFilter(flagged: true, includeTotalCount: true)),
+        ListTaskScenario(name: "flagged_only_no_total", filter: TaskFilter(flagged: true, includeTotalCount: false))
     ]
 }
 
@@ -262,7 +269,10 @@ private func listTaskBenchCall(
             timeout: false,
             error: nil,
             returnedCount: page.returnedCount,
-            totalCount: page.totalCount
+            totalCount: page.totalCount,
+            nextCursor: page.nextCursor,
+            firstItemID: page.items.first?.id,
+            lastItemID: page.items.last?.id
         )
         try listTaskAppendJSONLine(event, to: rawURL)
         return event
@@ -295,7 +305,10 @@ private func listTaskBenchCall(
             timeout: timeout,
             error: error.localizedDescription,
             returnedCount: nil,
-            totalCount: nil
+            totalCount: nil,
+            nextCursor: nil,
+            firstItemID: nil,
+            lastItemID: nil
         )
         try listTaskAppendJSONLine(event, to: rawURL)
         return event
@@ -319,6 +332,14 @@ private func ingestListTaskEvent(_ event: ListTaskEvent, into stats: inout [Stri
     perTransport.ingest(event)
     perScenario[event.transport] = perTransport
     stats[event.scenario] = perScenario
+}
+
+private func listTaskEventsMatch(_ lhs: ListTaskEvent, _ rhs: ListTaskEvent) -> Bool {
+    lhs.returnedCount == rhs.returnedCount &&
+    lhs.totalCount == rhs.totalCount &&
+    lhs.nextCursor == rhs.nextCursor &&
+    lhs.firstItemID == rhs.firstItemID &&
+    lhs.lastItemID == rhs.lastItemID
 }
 
 private func renderListTaskSummary(

--- a/Sources/FocusRelayCLI/BenchmarkProjectCountsCommand.swift
+++ b/Sources/FocusRelayCLI/BenchmarkProjectCountsCommand.swift
@@ -1,0 +1,744 @@
+import ArgumentParser
+import Foundation
+import OmniFocusAutomation
+import OmniFocusCore
+
+private typealias ProjectCountsModel = OmniFocusCore.ProjectCounts
+
+struct BenchmarkProjectCounts: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "benchmark-project-counts",
+        abstract: "Benchmark get_project_counts for plugin vs JXA transports.",
+        aliases: ["benchmark_get_project_counts"]
+    )
+
+    @Option(name: .customLong("duration-hours"), help: "Measured phase duration in hours.")
+    var durationHours: Double = 3.0
+
+    @Option(name: .customLong("warmup-calls"), help: "Warmup calls per transport before measured runs.")
+    var warmupCalls: Int = 20
+
+    @Option(name: .customLong("interval-ms"), help: "Minimum start-to-start interval between calls in milliseconds.")
+    var intervalMS: Int = 1200
+
+    @Option(name: .customLong("cooldown-ms"), help: "Cooldown delay after failed/timeout calls in milliseconds.")
+    var cooldownMS: Int = 5000
+
+    @Option(name: .customLong("memory-interval-seconds"), help: "RSS sample interval in seconds.")
+    var memoryIntervalSeconds: Int = 30
+
+    @Option(name: .customLong("completed-after"), help: "Fixed ISO8601 anchor for completed-date scenario.")
+    var completedAfter: String = "2020-01-01T00:00:00Z"
+
+    @Option(name: .customLong("output-dir"), help: "Output directory. Defaults to docs/benchmarks/<timestamp>.")
+    var outputDir: String?
+
+    @Flag(name: .customLong("run-preflight"), help: "Run process cleanup and OmniFocus restart before benchmarking.")
+    var performPreflight: Bool = false
+
+    func run() async throws {
+        guard durationHours > 0 else {
+            throw ValidationError("--duration-hours must be > 0.")
+        }
+        guard warmupCalls >= 0 else {
+            throw ValidationError("--warmup-calls must be >= 0.")
+        }
+        guard intervalMS >= 0 else {
+            throw ValidationError("--interval-ms must be >= 0.")
+        }
+        guard cooldownMS >= 0 else {
+            throw ValidationError("--cooldown-ms must be >= 0.")
+        }
+        guard memoryIntervalSeconds > 0 else {
+            throw ValidationError("--memory-interval-seconds must be > 0.")
+        }
+
+        let completedAfterDate = try ISO8601DateParser.parse(completedAfter, argumentName: "--completed-after")
+        let scenarios = projectCountBenchmarkScenarios(completedAfter: completedAfterDate)
+
+        let directoryURL = try benchmarkOutputDirectory(customPath: outputDir)
+        let rawURL = directoryURL.appendingPathComponent("raw.jsonl")
+        let memoryURL = directoryURL.appendingPathComponent("memory.csv")
+        let summaryURL = directoryURL.appendingPathComponent("summary.md")
+        try initializeBenchmarkArtifacts(rawURL: rawURL, memoryURL: memoryURL)
+
+        print("Benchmark output directory: \(directoryURL.path)")
+        print("Scenarios: \(scenarios.map(\.name).joined(separator: ", "))")
+
+        if performPreflight {
+            runPreflight()
+        }
+
+        let benchmarkPID = ProcessInfo.processInfo.processIdentifier
+        let memoryTask = Task.detached(priority: .utility) {
+            while !Task.isCancelled {
+                let timestamp = iso8601Now()
+                if let rss = readRSSKilobytes(pid: benchmarkPID) {
+                    let line = "\(timestamp),focusrelay,\(benchmarkPID),\(rss)\n"
+                    try? appendLine(line, to: memoryURL)
+                }
+
+                if let omniPID = currentOmniFocusPID(), let rss = readRSSKilobytes(pid: omniPID) {
+                    let line = "\(timestamp),OmniFocus,\(omniPID),\(rss)\n"
+                    try? appendLine(line, to: memoryURL)
+                }
+
+                let nanos = UInt64(memoryIntervalSeconds) * 1_000_000_000
+                try? await Task.sleep(nanoseconds: nanos)
+            }
+        }
+        defer { memoryTask.cancel() }
+
+        let pluginService = OmniFocusBridgeService()
+        let jxaService = OmniAutomationService()
+
+        var statsByTransport: [Transport: StatsAccumulator] = [:]
+        var statsByScenarioTransport: [String: [Transport: StatsAccumulator]] = [:]
+        var parityMismatches: [ProjectParityMismatch] = []
+        var callIndex = 0
+
+        if warmupCalls > 0 {
+            print("Warmup phase: \(warmupCalls) calls per transport")
+            try await runWarmup(
+                warmupCalls: warmupCalls,
+                scenarios: scenarios,
+                pluginService: pluginService,
+                jxaService: jxaService,
+                rawURL: rawURL,
+                intervalMS: intervalMS,
+                cooldownMS: cooldownMS,
+                callIndex: &callIndex
+            )
+        }
+
+        let durationSeconds = durationHours * 3600
+        let measuredStart = Date()
+        let measuredEnd = measuredStart.addingTimeInterval(durationSeconds)
+        print("Measured phase started at \(iso8601(measuredStart)); ending at \(iso8601(measuredEnd))")
+
+        var scenarioIndex = 0
+        while Date() < measuredEnd {
+            let scenario = scenarios[scenarioIndex % scenarios.count]
+            scenarioIndex += 1
+
+            let pluginEvent = try await runProjectBenchCall(
+                transport: .plugin,
+                scenario: scenario,
+                phase: "measured",
+                service: pluginService,
+                intervalMS: intervalMS,
+                cooldownMS: cooldownMS,
+                callIndex: &callIndex
+            )
+            try appendJSONLine(pluginEvent, to: rawURL)
+            accumulate(pluginEvent, byTransport: &statsByTransport, byScenarioTransport: &statsByScenarioTransport)
+            if pluginEvent.timeout {
+                await runTimeoutRecoveryGate()
+            }
+
+            let jxaEvent = try await runProjectBenchCall(
+                transport: .jxa,
+                scenario: scenario,
+                phase: "measured",
+                service: jxaService,
+                intervalMS: intervalMS,
+                cooldownMS: cooldownMS,
+                callIndex: &callIndex
+            )
+            try appendJSONLine(jxaEvent, to: rawURL)
+            accumulate(jxaEvent, byTransport: &statsByTransport, byScenarioTransport: &statsByScenarioTransport)
+            if jxaEvent.timeout {
+                await runTimeoutRecoveryGate()
+            }
+
+            if let pluginCounts = pluginEvent.counts,
+               let jxaCounts = jxaEvent.counts,
+               !projectCountsEqual(pluginCounts, jxaCounts) {
+                let mismatch = ProjectParityMismatch(
+                    timestamp: iso8601Now(),
+                    scenario: scenario.name,
+                    plugin: pluginCounts,
+                    jxa: jxaCounts
+                )
+                parityMismatches.append(mismatch)
+            }
+        }
+
+        try await writeSummary(
+            to: summaryURL,
+            startedAt: measuredStart,
+            endedAt: Date(),
+            memoryURL: memoryURL,
+            durationHours: durationHours,
+            warmupCalls: warmupCalls,
+            intervalMS: intervalMS,
+            cooldownMS: cooldownMS,
+            memoryIntervalSeconds: memoryIntervalSeconds,
+            scenarios: scenarios,
+            statsByTransport: statsByTransport,
+            statsByScenarioTransport: statsByScenarioTransport,
+            parityMismatches: parityMismatches
+        )
+
+        print("Benchmark complete.")
+        print("Raw data: \(rawURL.path)")
+        print("Memory samples: \(memoryURL.path)")
+        print("Summary: \(summaryURL.path)")
+    }
+}
+
+private struct BenchmarkScenario {
+    let name: String
+    let filter: TaskFilter
+}
+
+private func projectCountBenchmarkScenarios(completedAfter: Date) -> [BenchmarkScenario] {
+    [
+        BenchmarkScenario(name: "project_view_remaining", filter: TaskFilter(projectView: "remaining")),
+        BenchmarkScenario(name: "project_view_active", filter: TaskFilter(projectView: "active")),
+        BenchmarkScenario(name: "project_view_available", filter: TaskFilter(projectView: "available")),
+        BenchmarkScenario(name: "project_view_everything", filter: TaskFilter(projectView: "everything")),
+        BenchmarkScenario(
+            name: "completed_after_anchor",
+            filter: TaskFilter(completed: true, completedAfter: completedAfter)
+        )
+    ]
+}
+
+private enum Transport: String, Codable, CaseIterable {
+    case plugin
+    case jxa
+}
+
+private struct ProjectBenchEvent: Codable {
+    let timestamp: String
+    let phase: String
+    let callIndex: Int
+    let transport: String
+    let scenario: String
+    let latencyMs: Double
+    let ok: Bool
+    let timeout: Bool
+    let error: String?
+    let counts: ProjectCountsModel?
+}
+
+private struct StatsAccumulator {
+    var successCount: Int = 0
+    var errorCount: Int = 0
+    var timeoutCount: Int = 0
+    var latencies: [Double] = []
+
+    mutating func ingest(_ event: ProjectBenchEvent) {
+        if event.ok {
+            successCount += 1
+            latencies.append(event.latencyMs)
+        } else {
+            errorCount += 1
+            if event.timeout {
+                timeoutCount += 1
+            }
+        }
+    }
+}
+
+private struct ProjectParityMismatch: Codable {
+    let timestamp: String
+    let scenario: String
+    let plugin: ProjectCountsModel
+    let jxa: ProjectCountsModel
+}
+
+private func runWarmup(
+    warmupCalls: Int,
+    scenarios: [BenchmarkScenario],
+    pluginService: OmniFocusBridgeService,
+    jxaService: OmniAutomationService,
+    rawURL: URL,
+    intervalMS: Int,
+    cooldownMS: Int,
+    callIndex: inout Int
+) async throws {
+    var scenarioIndex = 0
+    for _ in 0..<warmupCalls {
+        let scenario = scenarios[scenarioIndex % scenarios.count]
+        scenarioIndex += 1
+        let event = try await runProjectBenchCall(
+            transport: .plugin,
+            scenario: scenario,
+            phase: "warmup",
+            service: pluginService,
+            intervalMS: intervalMS,
+            cooldownMS: cooldownMS,
+            callIndex: &callIndex
+        )
+        try appendJSONLine(event, to: rawURL)
+    }
+
+    for _ in 0..<warmupCalls {
+        let scenario = scenarios[scenarioIndex % scenarios.count]
+        scenarioIndex += 1
+        let event = try await runProjectBenchCall(
+            transport: .jxa,
+            scenario: scenario,
+            phase: "warmup",
+            service: jxaService,
+            intervalMS: intervalMS,
+            cooldownMS: cooldownMS,
+            callIndex: &callIndex
+        )
+        try appendJSONLine(event, to: rawURL)
+    }
+}
+
+private func runProjectBenchCall(
+    transport: Transport,
+    scenario: BenchmarkScenario,
+    phase: String,
+    service: any OmniFocusService,
+    intervalMS: Int,
+    cooldownMS: Int,
+    callIndex: inout Int
+) async throws -> ProjectBenchEvent {
+    callIndex += 1
+    let start = Date()
+    do {
+        let counts = try await service.getProjectCounts(filter: scenario.filter)
+        let elapsed = Date().timeIntervalSince(start)
+        try await enforceInterval(start: start, intervalMS: intervalMS)
+        return ProjectBenchEvent(
+            timestamp: iso8601Now(),
+            phase: phase,
+            callIndex: callIndex,
+            transport: transport.rawValue,
+            scenario: scenario.name,
+            latencyMs: elapsed * 1000,
+            ok: true,
+            timeout: false,
+            error: nil,
+            counts: counts
+        )
+    } catch {
+        let elapsed = Date().timeIntervalSince(start)
+        let message = error.localizedDescription
+        let isTimeout = isTimeoutError(error)
+        try await enforceInterval(start: start, intervalMS: intervalMS)
+        if cooldownMS > 0 {
+            try? await Task.sleep(nanoseconds: UInt64(cooldownMS) * 1_000_000)
+        }
+        return ProjectBenchEvent(
+            timestamp: iso8601Now(),
+            phase: phase,
+            callIndex: callIndex,
+            transport: transport.rawValue,
+            scenario: scenario.name,
+            latencyMs: elapsed * 1000,
+            ok: false,
+            timeout: isTimeout,
+            error: message,
+            counts: nil
+        )
+    }
+}
+
+private func runTimeoutRecoveryGate() async {
+    let env = ProcessInfo.processInfo.environment
+    let recoveryMs = max(0, env["FOCUS_RELAY_TIMEOUT_RECOVERY_MS"].flatMap(Int.init) ?? 10_000)
+    if recoveryMs > 0 {
+        try? await Task.sleep(nanoseconds: UInt64(recoveryMs) * 1_000_000)
+    }
+    // Lightweight readiness probe before resuming to reduce timeout cascades.
+    _ = try? OmniFocusBridgeService().healthCheck()
+}
+
+private func enforceInterval(start: Date, intervalMS: Int) async throws {
+    guard intervalMS > 0 else { return }
+    let elapsed = Date().timeIntervalSince(start)
+    let target = Double(intervalMS) / 1000.0
+    if elapsed < target {
+        let wait = target - elapsed
+        try await Task.sleep(nanoseconds: UInt64(wait * 1_000_000_000))
+    }
+}
+
+private func accumulate(
+    _ event: ProjectBenchEvent,
+    byTransport: inout [Transport: StatsAccumulator],
+    byScenarioTransport: inout [String: [Transport: StatsAccumulator]]
+) {
+    guard let transport = Transport(rawValue: event.transport) else { return }
+
+    var transportStats = byTransport[transport] ?? StatsAccumulator()
+    transportStats.ingest(event)
+    byTransport[transport] = transportStats
+
+    var scenarioStats = byScenarioTransport[event.scenario] ?? [:]
+    var scopedStats = scenarioStats[transport] ?? StatsAccumulator()
+    scopedStats.ingest(event)
+    scenarioStats[transport] = scopedStats
+    byScenarioTransport[event.scenario] = scenarioStats
+}
+
+private func benchmarkOutputDirectory(customPath: String?) throws -> URL {
+    if let customPath, !customPath.isEmpty {
+        let url = URL(fileURLWithPath: customPath, relativeTo: URL(fileURLWithPath: FileManager.default.currentDirectoryPath))
+            .standardizedFileURL
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.dateFormat = "yyyyMMdd-HHmmss"
+    let timestamp = formatter.string(from: Date())
+    let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        .appendingPathComponent("docs", isDirectory: true)
+        .appendingPathComponent("benchmarks", isDirectory: true)
+        .appendingPathComponent(timestamp, isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+}
+
+private func initializeBenchmarkArtifacts(rawURL: URL, memoryURL: URL) throws {
+    FileManager.default.createFile(atPath: rawURL.path, contents: nil)
+    FileManager.default.createFile(atPath: memoryURL.path, contents: nil)
+    try appendLine("timestamp,process,pid,rss_kb\n", to: memoryURL)
+}
+
+private func appendJSONLine<T: Encodable>(_ value: T, to url: URL) throws {
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    let data = try encoder.encode(value)
+    guard var line = String(data: data, encoding: .utf8) else {
+        throw ValidationError("Failed to encode benchmark event as UTF-8.")
+    }
+    line.append("\n")
+    try appendLine(line, to: url)
+}
+
+private func appendLine(_ line: String, to url: URL) throws {
+    guard let data = line.data(using: .utf8) else { return }
+    let handle = try FileHandle(forWritingTo: url)
+    defer { try? handle.close() }
+    try handle.seekToEnd()
+    try handle.write(contentsOf: data)
+}
+
+private func isTimeoutError(_ error: Error) -> Bool {
+    let message = error.localizedDescription.lowercased()
+    return message.contains("timed out") || message.contains("timeout")
+}
+
+private func runPreflight() {
+    do {
+        try stopExtraServeProcesses()
+    } catch {
+        print("Preflight warning: failed to inspect/terminate extra servers (\(error.localizedDescription)).")
+    }
+
+    do {
+        try restartOmniFocus()
+    } catch {
+        print("Preflight warning: failed to restart OmniFocus (\(error.localizedDescription)).")
+    }
+}
+
+private func stopExtraServeProcesses() throws {
+    let currentPID = ProcessInfo.processInfo.processIdentifier
+    guard let output = try? runProcess(
+        executable: "/usr/bin/pgrep",
+        arguments: ["-f", "focusrelay"],
+        timeout: 3
+    ) else {
+        print("Preflight: no extra focusrelay server processes detected.")
+        return
+    }
+
+    let candidatePIDs = output
+        .split(separator: "\n")
+        .compactMap { Int32($0) }
+
+    var terminated: [Int32] = []
+    for pid in candidatePIDs {
+        if pid == currentPID { continue }
+        guard let command = try? runProcess(
+            executable: "/bin/ps",
+            arguments: ["-o", "command=", "-p", String(pid)],
+            timeout: 3
+        ) else {
+            continue
+        }
+        let trimmedCommand = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedCommand.contains("focusrelay serve") || trimmedCommand.contains("focusrelay mcp") || trimmedCommand.contains("focusrelay server") {
+            _ = try? runProcess(executable: "/bin/kill", arguments: ["-TERM", String(pid)], timeout: 2)
+            terminated.append(pid)
+        }
+    }
+
+    if !terminated.isEmpty {
+        print("Preflight: terminated focusrelay server processes: \(terminated.map(String.init).joined(separator: ", "))")
+        Thread.sleep(forTimeInterval: 1.0)
+    } else {
+        print("Preflight: no extra focusrelay server processes detected.")
+    }
+}
+
+private func restartOmniFocus() throws {
+    print("Preflight: restarting OmniFocus...")
+    _ = try? runProcess(
+        executable: "/usr/bin/osascript",
+        arguments: ["-e", "tell application \"OmniFocus\" to quit"],
+        timeout: 8
+    )
+    Thread.sleep(forTimeInterval: 2.0)
+    _ = try runProcess(executable: "/usr/bin/open", arguments: ["-a", "OmniFocus"], timeout: 8)
+    Thread.sleep(forTimeInterval: 3.0)
+}
+
+private func currentOmniFocusPID() -> Int32? {
+    guard let output = try? runProcess(executable: "/usr/bin/pgrep", arguments: ["-x", "OmniFocus"], timeout: 3) else {
+        return nil
+    }
+    let firstLine = output.split(separator: "\n").first
+    return firstLine.flatMap { Int32($0) }
+}
+
+private func readRSSKilobytes(pid: Int32) -> Int? {
+    guard let output = try? runProcess(executable: "/bin/ps", arguments: ["-o", "rss=", "-p", String(pid)], timeout: 3) else {
+        return nil
+    }
+    return Int(output.trimmingCharacters(in: .whitespacesAndNewlines))
+}
+
+@discardableResult
+private func runProcess(executable: String, arguments: [String], timeout: TimeInterval = 15) throws -> String {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: executable)
+    process.arguments = arguments
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = pipe
+    try process.run()
+    let deadline = Date().addingTimeInterval(timeout)
+    while process.isRunning && Date() < deadline {
+        Thread.sleep(forTimeInterval: 0.05)
+    }
+
+    if process.isRunning {
+        process.terminate()
+        throw AutomationError.executionFailed("Process \(executable) timed out after \(Int(timeout))s")
+    }
+
+    process.waitUntilExit()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    let output = String(decoding: data, as: UTF8.self)
+    if process.terminationStatus != 0 {
+        throw AutomationError.executionFailed("Process \(executable) failed: \(output)")
+    }
+    return output
+}
+
+private func writeSummary(
+    to url: URL,
+    startedAt: Date,
+    endedAt: Date,
+    memoryURL: URL,
+    durationHours: Double,
+    warmupCalls: Int,
+    intervalMS: Int,
+    cooldownMS: Int,
+    memoryIntervalSeconds: Int,
+    scenarios: [BenchmarkScenario],
+    statsByTransport: [Transport: StatsAccumulator],
+    statsByScenarioTransport: [String: [Transport: StatsAccumulator]],
+    parityMismatches: [ProjectParityMismatch]
+) async throws {
+    let memorySummary = loadMemorySummary(from: memoryURL)
+    var lines: [String] = []
+    lines.append("# get_project_counts Benchmark Summary")
+    lines.append("")
+    lines.append("- Started: \(iso8601(startedAt))")
+    lines.append("- Ended: \(iso8601(endedAt))")
+    lines.append(String(format: "- Configured duration (hours): %.2f", durationHours))
+    lines.append("- Warmup calls per transport: \(warmupCalls)")
+    lines.append("- Interval (ms): \(intervalMS)")
+    lines.append("- Cooldown after failure (ms): \(cooldownMS)")
+    lines.append("- Memory sampling interval (seconds): \(memoryIntervalSeconds)")
+    lines.append("- Scenarios: \(scenarios.map(\.name).joined(separator: ", "))")
+    lines.append("")
+    lines.append("## Overall Transport Stats")
+    lines.append("")
+    for transport in Transport.allCases {
+        let stats = statsByTransport[transport] ?? StatsAccumulator()
+        let totalCalls = stats.successCount + stats.errorCount
+        let timeoutRate = percentage(part: stats.timeoutCount, total: totalCalls)
+        let errorRate = percentage(part: stats.errorCount, total: totalCalls)
+        lines.append("### \(transport.rawValue)")
+        lines.append("- Total calls: \(totalCalls)")
+        lines.append("- Success calls: \(stats.successCount)")
+        lines.append("- Error calls: \(stats.errorCount)")
+        lines.append("- Error rate: \(formatPercentage(errorRate))")
+        lines.append("- Timeout calls: \(stats.timeoutCount)")
+        lines.append("- Timeout rate: \(formatPercentage(timeoutRate))")
+        lines.append("- p50 latency (ms): \(formatDouble(percentile(stats.latencies, p: 0.50)))")
+        lines.append("- p95 latency (ms): \(formatDouble(percentile(stats.latencies, p: 0.95)))")
+        lines.append("- p99 latency (ms): \(formatDouble(percentile(stats.latencies, p: 0.99)))")
+        lines.append("")
+    }
+
+    lines.append("## Scenario Stats")
+    lines.append("")
+    for scenario in scenarios {
+        lines.append("### \(scenario.name)")
+        let scoped = statsByScenarioTransport[scenario.name] ?? [:]
+        for transport in Transport.allCases {
+            let stats = scoped[transport] ?? StatsAccumulator()
+            let totalCalls = stats.successCount + stats.errorCount
+            let timeoutRate = percentage(part: stats.timeoutCount, total: totalCalls)
+            let errorRate = percentage(part: stats.errorCount, total: totalCalls)
+            lines.append("- \(transport.rawValue): total=\(totalCalls), success=\(stats.successCount), errors=\(stats.errorCount), error_rate=\(formatPercentage(errorRate)), timeouts=\(stats.timeoutCount), timeout_rate=\(formatPercentage(timeoutRate)), p95_ms=\(formatDouble(percentile(stats.latencies, p: 0.95)))")
+        }
+        lines.append("")
+    }
+
+    lines.append("## Parity")
+    lines.append("")
+    lines.append("- Mismatch count: \(parityMismatches.count)")
+    if !parityMismatches.isEmpty {
+        lines.append("")
+        lines.append("First mismatches:")
+        for mismatch in parityMismatches.prefix(10) {
+            lines.append("- \(mismatch.timestamp) scenario=\(mismatch.scenario) plugin=\(mismatch.plugin) jxa=\(mismatch.jxa)")
+        }
+    }
+
+    lines.append("")
+    lines.append("## Memory Notes")
+    lines.append("")
+    lines.append("- `memory.csv` contains RSS samples for `focusrelay` and `OmniFocus`.")
+    lines.append("- Memory growth slope is estimated in KB/min from sampled RSS values.")
+    lines.append("")
+    lines.append("### Memory Growth")
+    for process in ["focusrelay", "OmniFocus"] {
+        if let summary = memorySummary[process] {
+            lines.append("- \(process): samples=\(summary.samples), start_kb=\(summary.startKB), end_kb=\(summary.endKB), delta_kb=\(summary.endKB - summary.startKB), slope_kb_per_min=\(formatDouble(summary.slopeKBPerMinute))")
+        } else {
+            lines.append("- \(process): no samples")
+        }
+    }
+
+    try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
+}
+
+private func percentile(_ values: [Double], p: Double) -> Double {
+    guard !values.isEmpty else { return .nan }
+    let sorted = values.sorted()
+    let index = Int(Double(sorted.count - 1) * p)
+    return sorted[max(0, min(index, sorted.count - 1))]
+}
+
+private func formatDouble(_ value: Double) -> String {
+    guard value.isFinite else { return "n/a" }
+    return String(format: "%.2f", value)
+}
+
+private func formatPercentage(_ value: Double) -> String {
+    guard value.isFinite else { return "n/a" }
+    return String(format: "%.2f%%", value)
+}
+
+private func projectCountsEqual(_ lhs: ProjectCountsModel, _ rhs: ProjectCountsModel) -> Bool {
+    lhs.projects == rhs.projects &&
+        lhs.actions == rhs.actions
+}
+
+private struct MemorySample {
+    let timestamp: Date
+    let process: String
+    let rssKB: Double
+}
+
+private struct MemoryProcessSummary {
+    let samples: Int
+    let startKB: Int
+    let endKB: Int
+    let slopeKBPerMinute: Double
+}
+
+private func loadMemorySummary(from url: URL) -> [String: MemoryProcessSummary] {
+    guard let content = try? String(contentsOf: url, encoding: .utf8) else {
+        return [:]
+    }
+
+    let parser = ISO8601DateFormatter()
+    parser.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+    var byProcess: [String: [MemorySample]] = [:]
+    let lines = content.split(separator: "\n")
+    for (index, line) in lines.enumerated() {
+        if index == 0 { continue } // header
+        let columns = line.split(separator: ",", omittingEmptySubsequences: false)
+        if columns.count < 4 { continue }
+        let timestampRaw = String(columns[0])
+        let process = String(columns[1])
+        let rssRaw = String(columns[3])
+        guard let timestamp = parser.date(from: timestampRaw),
+              let rss = Double(rssRaw) else {
+            continue
+        }
+        let sample = MemorySample(timestamp: timestamp, process: process, rssKB: rss)
+        byProcess[process, default: []].append(sample)
+    }
+
+    var summary: [String: MemoryProcessSummary] = [:]
+    for (process, samples) in byProcess {
+        let sorted = samples.sorted { $0.timestamp < $1.timestamp }
+        guard let first = sorted.first, let last = sorted.last else { continue }
+        let slope = linearSlopeKBPerMinute(samples: sorted)
+        summary[process] = MemoryProcessSummary(
+            samples: sorted.count,
+            startKB: Int(first.rssKB.rounded()),
+            endKB: Int(last.rssKB.rounded()),
+            slopeKBPerMinute: slope
+        )
+    }
+    return summary
+}
+
+private func linearSlopeKBPerMinute(samples: [MemorySample]) -> Double {
+    guard samples.count > 1, let first = samples.first else { return .nan }
+
+    var sumX = 0.0
+    var sumY = 0.0
+    var sumXX = 0.0
+    var sumXY = 0.0
+    let n = Double(samples.count)
+
+    for sample in samples {
+        let x = sample.timestamp.timeIntervalSince(first.timestamp) / 60.0
+        let y = sample.rssKB
+        sumX += x
+        sumY += y
+        sumXX += x * x
+        sumXY += x * y
+    }
+
+    let denominator = (n * sumXX) - (sumX * sumX)
+    if abs(denominator) < 1e-9 { return .nan }
+    return ((n * sumXY) - (sumX * sumY)) / denominator
+}
+
+private func percentage(part: Int, total: Int) -> Double {
+    guard total > 0 else { return .nan }
+    return (Double(part) / Double(total)) * 100.0
+}
+
+private func iso8601Now() -> String {
+    iso8601(Date())
+}
+
+private func iso8601(_ date: Date) -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter.string(from: date)
+}

--- a/Sources/FocusRelayCLI/BenchmarkProjectCountsCommand.swift
+++ b/Sources/FocusRelayCLI/BenchmarkProjectCountsCommand.swift
@@ -60,7 +60,8 @@ struct BenchmarkProjectCounts: AsyncParsableCommand {
         let rawURL = directoryURL.appendingPathComponent("raw.jsonl")
         let memoryURL = directoryURL.appendingPathComponent("memory.csv")
         let summaryURL = directoryURL.appendingPathComponent("summary.md")
-        try initializeBenchmarkArtifacts(rawURL: rawURL, memoryURL: memoryURL)
+        let timeoutDiagnosticsURL = directoryURL.appendingPathComponent("timeout-diagnostics.jsonl")
+        try initializeBenchmarkArtifacts(rawURL: rawURL, memoryURL: memoryURL, timeoutDiagnosticsURL: timeoutDiagnosticsURL)
 
         print("Benchmark output directory: \(directoryURL.path)")
         print("Scenarios: \(scenarios.map(\.name).joined(separator: ", "))")
@@ -105,6 +106,7 @@ struct BenchmarkProjectCounts: AsyncParsableCommand {
                 pluginService: pluginService,
                 jxaService: jxaService,
                 rawURL: rawURL,
+                timeoutDiagnosticsURL: timeoutDiagnosticsURL,
                 intervalMS: intervalMS,
                 cooldownMS: cooldownMS,
                 callIndex: &callIndex
@@ -126,6 +128,7 @@ struct BenchmarkProjectCounts: AsyncParsableCommand {
                 scenario: scenario,
                 phase: "measured",
                 service: pluginService,
+                timeoutDiagnosticsURL: timeoutDiagnosticsURL,
                 intervalMS: intervalMS,
                 cooldownMS: cooldownMS,
                 callIndex: &callIndex
@@ -141,6 +144,7 @@ struct BenchmarkProjectCounts: AsyncParsableCommand {
                 scenario: scenario,
                 phase: "measured",
                 service: jxaService,
+                timeoutDiagnosticsURL: timeoutDiagnosticsURL,
                 intervalMS: intervalMS,
                 cooldownMS: cooldownMS,
                 callIndex: &callIndex
@@ -174,6 +178,7 @@ struct BenchmarkProjectCounts: AsyncParsableCommand {
             intervalMS: intervalMS,
             cooldownMS: cooldownMS,
             memoryIntervalSeconds: memoryIntervalSeconds,
+            timeoutDiagnosticsURL: timeoutDiagnosticsURL,
             scenarios: scenarios,
             statsByTransport: statsByTransport,
             statsByScenarioTransport: statsByScenarioTransport,
@@ -249,12 +254,52 @@ private struct ProjectParityMismatch: Codable {
     let jxa: ProjectCountsModel
 }
 
+private struct TimeoutQueueSnapshot: Codable {
+    let basePath: String
+    let requestsCount: Int
+    let locksCount: Int
+    let responsesCount: Int
+    let requestExists: Bool?
+    let lockExists: Bool?
+    let responseExists: Bool?
+    let sampleRequests: [String]
+    let sampleLocks: [String]
+    let sampleResponses: [String]
+}
+
+private struct TimeoutProcessSnapshot: Codable {
+    let process: String
+    let pid: Int32?
+    let rssKB: Int?
+}
+
+private struct TimeoutBridgeHealthSnapshot: Codable {
+    let ok: Bool
+    let detail: String
+}
+
+private struct ProjectTimeoutDiagnostic: Codable {
+    let timestamp: String
+    let transport: String
+    let scenario: String
+    let phase: String
+    let callIndex: Int
+    let latencyMs: Double
+    let error: String
+    let requestId: String?
+    let queue: TimeoutQueueSnapshot
+    let omniFocus: TimeoutProcessSnapshot
+    let focusrelay: TimeoutProcessSnapshot
+    let bridgeHealth: TimeoutBridgeHealthSnapshot?
+}
+
 private func runWarmup(
     warmupCalls: Int,
     scenarios: [BenchmarkScenario],
     pluginService: OmniFocusBridgeService,
     jxaService: OmniAutomationService,
     rawURL: URL,
+    timeoutDiagnosticsURL: URL,
     intervalMS: Int,
     cooldownMS: Int,
     callIndex: inout Int
@@ -268,6 +313,7 @@ private func runWarmup(
             scenario: scenario,
             phase: "warmup",
             service: pluginService,
+            timeoutDiagnosticsURL: timeoutDiagnosticsURL,
             intervalMS: intervalMS,
             cooldownMS: cooldownMS,
             callIndex: &callIndex
@@ -283,6 +329,7 @@ private func runWarmup(
             scenario: scenario,
             phase: "warmup",
             service: jxaService,
+            timeoutDiagnosticsURL: timeoutDiagnosticsURL,
             intervalMS: intervalMS,
             cooldownMS: cooldownMS,
             callIndex: &callIndex
@@ -296,6 +343,7 @@ private func runProjectBenchCall(
     scenario: BenchmarkScenario,
     phase: String,
     service: any OmniFocusService,
+    timeoutDiagnosticsURL: URL,
     intervalMS: Int,
     cooldownMS: Int,
     callIndex: inout Int
@@ -325,6 +373,17 @@ private func runProjectBenchCall(
         try await enforceInterval(start: start, intervalMS: intervalMS)
         if cooldownMS > 0 {
             try? await Task.sleep(nanoseconds: UInt64(cooldownMS) * 1_000_000)
+        }
+        if isTimeout {
+            let diagnostic = captureProjectTimeoutDiagnostic(
+                transport: transport,
+                scenario: scenario,
+                phase: phase,
+                callIndex: callIndex,
+                latencyMs: elapsed * 1000,
+                errorMessage: message
+            )
+            try? appendJSONLine(diagnostic, to: timeoutDiagnosticsURL)
         }
         return ProjectBenchEvent(
             timestamp: iso8601Now(),
@@ -399,9 +458,10 @@ private func benchmarkOutputDirectory(customPath: String?) throws -> URL {
     return url
 }
 
-private func initializeBenchmarkArtifacts(rawURL: URL, memoryURL: URL) throws {
+private func initializeBenchmarkArtifacts(rawURL: URL, memoryURL: URL, timeoutDiagnosticsURL: URL) throws {
     FileManager.default.createFile(atPath: rawURL.path, contents: nil)
     FileManager.default.createFile(atPath: memoryURL.path, contents: nil)
+    FileManager.default.createFile(atPath: timeoutDiagnosticsURL.path, contents: nil)
     try appendLine("timestamp,process,pid,rss_kb\n", to: memoryURL)
 }
 
@@ -538,6 +598,121 @@ private func runProcess(executable: String, arguments: [String], timeout: TimeIn
     return output
 }
 
+private func captureProjectTimeoutDiagnostic(
+    transport: Transport,
+    scenario: BenchmarkScenario,
+    phase: String,
+    callIndex: Int,
+    latencyMs: Double,
+    errorMessage: String
+) -> ProjectTimeoutDiagnostic {
+    let requestID = extractRequestID(from: errorMessage)
+    let baseURL = defaultIPCBaseURL()
+    let requestsURL = baseURL.appendingPathComponent("requests", isDirectory: true)
+    let locksURL = baseURL.appendingPathComponent("locks", isDirectory: true)
+    let responsesURL = baseURL.appendingPathComponent("responses", isDirectory: true)
+    let queue = TimeoutQueueSnapshot(
+        basePath: baseURL.path,
+        requestsCount: directoryEntryCount(requestsURL),
+        locksCount: directoryEntryCount(locksURL),
+        responsesCount: directoryEntryCount(responsesURL),
+        requestExists: requestID.map { FileManager.default.fileExists(atPath: requestsURL.appendingPathComponent("\($0).json").path) },
+        lockExists: requestID.map { FileManager.default.fileExists(atPath: locksURL.appendingPathComponent("\($0).lock").path) },
+        responseExists: requestID.map { FileManager.default.fileExists(atPath: responsesURL.appendingPathComponent("\($0).json").path) },
+        sampleRequests: directoryEntrySamples(requestsURL),
+        sampleLocks: directoryEntrySamples(locksURL),
+        sampleResponses: directoryEntrySamples(responsesURL)
+    )
+    let omniPID = currentOmniFocusPID()
+    let benchmarkPID = ProcessInfo.processInfo.processIdentifier
+    let bridgeHealth: TimeoutBridgeHealthSnapshot?
+    if transport == .plugin {
+        if let result = try? OmniFocusBridgeService().healthCheck() {
+            bridgeHealth = TimeoutBridgeHealthSnapshot(
+                ok: result.ok,
+                detail: "plugin=\(result.plugin ?? "unknown") version=\(result.version ?? "unknown")"
+            )
+        } else {
+            bridgeHealth = TimeoutBridgeHealthSnapshot(
+                ok: false,
+                detail: "bridge-health-check failed after timeout"
+            )
+        }
+    } else {
+        bridgeHealth = nil
+    }
+
+    return ProjectTimeoutDiagnostic(
+        timestamp: iso8601Now(),
+        transport: transport.rawValue,
+        scenario: scenario.name,
+        phase: phase,
+        callIndex: callIndex,
+        latencyMs: latencyMs,
+        error: errorMessage,
+        requestId: requestID,
+        queue: queue,
+        omniFocus: TimeoutProcessSnapshot(
+            process: "OmniFocus",
+            pid: omniPID,
+            rssKB: omniPID.flatMap(readRSSKilobytes(pid:))
+        ),
+        focusrelay: TimeoutProcessSnapshot(
+            process: "focusrelay",
+            pid: benchmarkPID,
+            rssKB: readRSSKilobytes(pid: benchmarkPID)
+        ),
+        bridgeHealth: bridgeHealth
+    )
+}
+
+private func extractRequestID(from message: String) -> String? {
+    let pattern = #"requestId=([A-F0-9-]+)"#
+    guard let regex = try? NSRegularExpression(pattern: pattern) else {
+        return nil
+    }
+    let range = NSRange(message.startIndex..<message.endIndex, in: message)
+    guard let match = regex.firstMatch(in: message, range: range),
+          let matchRange = Range(match.range(at: 1), in: message) else {
+        return nil
+    }
+    return String(message[matchRange])
+}
+
+private func directoryEntryCount(_ url: URL) -> Int {
+    guard let contents = try? FileManager.default.contentsOfDirectory(atPath: url.path) else {
+        return 0
+    }
+    return contents.count
+}
+
+private func directoryEntrySamples(_ url: URL, limit: Int = 5) -> [String] {
+    guard let contents = try? FileManager.default.contentsOfDirectory(atPath: url.path) else {
+        return []
+    }
+    return Array(contents.sorted().prefix(limit))
+}
+
+private func defaultIPCBaseURL() -> URL {
+    let home = FileManager.default.homeDirectoryForCurrentUser
+    let container = home
+        .appendingPathComponent("Library", isDirectory: true)
+        .appendingPathComponent("Containers", isDirectory: true)
+        .appendingPathComponent("com.omnigroup.OmniFocus4", isDirectory: true)
+        .appendingPathComponent("Data", isDirectory: true)
+        .appendingPathComponent("Documents", isDirectory: true)
+        .appendingPathComponent("FocusRelayIPC", isDirectory: true)
+
+    if FileManager.default.fileExists(atPath: container.deletingLastPathComponent().path) {
+        return container
+    }
+
+    return home
+        .appendingPathComponent("Library", isDirectory: true)
+        .appendingPathComponent("Caches", isDirectory: true)
+        .appendingPathComponent("focusrelay", isDirectory: true)
+}
+
 private func writeSummary(
     to url: URL,
     startedAt: Date,
@@ -548,12 +723,14 @@ private func writeSummary(
     intervalMS: Int,
     cooldownMS: Int,
     memoryIntervalSeconds: Int,
+    timeoutDiagnosticsURL: URL,
     scenarios: [BenchmarkScenario],
     statsByTransport: [Transport: StatsAccumulator],
     statsByScenarioTransport: [String: [Transport: StatsAccumulator]],
     parityMismatches: [ProjectParityMismatch]
 ) async throws {
     let memorySummary = loadMemorySummary(from: memoryURL)
+    let timeoutDiagnosticCount = countLines(in: timeoutDiagnosticsURL)
     var lines: [String] = []
     lines.append("# get_project_counts Benchmark Summary")
     lines.append("")
@@ -617,6 +794,7 @@ private func writeSummary(
     lines.append("")
     lines.append("- `memory.csv` contains RSS samples for `focusrelay` and `OmniFocus`.")
     lines.append("- Memory growth slope is estimated in KB/min from sampled RSS values.")
+    lines.append("- `timeout-diagnostics.jsonl` contains timeout queue/process snapshots for this benchmark.")
     lines.append("")
     lines.append("### Memory Growth")
     for process in ["focusrelay", "OmniFocus"] {
@@ -626,8 +804,19 @@ private func writeSummary(
             lines.append("- \(process): no samples")
         }
     }
+    lines.append("")
+    lines.append("## Timeout Diagnostics")
+    lines.append("")
+    lines.append("- Diagnostic entries: \(timeoutDiagnosticCount)")
 
     try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
+}
+
+private func countLines(in url: URL) -> Int {
+    guard let content = try? String(contentsOf: url, encoding: .utf8) else {
+        return 0
+    }
+    return content.split(separator: "\n", omittingEmptySubsequences: true).count
 }
 
 private func percentile(_ values: [Double], p: Double) -> Double {

--- a/Sources/FocusRelayCLI/BenchmarkTaskCountsCommand.swift
+++ b/Sources/FocusRelayCLI/BenchmarkTaskCountsCommand.swift
@@ -60,7 +60,8 @@ struct BenchmarkTaskCounts: AsyncParsableCommand {
         let rawURL = directoryURL.appendingPathComponent("raw.jsonl")
         let memoryURL = directoryURL.appendingPathComponent("memory.csv")
         let summaryURL = directoryURL.appendingPathComponent("summary.md")
-        try initializeBenchmarkArtifacts(rawURL: rawURL, memoryURL: memoryURL)
+        let timeoutDiagnosticsURL = directoryURL.appendingPathComponent("timeout-diagnostics.jsonl")
+        try initializeBenchmarkArtifacts(rawURL: rawURL, memoryURL: memoryURL, timeoutDiagnosticsURL: timeoutDiagnosticsURL)
 
         print("Benchmark output directory: \(directoryURL.path)")
         print("Scenarios: \(scenarios.map(\.name).joined(separator: ", "))")
@@ -105,6 +106,7 @@ struct BenchmarkTaskCounts: AsyncParsableCommand {
                 pluginService: pluginService,
                 jxaService: jxaService,
                 rawURL: rawURL,
+                timeoutDiagnosticsURL: timeoutDiagnosticsURL,
                 intervalMS: intervalMS,
                 cooldownMS: cooldownMS,
                 callIndex: &callIndex
@@ -126,6 +128,7 @@ struct BenchmarkTaskCounts: AsyncParsableCommand {
                 scenario: scenario,
                 phase: "measured",
                 service: pluginService,
+                timeoutDiagnosticsURL: timeoutDiagnosticsURL,
                 intervalMS: intervalMS,
                 cooldownMS: cooldownMS,
                 callIndex: &callIndex
@@ -141,6 +144,7 @@ struct BenchmarkTaskCounts: AsyncParsableCommand {
                 scenario: scenario,
                 phase: "measured",
                 service: jxaService,
+                timeoutDiagnosticsURL: timeoutDiagnosticsURL,
                 intervalMS: intervalMS,
                 cooldownMS: cooldownMS,
                 callIndex: &callIndex
@@ -174,6 +178,7 @@ struct BenchmarkTaskCounts: AsyncParsableCommand {
             intervalMS: intervalMS,
             cooldownMS: cooldownMS,
             memoryIntervalSeconds: memoryIntervalSeconds,
+            timeoutDiagnosticsURL: timeoutDiagnosticsURL,
             scenarios: scenarios,
             statsByTransport: statsByTransport,
             statsByScenarioTransport: statsByScenarioTransport,
@@ -249,12 +254,52 @@ private struct ParityMismatch: Codable {
     let jxa: TaskCountsModel
 }
 
+private struct TimeoutQueueSnapshot: Codable {
+    let basePath: String
+    let requestsCount: Int
+    let locksCount: Int
+    let responsesCount: Int
+    let requestExists: Bool?
+    let lockExists: Bool?
+    let responseExists: Bool?
+    let sampleRequests: [String]
+    let sampleLocks: [String]
+    let sampleResponses: [String]
+}
+
+private struct TimeoutProcessSnapshot: Codable {
+    let process: String
+    let pid: Int32?
+    let rssKB: Int?
+}
+
+private struct TimeoutBridgeHealthSnapshot: Codable {
+    let ok: Bool
+    let detail: String
+}
+
+private struct TaskTimeoutDiagnostic: Codable {
+    let timestamp: String
+    let transport: String
+    let scenario: String
+    let phase: String
+    let callIndex: Int
+    let latencyMs: Double
+    let error: String
+    let requestId: String?
+    let queue: TimeoutQueueSnapshot
+    let omniFocus: TimeoutProcessSnapshot
+    let focusrelay: TimeoutProcessSnapshot
+    let bridgeHealth: TimeoutBridgeHealthSnapshot?
+}
+
 private func runWarmup(
     warmupCalls: Int,
     scenarios: [BenchmarkScenario],
     pluginService: OmniFocusBridgeService,
     jxaService: OmniAutomationService,
     rawURL: URL,
+    timeoutDiagnosticsURL: URL,
     intervalMS: Int,
     cooldownMS: Int,
     callIndex: inout Int
@@ -268,6 +313,7 @@ private func runWarmup(
             scenario: scenario,
             phase: "warmup",
             service: pluginService,
+            timeoutDiagnosticsURL: timeoutDiagnosticsURL,
             intervalMS: intervalMS,
             cooldownMS: cooldownMS,
             callIndex: &callIndex
@@ -283,6 +329,7 @@ private func runWarmup(
             scenario: scenario,
             phase: "warmup",
             service: jxaService,
+            timeoutDiagnosticsURL: timeoutDiagnosticsURL,
             intervalMS: intervalMS,
             cooldownMS: cooldownMS,
             callIndex: &callIndex
@@ -296,6 +343,7 @@ private func runBenchCall(
     scenario: BenchmarkScenario,
     phase: String,
     service: any OmniFocusService,
+    timeoutDiagnosticsURL: URL,
     intervalMS: Int,
     cooldownMS: Int,
     callIndex: inout Int
@@ -325,6 +373,17 @@ private func runBenchCall(
         try await enforceInterval(start: start, intervalMS: intervalMS)
         if cooldownMS > 0 {
             try? await Task.sleep(nanoseconds: UInt64(cooldownMS) * 1_000_000)
+        }
+        if isTimeout {
+            let diagnostic = captureTaskTimeoutDiagnostic(
+                transport: transport,
+                scenario: scenario,
+                phase: phase,
+                callIndex: callIndex,
+                latencyMs: elapsed * 1000,
+                errorMessage: message
+            )
+            try? appendJSONLine(diagnostic, to: timeoutDiagnosticsURL)
         }
         return BenchEvent(
             timestamp: iso8601Now(),
@@ -399,9 +458,10 @@ private func benchmarkOutputDirectory(customPath: String?) throws -> URL {
     return url
 }
 
-private func initializeBenchmarkArtifacts(rawURL: URL, memoryURL: URL) throws {
+private func initializeBenchmarkArtifacts(rawURL: URL, memoryURL: URL, timeoutDiagnosticsURL: URL) throws {
     FileManager.default.createFile(atPath: rawURL.path, contents: nil)
     FileManager.default.createFile(atPath: memoryURL.path, contents: nil)
+    FileManager.default.createFile(atPath: timeoutDiagnosticsURL.path, contents: nil)
     try appendLine("timestamp,process,pid,rss_kb\n", to: memoryURL)
 }
 
@@ -538,6 +598,121 @@ private func runProcess(executable: String, arguments: [String], timeout: TimeIn
     return output
 }
 
+private func captureTaskTimeoutDiagnostic(
+    transport: Transport,
+    scenario: BenchmarkScenario,
+    phase: String,
+    callIndex: Int,
+    latencyMs: Double,
+    errorMessage: String
+) -> TaskTimeoutDiagnostic {
+    let requestID = extractRequestID(from: errorMessage)
+    let baseURL = defaultIPCBaseURL()
+    let requestsURL = baseURL.appendingPathComponent("requests", isDirectory: true)
+    let locksURL = baseURL.appendingPathComponent("locks", isDirectory: true)
+    let responsesURL = baseURL.appendingPathComponent("responses", isDirectory: true)
+    let queue = TimeoutQueueSnapshot(
+        basePath: baseURL.path,
+        requestsCount: directoryEntryCount(requestsURL),
+        locksCount: directoryEntryCount(locksURL),
+        responsesCount: directoryEntryCount(responsesURL),
+        requestExists: requestID.map { FileManager.default.fileExists(atPath: requestsURL.appendingPathComponent("\($0).json").path) },
+        lockExists: requestID.map { FileManager.default.fileExists(atPath: locksURL.appendingPathComponent("\($0).lock").path) },
+        responseExists: requestID.map { FileManager.default.fileExists(atPath: responsesURL.appendingPathComponent("\($0).json").path) },
+        sampleRequests: directoryEntrySamples(requestsURL),
+        sampleLocks: directoryEntrySamples(locksURL),
+        sampleResponses: directoryEntrySamples(responsesURL)
+    )
+    let omniPID = currentOmniFocusPID()
+    let benchmarkPID = ProcessInfo.processInfo.processIdentifier
+    let bridgeHealth: TimeoutBridgeHealthSnapshot?
+    if transport == .plugin {
+        if let result = try? OmniFocusBridgeService().healthCheck() {
+            bridgeHealth = TimeoutBridgeHealthSnapshot(
+                ok: result.ok,
+                detail: "plugin=\(result.plugin ?? "unknown") version=\(result.version ?? "unknown")"
+            )
+        } else {
+            bridgeHealth = TimeoutBridgeHealthSnapshot(
+                ok: false,
+                detail: "bridge-health-check failed after timeout"
+            )
+        }
+    } else {
+        bridgeHealth = nil
+    }
+
+    return TaskTimeoutDiagnostic(
+        timestamp: iso8601Now(),
+        transport: transport.rawValue,
+        scenario: scenario.name,
+        phase: phase,
+        callIndex: callIndex,
+        latencyMs: latencyMs,
+        error: errorMessage,
+        requestId: requestID,
+        queue: queue,
+        omniFocus: TimeoutProcessSnapshot(
+            process: "OmniFocus",
+            pid: omniPID,
+            rssKB: omniPID.flatMap(readRSSKilobytes(pid:))
+        ),
+        focusrelay: TimeoutProcessSnapshot(
+            process: "focusrelay",
+            pid: benchmarkPID,
+            rssKB: readRSSKilobytes(pid: benchmarkPID)
+        ),
+        bridgeHealth: bridgeHealth
+    )
+}
+
+private func extractRequestID(from message: String) -> String? {
+    let pattern = #"requestId=([A-F0-9-]+)"#
+    guard let regex = try? NSRegularExpression(pattern: pattern) else {
+        return nil
+    }
+    let range = NSRange(message.startIndex..<message.endIndex, in: message)
+    guard let match = regex.firstMatch(in: message, range: range),
+          let matchRange = Range(match.range(at: 1), in: message) else {
+        return nil
+    }
+    return String(message[matchRange])
+}
+
+private func directoryEntryCount(_ url: URL) -> Int {
+    guard let contents = try? FileManager.default.contentsOfDirectory(atPath: url.path) else {
+        return 0
+    }
+    return contents.count
+}
+
+private func directoryEntrySamples(_ url: URL, limit: Int = 5) -> [String] {
+    guard let contents = try? FileManager.default.contentsOfDirectory(atPath: url.path) else {
+        return []
+    }
+    return Array(contents.sorted().prefix(limit))
+}
+
+private func defaultIPCBaseURL() -> URL {
+    let home = FileManager.default.homeDirectoryForCurrentUser
+    let container = home
+        .appendingPathComponent("Library", isDirectory: true)
+        .appendingPathComponent("Containers", isDirectory: true)
+        .appendingPathComponent("com.omnigroup.OmniFocus4", isDirectory: true)
+        .appendingPathComponent("Data", isDirectory: true)
+        .appendingPathComponent("Documents", isDirectory: true)
+        .appendingPathComponent("FocusRelayIPC", isDirectory: true)
+
+    if FileManager.default.fileExists(atPath: container.deletingLastPathComponent().path) {
+        return container
+    }
+
+    return home
+        .appendingPathComponent("Library", isDirectory: true)
+        .appendingPathComponent("Caches", isDirectory: true)
+        .appendingPathComponent("focusrelay", isDirectory: true)
+}
+
 private func writeSummary(
     to url: URL,
     startedAt: Date,
@@ -548,12 +723,14 @@ private func writeSummary(
     intervalMS: Int,
     cooldownMS: Int,
     memoryIntervalSeconds: Int,
+    timeoutDiagnosticsURL: URL,
     scenarios: [BenchmarkScenario],
     statsByTransport: [Transport: StatsAccumulator],
     statsByScenarioTransport: [String: [Transport: StatsAccumulator]],
     parityMismatches: [ParityMismatch]
 ) async throws {
     let memorySummary = loadMemorySummary(from: memoryURL)
+    let timeoutDiagnosticCount = countLines(in: timeoutDiagnosticsURL)
     var lines: [String] = []
     lines.append("# get_task_counts Benchmark Summary")
     lines.append("")
@@ -617,6 +794,7 @@ private func writeSummary(
     lines.append("")
     lines.append("- `memory.csv` contains RSS samples for `focusrelay` and `OmniFocus`.")
     lines.append("- Memory growth slope is estimated in KB/min from sampled RSS values.")
+    lines.append("- `timeout-diagnostics.jsonl` contains timeout queue/process snapshots for this benchmark.")
     lines.append("")
     lines.append("### Memory Growth")
     for process in ["focusrelay", "OmniFocus"] {
@@ -626,6 +804,11 @@ private func writeSummary(
             lines.append("- \(process): no samples")
         }
     }
+
+    lines.append("")
+    lines.append("## Timeout Diagnostics")
+    lines.append("")
+    lines.append("- Diagnostic entries: \(timeoutDiagnosticCount)")
 
     try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
 }
@@ -733,6 +916,13 @@ private func linearSlopeKBPerMinute(samples: [MemorySample]) -> Double {
 private func percentage(part: Int, total: Int) -> Double {
     guard total > 0 else { return .nan }
     return (Double(part) / Double(total)) * 100.0
+}
+
+private func countLines(in url: URL) -> Int {
+    guard let content = try? String(contentsOf: url, encoding: .utf8), !content.isEmpty else {
+        return 0
+    }
+    return max(0, content.split(separator: "\n").count)
 }
 
 private func iso8601Now() -> String {

--- a/Sources/FocusRelayCLI/BenchmarkTaskCountsCommand.swift
+++ b/Sources/FocusRelayCLI/BenchmarkTaskCountsCommand.swift
@@ -1,0 +1,746 @@
+import ArgumentParser
+import Foundation
+import OmniFocusAutomation
+import OmniFocusCore
+
+private typealias TaskCountsModel = OmniFocusCore.TaskCounts
+
+struct BenchmarkTaskCounts: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "benchmark-task-counts",
+        abstract: "Benchmark get_task_counts for plugin vs JXA transports.",
+        aliases: ["benchmark_get_task_counts"]
+    )
+
+    @Option(name: .customLong("duration-hours"), help: "Measured phase duration in hours.")
+    var durationHours: Double = 3.0
+
+    @Option(name: .customLong("warmup-calls"), help: "Warmup calls per transport before measured runs.")
+    var warmupCalls: Int = 20
+
+    @Option(name: .customLong("interval-ms"), help: "Minimum start-to-start interval between calls in milliseconds.")
+    var intervalMS: Int = 1200
+
+    @Option(name: .customLong("cooldown-ms"), help: "Cooldown delay after failed/timeout calls in milliseconds.")
+    var cooldownMS: Int = 5000
+
+    @Option(name: .customLong("memory-interval-seconds"), help: "RSS sample interval in seconds.")
+    var memoryIntervalSeconds: Int = 30
+
+    @Option(name: .customLong("completed-after"), help: "Fixed ISO8601 anchor for completed-date scenario.")
+    var completedAfter: String = "2020-01-01T00:00:00Z"
+
+    @Option(name: .customLong("output-dir"), help: "Output directory. Defaults to docs/benchmarks/<timestamp>.")
+    var outputDir: String?
+
+    @Flag(name: .customLong("run-preflight"), help: "Run process cleanup and OmniFocus restart before benchmarking.")
+    var performPreflight: Bool = false
+
+    func run() async throws {
+        guard durationHours > 0 else {
+            throw ValidationError("--duration-hours must be > 0.")
+        }
+        guard warmupCalls >= 0 else {
+            throw ValidationError("--warmup-calls must be >= 0.")
+        }
+        guard intervalMS >= 0 else {
+            throw ValidationError("--interval-ms must be >= 0.")
+        }
+        guard cooldownMS >= 0 else {
+            throw ValidationError("--cooldown-ms must be >= 0.")
+        }
+        guard memoryIntervalSeconds > 0 else {
+            throw ValidationError("--memory-interval-seconds must be > 0.")
+        }
+
+        let completedAfterDate = try ISO8601DateParser.parse(completedAfter, argumentName: "--completed-after")
+        let scenarios = benchmarkScenarios(completedAfter: completedAfterDate)
+
+        let directoryURL = try benchmarkOutputDirectory(customPath: outputDir)
+        let rawURL = directoryURL.appendingPathComponent("raw.jsonl")
+        let memoryURL = directoryURL.appendingPathComponent("memory.csv")
+        let summaryURL = directoryURL.appendingPathComponent("summary.md")
+        try initializeBenchmarkArtifacts(rawURL: rawURL, memoryURL: memoryURL)
+
+        print("Benchmark output directory: \(directoryURL.path)")
+        print("Scenarios: \(scenarios.map(\.name).joined(separator: ", "))")
+
+        if performPreflight {
+            runPreflight()
+        }
+
+        let benchmarkPID = ProcessInfo.processInfo.processIdentifier
+        let memoryTask = Task.detached(priority: .utility) {
+            while !Task.isCancelled {
+                let timestamp = iso8601Now()
+                if let rss = readRSSKilobytes(pid: benchmarkPID) {
+                    let line = "\(timestamp),focusrelay,\(benchmarkPID),\(rss)\n"
+                    try? appendLine(line, to: memoryURL)
+                }
+
+                if let omniPID = currentOmniFocusPID(), let rss = readRSSKilobytes(pid: omniPID) {
+                    let line = "\(timestamp),OmniFocus,\(omniPID),\(rss)\n"
+                    try? appendLine(line, to: memoryURL)
+                }
+
+                let nanos = UInt64(memoryIntervalSeconds) * 1_000_000_000
+                try? await Task.sleep(nanoseconds: nanos)
+            }
+        }
+        defer { memoryTask.cancel() }
+
+        let pluginService = OmniFocusBridgeService()
+        let jxaService = OmniAutomationService()
+
+        var statsByTransport: [Transport: StatsAccumulator] = [:]
+        var statsByScenarioTransport: [String: [Transport: StatsAccumulator]] = [:]
+        var parityMismatches: [ParityMismatch] = []
+        var callIndex = 0
+
+        if warmupCalls > 0 {
+            print("Warmup phase: \(warmupCalls) calls per transport")
+            try await runWarmup(
+                warmupCalls: warmupCalls,
+                scenarios: scenarios,
+                pluginService: pluginService,
+                jxaService: jxaService,
+                rawURL: rawURL,
+                intervalMS: intervalMS,
+                cooldownMS: cooldownMS,
+                callIndex: &callIndex
+            )
+        }
+
+        let durationSeconds = durationHours * 3600
+        let measuredStart = Date()
+        let measuredEnd = measuredStart.addingTimeInterval(durationSeconds)
+        print("Measured phase started at \(iso8601(measuredStart)); ending at \(iso8601(measuredEnd))")
+
+        var scenarioIndex = 0
+        while Date() < measuredEnd {
+            let scenario = scenarios[scenarioIndex % scenarios.count]
+            scenarioIndex += 1
+
+            let pluginEvent = try await runBenchCall(
+                transport: .plugin,
+                scenario: scenario,
+                phase: "measured",
+                service: pluginService,
+                intervalMS: intervalMS,
+                cooldownMS: cooldownMS,
+                callIndex: &callIndex
+            )
+            try appendJSONLine(pluginEvent, to: rawURL)
+            accumulate(pluginEvent, byTransport: &statsByTransport, byScenarioTransport: &statsByScenarioTransport)
+            if pluginEvent.timeout {
+                await runTimeoutRecoveryGate()
+            }
+
+            let jxaEvent = try await runBenchCall(
+                transport: .jxa,
+                scenario: scenario,
+                phase: "measured",
+                service: jxaService,
+                intervalMS: intervalMS,
+                cooldownMS: cooldownMS,
+                callIndex: &callIndex
+            )
+            try appendJSONLine(jxaEvent, to: rawURL)
+            accumulate(jxaEvent, byTransport: &statsByTransport, byScenarioTransport: &statsByScenarioTransport)
+            if jxaEvent.timeout {
+                await runTimeoutRecoveryGate()
+            }
+
+            if let pluginCounts = pluginEvent.counts,
+               let jxaCounts = jxaEvent.counts,
+               !taskCountsEqual(pluginCounts, jxaCounts) {
+                let mismatch = ParityMismatch(
+                    timestamp: iso8601Now(),
+                    scenario: scenario.name,
+                    plugin: pluginCounts,
+                    jxa: jxaCounts
+                )
+                parityMismatches.append(mismatch)
+            }
+        }
+
+        try await writeSummary(
+            to: summaryURL,
+            startedAt: measuredStart,
+            endedAt: Date(),
+            memoryURL: memoryURL,
+            durationHours: durationHours,
+            warmupCalls: warmupCalls,
+            intervalMS: intervalMS,
+            cooldownMS: cooldownMS,
+            memoryIntervalSeconds: memoryIntervalSeconds,
+            scenarios: scenarios,
+            statsByTransport: statsByTransport,
+            statsByScenarioTransport: statsByScenarioTransport,
+            parityMismatches: parityMismatches
+        )
+
+        print("Benchmark complete.")
+        print("Raw data: \(rawURL.path)")
+        print("Memory samples: \(memoryURL.path)")
+        print("Summary: \(summaryURL.path)")
+    }
+}
+
+private struct BenchmarkScenario {
+    let name: String
+    let filter: TaskFilter
+}
+
+private func benchmarkScenarios(completedAfter: Date) -> [BenchmarkScenario] {
+    [
+        BenchmarkScenario(name: "default", filter: TaskFilter()),
+        BenchmarkScenario(name: "inbox_only", filter: TaskFilter(inboxOnly: true)),
+        BenchmarkScenario(name: "available_only", filter: TaskFilter(availableOnly: true)),
+        BenchmarkScenario(
+            name: "completed_after_anchor",
+            filter: TaskFilter(completed: true, completedAfter: completedAfter)
+        ),
+        BenchmarkScenario(name: "flagged_only", filter: TaskFilter(flagged: true))
+    ]
+}
+
+private enum Transport: String, Codable, CaseIterable {
+    case plugin
+    case jxa
+}
+
+private struct BenchEvent: Codable {
+    let timestamp: String
+    let phase: String
+    let callIndex: Int
+    let transport: String
+    let scenario: String
+    let latencyMs: Double
+    let ok: Bool
+    let timeout: Bool
+    let error: String?
+    let counts: TaskCountsModel?
+}
+
+private struct StatsAccumulator {
+    var successCount: Int = 0
+    var errorCount: Int = 0
+    var timeoutCount: Int = 0
+    var latencies: [Double] = []
+
+    mutating func ingest(_ event: BenchEvent) {
+        if event.ok {
+            successCount += 1
+            latencies.append(event.latencyMs)
+        } else {
+            errorCount += 1
+            if event.timeout {
+                timeoutCount += 1
+            }
+        }
+    }
+}
+
+private struct ParityMismatch: Codable {
+    let timestamp: String
+    let scenario: String
+    let plugin: TaskCountsModel
+    let jxa: TaskCountsModel
+}
+
+private func runWarmup(
+    warmupCalls: Int,
+    scenarios: [BenchmarkScenario],
+    pluginService: OmniFocusBridgeService,
+    jxaService: OmniAutomationService,
+    rawURL: URL,
+    intervalMS: Int,
+    cooldownMS: Int,
+    callIndex: inout Int
+) async throws {
+    var scenarioIndex = 0
+    for _ in 0..<warmupCalls {
+        let scenario = scenarios[scenarioIndex % scenarios.count]
+        scenarioIndex += 1
+        let event = try await runBenchCall(
+            transport: .plugin,
+            scenario: scenario,
+            phase: "warmup",
+            service: pluginService,
+            intervalMS: intervalMS,
+            cooldownMS: cooldownMS,
+            callIndex: &callIndex
+        )
+        try appendJSONLine(event, to: rawURL)
+    }
+
+    for _ in 0..<warmupCalls {
+        let scenario = scenarios[scenarioIndex % scenarios.count]
+        scenarioIndex += 1
+        let event = try await runBenchCall(
+            transport: .jxa,
+            scenario: scenario,
+            phase: "warmup",
+            service: jxaService,
+            intervalMS: intervalMS,
+            cooldownMS: cooldownMS,
+            callIndex: &callIndex
+        )
+        try appendJSONLine(event, to: rawURL)
+    }
+}
+
+private func runBenchCall(
+    transport: Transport,
+    scenario: BenchmarkScenario,
+    phase: String,
+    service: any OmniFocusService,
+    intervalMS: Int,
+    cooldownMS: Int,
+    callIndex: inout Int
+) async throws -> BenchEvent {
+    callIndex += 1
+    let start = Date()
+    do {
+        let counts = try await service.getTaskCounts(filter: scenario.filter)
+        let elapsed = Date().timeIntervalSince(start)
+        try await enforceInterval(start: start, intervalMS: intervalMS)
+        return BenchEvent(
+            timestamp: iso8601Now(),
+            phase: phase,
+            callIndex: callIndex,
+            transport: transport.rawValue,
+            scenario: scenario.name,
+            latencyMs: elapsed * 1000,
+            ok: true,
+            timeout: false,
+            error: nil,
+            counts: counts
+        )
+    } catch {
+        let elapsed = Date().timeIntervalSince(start)
+        let message = error.localizedDescription
+        let isTimeout = isTimeoutError(error)
+        try await enforceInterval(start: start, intervalMS: intervalMS)
+        if cooldownMS > 0 {
+            try? await Task.sleep(nanoseconds: UInt64(cooldownMS) * 1_000_000)
+        }
+        return BenchEvent(
+            timestamp: iso8601Now(),
+            phase: phase,
+            callIndex: callIndex,
+            transport: transport.rawValue,
+            scenario: scenario.name,
+            latencyMs: elapsed * 1000,
+            ok: false,
+            timeout: isTimeout,
+            error: message,
+            counts: nil
+        )
+    }
+}
+
+private func runTimeoutRecoveryGate() async {
+    let env = ProcessInfo.processInfo.environment
+    let recoveryMs = max(0, env["FOCUS_RELAY_TIMEOUT_RECOVERY_MS"].flatMap(Int.init) ?? 10_000)
+    if recoveryMs > 0 {
+        try? await Task.sleep(nanoseconds: UInt64(recoveryMs) * 1_000_000)
+    }
+    // Lightweight readiness probe before resuming to reduce timeout cascades.
+    _ = try? OmniFocusBridgeService().healthCheck()
+}
+
+private func enforceInterval(start: Date, intervalMS: Int) async throws {
+    guard intervalMS > 0 else { return }
+    let elapsed = Date().timeIntervalSince(start)
+    let target = Double(intervalMS) / 1000.0
+    if elapsed < target {
+        let wait = target - elapsed
+        try await Task.sleep(nanoseconds: UInt64(wait * 1_000_000_000))
+    }
+}
+
+private func accumulate(
+    _ event: BenchEvent,
+    byTransport: inout [Transport: StatsAccumulator],
+    byScenarioTransport: inout [String: [Transport: StatsAccumulator]]
+) {
+    guard let transport = Transport(rawValue: event.transport) else { return }
+
+    var transportStats = byTransport[transport] ?? StatsAccumulator()
+    transportStats.ingest(event)
+    byTransport[transport] = transportStats
+
+    var scenarioStats = byScenarioTransport[event.scenario] ?? [:]
+    var scopedStats = scenarioStats[transport] ?? StatsAccumulator()
+    scopedStats.ingest(event)
+    scenarioStats[transport] = scopedStats
+    byScenarioTransport[event.scenario] = scenarioStats
+}
+
+private func benchmarkOutputDirectory(customPath: String?) throws -> URL {
+    if let customPath, !customPath.isEmpty {
+        let url = URL(fileURLWithPath: customPath, relativeTo: URL(fileURLWithPath: FileManager.default.currentDirectoryPath))
+            .standardizedFileURL
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.dateFormat = "yyyyMMdd-HHmmss"
+    let timestamp = formatter.string(from: Date())
+    let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        .appendingPathComponent("docs", isDirectory: true)
+        .appendingPathComponent("benchmarks", isDirectory: true)
+        .appendingPathComponent(timestamp, isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+}
+
+private func initializeBenchmarkArtifacts(rawURL: URL, memoryURL: URL) throws {
+    FileManager.default.createFile(atPath: rawURL.path, contents: nil)
+    FileManager.default.createFile(atPath: memoryURL.path, contents: nil)
+    try appendLine("timestamp,process,pid,rss_kb\n", to: memoryURL)
+}
+
+private func appendJSONLine<T: Encodable>(_ value: T, to url: URL) throws {
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    let data = try encoder.encode(value)
+    guard var line = String(data: data, encoding: .utf8) else {
+        throw ValidationError("Failed to encode benchmark event as UTF-8.")
+    }
+    line.append("\n")
+    try appendLine(line, to: url)
+}
+
+private func appendLine(_ line: String, to url: URL) throws {
+    guard let data = line.data(using: .utf8) else { return }
+    let handle = try FileHandle(forWritingTo: url)
+    defer { try? handle.close() }
+    try handle.seekToEnd()
+    try handle.write(contentsOf: data)
+}
+
+private func isTimeoutError(_ error: Error) -> Bool {
+    let message = error.localizedDescription.lowercased()
+    return message.contains("timed out") || message.contains("timeout")
+}
+
+private func runPreflight() {
+    do {
+        try stopExtraServeProcesses()
+    } catch {
+        print("Preflight warning: failed to inspect/terminate extra servers (\(error.localizedDescription)).")
+    }
+
+    do {
+        try restartOmniFocus()
+    } catch {
+        print("Preflight warning: failed to restart OmniFocus (\(error.localizedDescription)).")
+    }
+}
+
+private func stopExtraServeProcesses() throws {
+    let currentPID = ProcessInfo.processInfo.processIdentifier
+    guard let output = try? runProcess(
+        executable: "/usr/bin/pgrep",
+        arguments: ["-f", "focusrelay"],
+        timeout: 3
+    ) else {
+        print("Preflight: no extra focusrelay server processes detected.")
+        return
+    }
+
+    let candidatePIDs = output
+        .split(separator: "\n")
+        .compactMap { Int32($0) }
+
+    var terminated: [Int32] = []
+    for pid in candidatePIDs {
+        if pid == currentPID { continue }
+        guard let command = try? runProcess(
+            executable: "/bin/ps",
+            arguments: ["-o", "command=", "-p", String(pid)],
+            timeout: 3
+        ) else {
+            continue
+        }
+        let trimmedCommand = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedCommand.contains("focusrelay serve") || trimmedCommand.contains("focusrelay mcp") || trimmedCommand.contains("focusrelay server") {
+            _ = try? runProcess(executable: "/bin/kill", arguments: ["-TERM", String(pid)], timeout: 2)
+            terminated.append(pid)
+        }
+    }
+
+    if !terminated.isEmpty {
+        print("Preflight: terminated focusrelay server processes: \(terminated.map(String.init).joined(separator: ", "))")
+        Thread.sleep(forTimeInterval: 1.0)
+    } else {
+        print("Preflight: no extra focusrelay server processes detected.")
+    }
+}
+
+private func restartOmniFocus() throws {
+    print("Preflight: restarting OmniFocus...")
+    _ = try? runProcess(
+        executable: "/usr/bin/osascript",
+        arguments: ["-e", "tell application \"OmniFocus\" to quit"],
+        timeout: 8
+    )
+    Thread.sleep(forTimeInterval: 2.0)
+    _ = try runProcess(executable: "/usr/bin/open", arguments: ["-a", "OmniFocus"], timeout: 8)
+    Thread.sleep(forTimeInterval: 3.0)
+}
+
+private func currentOmniFocusPID() -> Int32? {
+    guard let output = try? runProcess(executable: "/usr/bin/pgrep", arguments: ["-x", "OmniFocus"], timeout: 3) else {
+        return nil
+    }
+    let firstLine = output.split(separator: "\n").first
+    return firstLine.flatMap { Int32($0) }
+}
+
+private func readRSSKilobytes(pid: Int32) -> Int? {
+    guard let output = try? runProcess(executable: "/bin/ps", arguments: ["-o", "rss=", "-p", String(pid)], timeout: 3) else {
+        return nil
+    }
+    return Int(output.trimmingCharacters(in: .whitespacesAndNewlines))
+}
+
+@discardableResult
+private func runProcess(executable: String, arguments: [String], timeout: TimeInterval = 15) throws -> String {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: executable)
+    process.arguments = arguments
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = pipe
+    try process.run()
+    let deadline = Date().addingTimeInterval(timeout)
+    while process.isRunning && Date() < deadline {
+        Thread.sleep(forTimeInterval: 0.05)
+    }
+
+    if process.isRunning {
+        process.terminate()
+        throw AutomationError.executionFailed("Process \(executable) timed out after \(Int(timeout))s")
+    }
+
+    process.waitUntilExit()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    let output = String(decoding: data, as: UTF8.self)
+    if process.terminationStatus != 0 {
+        throw AutomationError.executionFailed("Process \(executable) failed: \(output)")
+    }
+    return output
+}
+
+private func writeSummary(
+    to url: URL,
+    startedAt: Date,
+    endedAt: Date,
+    memoryURL: URL,
+    durationHours: Double,
+    warmupCalls: Int,
+    intervalMS: Int,
+    cooldownMS: Int,
+    memoryIntervalSeconds: Int,
+    scenarios: [BenchmarkScenario],
+    statsByTransport: [Transport: StatsAccumulator],
+    statsByScenarioTransport: [String: [Transport: StatsAccumulator]],
+    parityMismatches: [ParityMismatch]
+) async throws {
+    let memorySummary = loadMemorySummary(from: memoryURL)
+    var lines: [String] = []
+    lines.append("# get_task_counts Benchmark Summary")
+    lines.append("")
+    lines.append("- Started: \(iso8601(startedAt))")
+    lines.append("- Ended: \(iso8601(endedAt))")
+    lines.append(String(format: "- Configured duration (hours): %.2f", durationHours))
+    lines.append("- Warmup calls per transport: \(warmupCalls)")
+    lines.append("- Interval (ms): \(intervalMS)")
+    lines.append("- Cooldown after failure (ms): \(cooldownMS)")
+    lines.append("- Memory sampling interval (seconds): \(memoryIntervalSeconds)")
+    lines.append("- Scenarios: \(scenarios.map(\.name).joined(separator: ", "))")
+    lines.append("")
+    lines.append("## Overall Transport Stats")
+    lines.append("")
+    for transport in Transport.allCases {
+        let stats = statsByTransport[transport] ?? StatsAccumulator()
+        let totalCalls = stats.successCount + stats.errorCount
+        let timeoutRate = percentage(part: stats.timeoutCount, total: totalCalls)
+        let errorRate = percentage(part: stats.errorCount, total: totalCalls)
+        lines.append("### \(transport.rawValue)")
+        lines.append("- Total calls: \(totalCalls)")
+        lines.append("- Success calls: \(stats.successCount)")
+        lines.append("- Error calls: \(stats.errorCount)")
+        lines.append("- Error rate: \(formatPercentage(errorRate))")
+        lines.append("- Timeout calls: \(stats.timeoutCount)")
+        lines.append("- Timeout rate: \(formatPercentage(timeoutRate))")
+        lines.append("- p50 latency (ms): \(formatDouble(percentile(stats.latencies, p: 0.50)))")
+        lines.append("- p95 latency (ms): \(formatDouble(percentile(stats.latencies, p: 0.95)))")
+        lines.append("- p99 latency (ms): \(formatDouble(percentile(stats.latencies, p: 0.99)))")
+        lines.append("")
+    }
+
+    lines.append("## Scenario Stats")
+    lines.append("")
+    for scenario in scenarios {
+        lines.append("### \(scenario.name)")
+        let scoped = statsByScenarioTransport[scenario.name] ?? [:]
+        for transport in Transport.allCases {
+            let stats = scoped[transport] ?? StatsAccumulator()
+            let totalCalls = stats.successCount + stats.errorCount
+            let timeoutRate = percentage(part: stats.timeoutCount, total: totalCalls)
+            let errorRate = percentage(part: stats.errorCount, total: totalCalls)
+            lines.append("- \(transport.rawValue): total=\(totalCalls), success=\(stats.successCount), errors=\(stats.errorCount), error_rate=\(formatPercentage(errorRate)), timeouts=\(stats.timeoutCount), timeout_rate=\(formatPercentage(timeoutRate)), p95_ms=\(formatDouble(percentile(stats.latencies, p: 0.95)))")
+        }
+        lines.append("")
+    }
+
+    lines.append("## Parity")
+    lines.append("")
+    lines.append("- Mismatch count: \(parityMismatches.count)")
+    if !parityMismatches.isEmpty {
+        lines.append("")
+        lines.append("First mismatches:")
+        for mismatch in parityMismatches.prefix(10) {
+            lines.append("- \(mismatch.timestamp) scenario=\(mismatch.scenario) plugin=\(mismatch.plugin) jxa=\(mismatch.jxa)")
+        }
+    }
+
+    lines.append("")
+    lines.append("## Memory Notes")
+    lines.append("")
+    lines.append("- `memory.csv` contains RSS samples for `focusrelay` and `OmniFocus`.")
+    lines.append("- Memory growth slope is estimated in KB/min from sampled RSS values.")
+    lines.append("")
+    lines.append("### Memory Growth")
+    for process in ["focusrelay", "OmniFocus"] {
+        if let summary = memorySummary[process] {
+            lines.append("- \(process): samples=\(summary.samples), start_kb=\(summary.startKB), end_kb=\(summary.endKB), delta_kb=\(summary.endKB - summary.startKB), slope_kb_per_min=\(formatDouble(summary.slopeKBPerMinute))")
+        } else {
+            lines.append("- \(process): no samples")
+        }
+    }
+
+    try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
+}
+
+private func percentile(_ values: [Double], p: Double) -> Double {
+    guard !values.isEmpty else { return .nan }
+    let sorted = values.sorted()
+    let index = Int(Double(sorted.count - 1) * p)
+    return sorted[max(0, min(index, sorted.count - 1))]
+}
+
+private func formatDouble(_ value: Double) -> String {
+    guard value.isFinite else { return "n/a" }
+    return String(format: "%.2f", value)
+}
+
+private func formatPercentage(_ value: Double) -> String {
+    guard value.isFinite else { return "n/a" }
+    return String(format: "%.2f%%", value)
+}
+
+private func taskCountsEqual(_ lhs: TaskCountsModel, _ rhs: TaskCountsModel) -> Bool {
+    lhs.total == rhs.total &&
+        lhs.completed == rhs.completed &&
+        lhs.available == rhs.available &&
+        lhs.flagged == rhs.flagged
+}
+
+private struct MemorySample {
+    let timestamp: Date
+    let process: String
+    let rssKB: Double
+}
+
+private struct MemoryProcessSummary {
+    let samples: Int
+    let startKB: Int
+    let endKB: Int
+    let slopeKBPerMinute: Double
+}
+
+private func loadMemorySummary(from url: URL) -> [String: MemoryProcessSummary] {
+    guard let content = try? String(contentsOf: url, encoding: .utf8) else {
+        return [:]
+    }
+
+    let parser = ISO8601DateFormatter()
+    parser.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+    var byProcess: [String: [MemorySample]] = [:]
+    let lines = content.split(separator: "\n")
+    for (index, line) in lines.enumerated() {
+        if index == 0 { continue } // header
+        let columns = line.split(separator: ",", omittingEmptySubsequences: false)
+        if columns.count < 4 { continue }
+        let timestampRaw = String(columns[0])
+        let process = String(columns[1])
+        let rssRaw = String(columns[3])
+        guard let timestamp = parser.date(from: timestampRaw),
+              let rss = Double(rssRaw) else {
+            continue
+        }
+        let sample = MemorySample(timestamp: timestamp, process: process, rssKB: rss)
+        byProcess[process, default: []].append(sample)
+    }
+
+    var summary: [String: MemoryProcessSummary] = [:]
+    for (process, samples) in byProcess {
+        let sorted = samples.sorted { $0.timestamp < $1.timestamp }
+        guard let first = sorted.first, let last = sorted.last else { continue }
+        let slope = linearSlopeKBPerMinute(samples: sorted)
+        summary[process] = MemoryProcessSummary(
+            samples: sorted.count,
+            startKB: Int(first.rssKB.rounded()),
+            endKB: Int(last.rssKB.rounded()),
+            slopeKBPerMinute: slope
+        )
+    }
+    return summary
+}
+
+private func linearSlopeKBPerMinute(samples: [MemorySample]) -> Double {
+    guard samples.count > 1, let first = samples.first else { return .nan }
+
+    var sumX = 0.0
+    var sumY = 0.0
+    var sumXX = 0.0
+    var sumXY = 0.0
+    let n = Double(samples.count)
+
+    for sample in samples {
+        let x = sample.timestamp.timeIntervalSince(first.timestamp) / 60.0
+        let y = sample.rssKB
+        sumX += x
+        sumY += y
+        sumXX += x * x
+        sumXY += x * y
+    }
+
+    let denominator = (n * sumXX) - (sumX * sumX)
+    if abs(denominator) < 1e-9 { return .nan }
+    return ((n * sumXY) - (sumX * sumY)) / denominator
+}
+
+private func percentage(part: Int, total: Int) -> Double {
+    guard total > 0 else { return .nan }
+    return (Double(part) / Double(total)) * 100.0
+}
+
+private func iso8601Now() -> String {
+    iso8601(Date())
+}
+
+private func iso8601(_ date: Date) -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter.string(from: date)
+}

--- a/Sources/FocusRelayCLI/FocusRelayCLI.swift
+++ b/Sources/FocusRelayCLI/FocusRelayCLI.swift
@@ -20,7 +20,11 @@ struct FocusRelayCLI: AsyncParsableCommand {
             ProjectCounts.self,
             DebugInboxProbe.self,
             DebugInboxProbeAlt.self,
-            BridgeHealthCheck.self
+            BridgeHealthCheck.self,
+            BenchmarkTaskCounts.self,
+            BenchmarkListTasks.self,
+            BenchmarkProjectCounts.self,
+            BenchmarkGateCheck.self
         ]
     )
 }

--- a/Sources/OmniFocusAutomation/BridgeClient.swift
+++ b/Sources/OmniFocusAutomation/BridgeClient.swift
@@ -7,11 +7,18 @@ final class BridgeClient: @unchecked Sendable {
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
     private let staleInterval: TimeInterval
+    private let configuration: BridgeClientConfiguration
 
-    init(paths: IPCPaths = .default(), fileManager: FileManager = .default, staleInterval: TimeInterval = 600) {
+    init(
+        paths: IPCPaths = .default(),
+        fileManager: FileManager = .default,
+        staleInterval: TimeInterval = 600,
+        configuration: BridgeClientConfiguration = .fromEnvironment(ProcessInfo.processInfo.environment)
+    ) {
         self.paths = paths
         self.fileManager = fileManager
         self.staleInterval = staleInterval
+        self.configuration = configuration
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         self.encoder = encoder
@@ -314,31 +321,85 @@ final class BridgeClient: @unchecked Sendable {
 
     private func sendRequest<T: Decodable>(_ request: BridgeRequest, responseType: T.Type) throws -> BridgeResponse<T> {
         try ensureDirectories()
-        try writeRequest(request, requestId: request.requestId)
-        try triggerOmniFocus(requestId: request.requestId)
-
         let responseURL = paths.responsesURL.appendingPathComponent("\(request.requestId).json")
         let requestURL = paths.requestsURL.appendingPathComponent("\(request.requestId).json")
         let lockURL = paths.locksURL.appendingPathComponent("\(request.requestId).lock")
         do {
-            return try waitForResponse(at: responseURL, timeout: 10.0, responseType: responseType)
+            try writeRequest(request, requestId: request.requestId)
+            try triggerOmniFocus(requestId: request.requestId)
+            return try waitForResponse(
+                at: responseURL,
+                requestURL: requestURL,
+                lockURL: lockURL,
+                requestId: request.requestId,
+                timeout: configuration.responseTimeout,
+                responseType: responseType
+            )
         } catch {
-            removeIfExists(url: requestURL)
-            removeIfExists(url: lockURL)
+            if !isTimeoutError(error) {
+                removeIfExists(url: requestURL)
+                removeIfExists(url: lockURL)
+            }
             throw error
         }
     }
 
-    private func waitForResponse<T: Decodable>(at url: URL, timeout: TimeInterval, responseType: T.Type) throws -> BridgeResponse<T> {
+    private func waitForResponse<T: Decodable>(
+        at url: URL,
+        requestURL: URL,
+        lockURL: URL,
+        requestId: String,
+        timeout: TimeInterval,
+        responseType: T.Type
+    ) throws -> BridgeResponse<T> {
         let start = Date()
+        var lastReadError: Error?
+        var hasRedispatchedStrandedRequest = false
         while Date().timeIntervalSince(start) < timeout {
             if fileManager.fileExists(atPath: url.path) {
+                do {
+                    let data = try Data(contentsOf: url)
+                    return try decoder.decode(BridgeResponse<T>.self, from: data)
+                } catch {
+                    lastReadError = error
+                }
+            }
+
+            if !hasRedispatchedStrandedRequest,
+               shouldRedispatchStrandedRequest(
+                elapsed: Date().timeIntervalSince(start),
+                timeout: timeout,
+                requestURL: requestURL,
+                responseURL: url,
+                lockURL: lockURL
+               ) {
+                do {
+                    try triggerOmniFocus(requestId: requestId)
+                    hasRedispatchedStrandedRequest = true
+                } catch {
+                    lastReadError = error
+                }
+            }
+            Thread.sleep(forTimeInterval: configuration.responsePollInterval)
+        }
+
+        if fileManager.fileExists(atPath: url.path) {
+            do {
                 let data = try Data(contentsOf: url)
                 return try decoder.decode(BridgeResponse<T>.self, from: data)
+            } catch {
+                lastReadError = error
             }
-            Thread.sleep(forTimeInterval: 0.05)
         }
-        throw AutomationError.executionFailed("Bridge response timed out")
+
+        let requestExists = fileManager.fileExists(atPath: requestURL.path)
+        let responseExists = fileManager.fileExists(atPath: url.path)
+        let lockExists = fileManager.fileExists(atPath: lockURL.path)
+        let timeoutSeconds = String(format: "%.1f", timeout)
+        let lastReadDetail = lastReadError.map { String(describing: $0) } ?? "none"
+        throw AutomationError.executionFailed(
+            "Bridge response timed out after \(timeoutSeconds)s (requestId=\(requestId), requestExists=\(requestExists), responseExists=\(responseExists), lockExists=\(lockExists), lastReadError=\(lastReadDetail))"
+        )
     }
 
     private func cleanupStaleFiles() {
@@ -364,6 +425,55 @@ final class BridgeClient: @unchecked Sendable {
             try? fileManager.removeItem(at: url)
         }
     }
+
+    private func shouldRedispatchStrandedRequest(
+        elapsed: TimeInterval,
+        timeout: TimeInterval,
+        requestURL: URL,
+        responseURL: URL,
+        lockURL: URL
+    ) -> Bool {
+        guard elapsed >= strandedRedispatchDelay(timeout: timeout) else {
+            return false
+        }
+        return fileManager.fileExists(atPath: requestURL.path)
+            && !fileManager.fileExists(atPath: responseURL.path)
+            && !fileManager.fileExists(atPath: lockURL.path)
+    }
+
+    private func isTimeoutError(_ error: Error) -> Bool {
+        guard let automationError = error as? AutomationError else {
+            return false
+        }
+        switch automationError {
+        case .executionFailed(let message):
+            let lower = message.lowercased()
+            return lower.contains("timed out") || lower.contains("timeout")
+        case .scriptCreationFailed, .notImplemented:
+            return false
+        }
+    }
+}
+
+struct BridgeClientConfiguration: Equatable {
+    let responseTimeout: TimeInterval
+    let responsePollInterval: TimeInterval
+
+    static func fromEnvironment(_ environment: [String: String]) -> BridgeClientConfiguration {
+        let parsedTimeout = environment["FOCUS_RELAY_BRIDGE_RESPONSE_TIMEOUT_SECONDS"].flatMap(TimeInterval.init)
+        let timeout = (parsedTimeout ?? 0) > 0 ? parsedTimeout! : 45.0
+
+        let parsedPollInterval = environment["FOCUS_RELAY_BRIDGE_RESPONSE_POLL_MS"]
+            .flatMap(Double.init)
+            .map { $0 / 1000.0 }
+        let pollInterval = (parsedPollInterval ?? 0) > 0 ? parsedPollInterval! : 0.05
+
+        return BridgeClientConfiguration(responseTimeout: timeout, responsePollInterval: pollInterval)
+    }
+}
+
+func strandedRedispatchDelay(timeout: TimeInterval) -> TimeInterval {
+    min(2.0, max(0.5, timeout * 0.1))
 }
 
 private func bridgeScript(basePath: String, requestId: String) -> String {

--- a/Sources/OmniFocusAutomation/BridgeClient.swift
+++ b/Sources/OmniFocusAutomation/BridgeClient.swift
@@ -444,11 +444,53 @@ final class BridgeClient: @unchecked Sendable {
         let requestExists = fileManager.fileExists(atPath: requestURL.path)
         let responseExists = fileManager.fileExists(atPath: url.path)
         let lockExists = fileManager.fileExists(atPath: lockURL.path)
+
+        if shouldAttemptLateStrandedRecovery(
+            transport: configuration.dispatchTransport,
+            requestExists: requestExists,
+            responseExists: responseExists,
+            lockExists: lockExists
+        ) {
+            do {
+                if let recovered: BridgeResponse<T> = try attemptLateStrandedRecovery(
+                    at: url,
+                    requestId: requestId,
+                    timeout: timeout,
+                    responseType: responseType
+                ) {
+                    return recovered
+                }
+            } catch {
+                lastReadError = error
+            }
+        }
+
         let timeoutSeconds = String(format: "%.1f", timeout)
         let lastReadDetail = lastReadError.map { String(describing: $0) } ?? "none"
         throw AutomationError.executionFailed(
             "Bridge response timed out after \(timeoutSeconds)s (requestId=\(requestId), requestExists=\(requestExists), responseExists=\(responseExists), lockExists=\(lockExists), lastReadError=\(lastReadDetail))"
         )
+    }
+
+    private func attemptLateStrandedRecovery<T: Decodable>(
+        at responseURL: URL,
+        requestId: String,
+        timeout: TimeInterval,
+        responseType: T.Type
+    ) throws -> BridgeResponse<T>? {
+        try writeDispatchRequestId(requestId)
+        try triggerOmniFocus(requestId: requestId)
+        let graceDeadline = Date().addingTimeInterval(lateStrandedRecoveryGrace(timeout: timeout))
+
+        while Date() < graceDeadline {
+            if fileManager.fileExists(atPath: responseURL.path) {
+                let data = try Data(contentsOf: responseURL)
+                return try decoder.decode(BridgeResponse<T>.self, from: data)
+            }
+            Thread.sleep(forTimeInterval: configuration.responsePollInterval)
+        }
+
+        return nil
     }
 
     private func cleanupStaleFiles() {
@@ -534,6 +576,19 @@ struct BridgeClientConfiguration: Equatable {
 
 func strandedRedispatchDelay(timeout: TimeInterval) -> TimeInterval {
     min(2.0, max(0.5, timeout * 0.1))
+}
+
+func lateStrandedRecoveryGrace(timeout: TimeInterval) -> TimeInterval {
+    min(10.0, max(3.0, timeout * 0.2))
+}
+
+func shouldAttemptLateStrandedRecovery(
+    transport: BridgeDispatchTransport,
+    requestExists: Bool,
+    responseExists: Bool,
+    lockExists: Bool
+) -> Bool {
+    transport == .urlScheme && requestExists && !responseExists && !lockExists
 }
 
 enum BridgeDispatchTransport: Equatable {

--- a/Sources/OmniFocusAutomation/BridgeClient.swift
+++ b/Sources/OmniFocusAutomation/BridgeClient.swift
@@ -7,6 +7,7 @@ final class BridgeClient: @unchecked Sendable {
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
     private let staleInterval: TimeInterval
+    private let dispatchRunner: SerializedJXARunner
     private let configuration: BridgeClientConfiguration
 
     init(
@@ -19,6 +20,7 @@ final class BridgeClient: @unchecked Sendable {
         self.fileManager = fileManager
         self.staleInterval = staleInterval
         self.configuration = configuration
+        self.dispatchRunner = SerializedJXARunner(runner: ScriptRunner(), defaultTimeout: configuration.dispatchTimeout)
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         self.encoder = encoder
@@ -301,7 +303,31 @@ final class BridgeClient: @unchecked Sendable {
         try data.write(to: requestURL, options: .atomic)
     }
 
+    private var dispatchDirectoryURL: URL {
+        paths.baseURL.appendingPathComponent("dispatch", isDirectory: true)
+    }
+
+    private var dispatchRequestURL: URL {
+        dispatchDirectoryURL.appendingPathComponent("request.json")
+    }
+
+    private func writeDispatchRequestId(_ requestId: String) throws {
+        try fileManager.createDirectory(at: dispatchDirectoryURL, withIntermediateDirectories: true)
+        let payload = ["requestId": requestId]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+        try data.write(to: dispatchRequestURL, options: .atomic)
+    }
+
     private func triggerOmniFocus(requestId: String) throws {
+        switch configuration.dispatchTransport {
+        case .urlScheme:
+            try triggerOmniFocusURLDispatch(requestId: requestId)
+        case .jxaEvaluate:
+            try triggerOmniFocusJXADispatch()
+        }
+    }
+
+    private func triggerOmniFocusURLDispatch(requestId: String) throws {
         let script = bridgeScript(basePath: paths.baseURL.path, requestId: requestId)
         var allowed = CharacterSet.urlQueryAllowed
         allowed.remove(charactersIn: "&+=?")
@@ -319,6 +345,25 @@ final class BridgeClient: @unchecked Sendable {
         try process.run()
     }
 
+    private func triggerOmniFocusJXADispatch() throws {
+        let script = buildBridgeEvaluateDispatchScript(basePath: paths.baseURL.path)
+        let output = try dispatchRunner.runJavaScript(script, timeout: configuration.dispatchTimeout)
+        guard let result = parseBridgeDispatchResult(from: output) else {
+            return
+        }
+        if result.ok {
+            if result.dispatched == false {
+                throw AutomationError.executionFailed("Bridge dispatch did not pick up any pending request")
+            }
+            return
+        }
+        if result.error == "PLUGIN_MISSING" {
+            try retryBridgePluginLookup(basePath: paths.baseURL.path, timeout: configuration.dispatchTimeout)
+            return
+        }
+        throw AutomationError.executionFailed("Bridge dispatch failed: \(result.error ?? "unknown dispatch error")")
+    }
+
     private func sendRequest<T: Decodable>(_ request: BridgeRequest, responseType: T.Type) throws -> BridgeResponse<T> {
         try ensureDirectories()
         let responseURL = paths.responsesURL.appendingPathComponent("\(request.requestId).json")
@@ -326,8 +371,9 @@ final class BridgeClient: @unchecked Sendable {
         let lockURL = paths.locksURL.appendingPathComponent("\(request.requestId).lock")
         do {
             try writeRequest(request, requestId: request.requestId)
+            try writeDispatchRequestId(request.requestId)
             try triggerOmniFocus(requestId: request.requestId)
-            return try waitForResponse(
+            let response = try waitForResponse(
                 at: responseURL,
                 requestURL: requestURL,
                 lockURL: lockURL,
@@ -335,10 +381,13 @@ final class BridgeClient: @unchecked Sendable {
                 timeout: configuration.responseTimeout,
                 responseType: responseType
             )
+            removeIfExists(url: dispatchRequestURL)
+            return response
         } catch {
             if !isTimeoutError(error) {
                 removeIfExists(url: requestURL)
                 removeIfExists(url: lockURL)
+                removeIfExists(url: dispatchRequestURL)
             }
             throw error
         }
@@ -458,6 +507,8 @@ final class BridgeClient: @unchecked Sendable {
 struct BridgeClientConfiguration: Equatable {
     let responseTimeout: TimeInterval
     let responsePollInterval: TimeInterval
+    let dispatchTransport: BridgeDispatchTransport
+    let dispatchTimeout: TimeInterval
 
     static func fromEnvironment(_ environment: [String: String]) -> BridgeClientConfiguration {
         let parsedTimeout = environment["FOCUS_RELAY_BRIDGE_RESPONSE_TIMEOUT_SECONDS"].flatMap(TimeInterval.init)
@@ -468,12 +519,129 @@ struct BridgeClientConfiguration: Equatable {
             .map { $0 / 1000.0 }
         let pollInterval = (parsedPollInterval ?? 0) > 0 ? parsedPollInterval! : 0.05
 
-        return BridgeClientConfiguration(responseTimeout: timeout, responsePollInterval: pollInterval)
+        let dispatchTransport = BridgeDispatchTransport.fromEnvironment(environment)
+        let parsedDispatchTimeout = environment["FOCUS_RELAY_BRIDGE_DISPATCH_TIMEOUT_SECONDS"].flatMap(TimeInterval.init)
+        let dispatchTimeout = (parsedDispatchTimeout ?? 0) > 0 ? parsedDispatchTimeout! : 20.0
+
+        return BridgeClientConfiguration(
+            responseTimeout: timeout,
+            responsePollInterval: pollInterval,
+            dispatchTransport: dispatchTransport,
+            dispatchTimeout: dispatchTimeout
+        )
     }
 }
 
 func strandedRedispatchDelay(timeout: TimeInterval) -> TimeInterval {
     min(2.0, max(0.5, timeout * 0.1))
+}
+
+enum BridgeDispatchTransport: Equatable {
+    case urlScheme
+    case jxaEvaluate
+
+    static func fromEnvironment(_ environment: [String: String]) -> BridgeDispatchTransport {
+        let raw = environment["FOCUS_RELAY_BRIDGE_DISPATCH_TRANSPORT"]?.lowercased()
+        return raw == "jxa" ? .jxaEvaluate : .urlScheme
+    }
+}
+
+private struct BridgeDispatchResult: Decodable {
+    let ok: Bool
+    let dispatched: Bool?
+    let error: String?
+}
+
+private func parseBridgeDispatchResult(from output: String) -> BridgeDispatchResult? {
+    let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty, trimmed.hasPrefix("{"), trimmed.hasSuffix("}") else {
+        return nil
+    }
+    guard let data = trimmed.data(using: .utf8) else { return nil }
+    return try? JSONDecoder().decode(BridgeDispatchResult.self, from: data)
+}
+
+private func retryBridgePluginLookup(basePath: String, timeout: TimeInterval) throws {
+    let runner = SerializedJXARunner(runner: ScriptRunner(), defaultTimeout: timeout)
+    for attempt in 1...4 {
+        Thread.sleep(forTimeInterval: 0.35)
+        let script = buildBridgeEvaluateDispatchScript(basePath: basePath)
+        let output = try runner.runJavaScript(script, timeout: timeout)
+        guard let result = parseBridgeDispatchResult(from: output) else {
+            return
+        }
+        if result.ok && result.dispatched != false {
+            return
+        }
+        if result.error != "PLUGIN_MISSING" || attempt == 4 {
+            throw AutomationError.executionFailed("Bridge dispatch failed: \(result.error ?? "unknown dispatch error")")
+        }
+    }
+}
+
+func buildBridgeEvaluateDispatchScript(basePath: String) -> String {
+    let automationScript = buildBridgeDispatchScript(basePath: basePath)
+    return """
+    (function() {
+      var app = Application("OmniFocus");
+      app.includeStandardAdditions = false;
+      var automationScript = \(jsonString(automationScript));
+      var result = app.evaluateJavascript(automationScript);
+      return (result === undefined || result === null) ? "" : String(result);
+    })();
+    """
+}
+
+func buildBridgeDispatchScript(basePath: String) -> String {
+    return """
+    (function() {
+      var basePath = \(jsonString(basePath));
+      var dispatchRequestPath = basePath + "/dispatch/request.json";
+
+      function readDispatchRequestId(path) {
+        try {
+          var url = URL.fromString("file://" + path);
+          var wrapper = FileWrapper.fromURL(url);
+          var text = wrapper.contents.toString();
+          if (!text) { return null; }
+          var trimmed = String(text).trim();
+          if (!trimmed) { return null; }
+          if (trimmed.startsWith("{")) {
+            var payload = JSON.parse(trimmed);
+            if (payload && payload.requestId) {
+              return String(payload.requestId);
+            }
+          }
+          return trimmed;
+        } catch (e) {
+          return null;
+        }
+      }
+
+      try {
+        var plugin = PlugIn.find("com.focusrelay.bridge");
+        if (!plugin) {
+          return JSON.stringify({ ok: false, dispatched: false, error: "PLUGIN_MISSING" });
+        }
+        var lib = plugin.library("BridgeLibrary");
+        if (lib && typeof lib.handleRequest === "function") {
+          var requestId = readDispatchRequestId(dispatchRequestPath);
+          if (!requestId) {
+            return JSON.stringify({ ok: false, dispatched: false, error: "DISPATCH_REQUEST_ID_MISSING" });
+          }
+          lib.handleRequest(requestId, basePath);
+          return JSON.stringify({ ok: true, dispatched: true, handler: "handleRequest", requestId: requestId });
+        }
+        if (lib && typeof lib.handleNextRequest === "function") {
+          var dispatched = lib.handleNextRequest(basePath);
+          return JSON.stringify({ ok: true, dispatched: Boolean(dispatched), handler: "handleNextRequest" });
+        }
+        return JSON.stringify({ ok: false, dispatched: false, error: "NO_COMPATIBLE_HANDLER" });
+      } catch (err) {
+        return JSON.stringify({ ok: false, dispatched: false, error: String(err) });
+      }
+    })();
+    """
 }
 
 private func bridgeScript(basePath: String, requestId: String) -> String {

--- a/Sources/OmniFocusAutomation/OmniFocusAutomation.swift
+++ b/Sources/OmniFocusAutomation/OmniFocusAutomation.swift
@@ -41,12 +41,16 @@ public final class ScriptRunner: Sendable {
 public final class OmniAutomationService: OmniFocusService {
     private let runner: ScriptRunner
     private let decoder: JSONDecoder
+    private let requestEncoder: JSONEncoder
 
     public init(runner: ScriptRunner = ScriptRunner()) {
         self.runner = runner
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         self.decoder = decoder
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        self.requestEncoder = encoder
     }
 
     public func listTasks(filter: TaskFilter, page: PageRequest, fields: [String]?) async throws -> Page<TaskItem> {
@@ -55,17 +59,13 @@ public final class OmniAutomationService: OmniFocusService {
             effectiveFilter.completed = false
         }
 
-        guard effectiveFilter.inboxOnly == true else {
-            throw AutomationError.executionFailed("Only inboxOnly is supported for listTasks in v0.1")
-        }
-
         let request = ListTasksRequest(filter: effectiveFilter, page: page, fields: fields)
-        let requestData = try JSONEncoder().encode(request)
+        let requestData = try requestEncoder.encode(request)
         guard let requestJSON = String(data: requestData, encoding: .utf8) else {
             throw AutomationError.executionFailed("Failed to encode request JSON")
         }
 
-        let script = listInboxTasksScript(requestJSON: requestJSON)
+        let script = listTasksEvaluateScript(requestJSON: requestJSON)
         let output = try runner.runJavaScript(script)
         let data = Data(output.utf8)
         let payloadPage = try decoder.decode(Page<TaskItemPayload>.self, from: data)
@@ -120,7 +120,7 @@ public final class OmniAutomationService: OmniFocusService {
             completedAfter: completedAfter,
             fields: fields
         )
-        let requestData = try JSONEncoder().encode(request)
+        let requestData = try requestEncoder.encode(request)
         guard let requestJSON = String(data: requestData, encoding: .utf8) else {
             throw AutomationError.executionFailed("Failed to encode request JSON")
         }
@@ -160,13 +160,29 @@ public final class OmniAutomationService: OmniFocusService {
     }
 
     public func getTaskCounts(filter: TaskFilter) async throws -> TaskCounts {
-        _ = runner
-        throw AutomationError.notImplemented
+        let request = TaskCountsRequest(filter: filter)
+        let requestData = try requestEncoder.encode(request)
+        guard let requestJSON = String(data: requestData, encoding: .utf8) else {
+            throw AutomationError.executionFailed("Failed to encode request JSON")
+        }
+
+        let script = taskCountsEvaluateScript(requestJSON: requestJSON)
+        let output = try runner.runJavaScript(script)
+        let data = Data(output.utf8)
+        return try decoder.decode(TaskCounts.self, from: data)
     }
 
     public func getProjectCounts(filter: TaskFilter) async throws -> ProjectCounts {
-        _ = runner
-        throw AutomationError.notImplemented
+        let request = ProjectCountsRequest(filter: filter)
+        let requestData = try requestEncoder.encode(request)
+        guard let requestJSON = String(data: requestData, encoding: .utf8) else {
+            throw AutomationError.executionFailed("Failed to encode request JSON")
+        }
+
+        let script = projectCountsEvaluateScript(requestJSON: requestJSON)
+        let output = try runner.runJavaScript(script)
+        let data = Data(output.utf8)
+        return try decoder.decode(ProjectCounts.self, from: data)
     }
 
     public func debugInboxProbe() async throws -> InboxProbe {
@@ -202,6 +218,14 @@ private struct ListProjectsRequest: Codable {
     let completedBefore: Date?
     let completedAfter: Date?
     let fields: [String]?
+}
+
+private struct TaskCountsRequest: Codable {
+    let filter: TaskFilter
+}
+
+private struct ProjectCountsRequest: Codable {
+    let filter: TaskFilter
 }
 
 
@@ -240,10 +264,32 @@ public struct InboxProbeAlt: Codable, Sendable {
     public let flattenedFilterMs: Int
 }
 
-private func listInboxTasksScript(requestJSON: String) -> String {
+private func listTasksEvaluateScript(requestJSON: String) -> String {
+    let automationScript = listTasksOmniAutomationScript(requestJSON: requestJSON)
+    return """
+    (function() {
+      var app = Application('OmniFocus');
+      var script = \(jsStringLiteral(automationScript));
+      var result = app.evaluateJavascript(script);
+      if (Array.isArray(result)) {
+        if (result.length === 0 || result[0] === null || typeof result[0] === "undefined") {
+          return "";
+        }
+        return String(result[0]);
+      }
+      if (result === null || typeof result === "undefined") {
+        return "";
+      }
+      return String(result);
+    })();
+    """
+}
+
+private func listTasksOmniAutomationScript(requestJSON: String) -> String {
     return """
     (function() {
       var request = \(requestJSON);
+      var filter = request.filter || {};
       var limit = (request.page && request.page.limit) ? request.page.limit : 50;
       var offset = 0;
       if (request.page && request.page.cursor) {
@@ -259,77 +305,345 @@ private func listInboxTasksScript(requestJSON: String) -> String {
         try { return fn(); } catch (e) { return null; }
       }
 
-      var app = Application('OmniFocus');
-      var doc = app.defaultDocument();
-      var tasks = doc.inboxTasks();
-      var completedFilter = null;
-      if (request.filter && typeof request.filter.completed === "boolean") {
-        completedFilter = request.filter.completed;
-      }
-      if (completedFilter !== null) {
-        tasks = tasks.filter(function(t) {
-          return Boolean(safe(function() { return t.completed(); })) === completedFilter;
-        });
-      }
-
-      tasks = tasks.filter(function(t) {
-        var dropDate = safe(function() { return t.dropDate(); });
-        if (dropDate) { return false; }
-        if (completedFilter === null) {
-          if (Boolean(safe(function() { return t.completed(); }))) { return false; }
+      function toTaskArray(collection) {
+        if (!collection) { return []; }
+        if (Array.isArray(collection)) { return collection; }
+        if (typeof collection.apply === "function") {
+          var items = [];
+          collection.apply(function(item) { items.push(item); });
+          return items;
         }
-        return true;
-      });
-      var projectFilter = null;
-      if (request.filter && typeof request.filter.project === "string" && request.filter.project.length > 0) {
-        projectFilter = request.filter.project;
+        try {
+          return Array.from(collection);
+        } catch (e) {
+          return [];
+        }
       }
-      if (projectFilter !== null) {
-        tasks = tasks.filter(function(t) {
-          var project = safe(function() { return t.containingProject(); });
-          if (!project) { return false; }
-          var projectID = String(safe(function() { return project.id(); }) || "");
-          var projectName = String(safe(function() { return project.name(); }) || "");
-          return projectID === projectFilter || projectName === projectFilter;
-        });
-      }
-      var availableOnly = null;
-      if (request.filter && typeof request.filter.availableOnly === "boolean") {
-        availableOnly = request.filter.availableOnly;
-      }
-      if (availableOnly === true) {
-        tasks = tasks.filter(function(t) {
-          return Boolean(safe(function() { return t.isAvailable(); }));
-        });
-      }
-      var total = tasks.length;
-      var slice = tasks.slice(offset, offset + limit);
 
-      var items = slice.map(function(t) {
-        var project = hasField("projectID") || hasField("projectName") ? safe(function() { return t.containingProject(); }) : null;
-        var tags = (hasField("tagIDs") || hasField("tagNames")) ? (safe(function() { return t.tags(); }) || []) : [];
-        var dueDate = hasField("dueDate") ? safe(function() { return t.dueDate(); }) : null;
-        var deferDate = hasField("deferDate") ? safe(function() { return t.deferDate(); }) : null;
+      function inboxTasksArray() {
+        var inboxCollection = safe(function() { return inbox; });
+        return toTaskArray(inboxCollection);
+      }
+
+      function taskStatusName(task) {
+        var status = safe(function() { return task.taskStatus; });
+        var statusText = String(status);
+        if (statusText.indexOf("Completed") !== -1) { return "completed"; }
+        if (statusText.indexOf("Dropped") !== -1) { return "dropped"; }
+        if (statusText.indexOf("Available") !== -1) { return "available"; }
+        if (statusText.indexOf("DueSoon") !== -1) { return "dueSoon"; }
+        if (statusText.indexOf("Next") !== -1) { return "next"; }
+        if (statusText.indexOf("Overdue") !== -1) { return "overdue"; }
+        if (statusText.indexOf("Blocked") !== -1) { return "blocked"; }
+        if (status === Task.Status.Completed) { return "completed"; }
+        if (status === Task.Status.Dropped) { return "dropped"; }
+        if (status === Task.Status.Available) { return "available"; }
+        if (status === Task.Status.DueSoon) { return "dueSoon"; }
+        if (status === Task.Status.Next) { return "next"; }
+        if (status === Task.Status.Overdue) { return "overdue"; }
+        if (status === Task.Status.Blocked) { return "blocked"; }
+        return "unknown";
+      }
+
+      function projectStatusName(project) {
+        var status = safe(function() { return project.status; });
+        var statusText = String(status);
+        if (statusText.indexOf("OnHold") !== -1) { return "onHold"; }
+        if (statusText.indexOf("Dropped") !== -1) { return "dropped"; }
+        if (statusText.indexOf("Done") !== -1) { return "done"; }
+        if (statusText.indexOf("Active") !== -1) { return "active"; }
+        if (status === Project.Status.OnHold) { return "onHold"; }
+        if (status === Project.Status.Dropped) { return "dropped"; }
+        if (status === Project.Status.Done) { return "done"; }
+        if (status === Project.Status.Active) { return "active"; }
+        return "unknown";
+      }
+
+      function isCompletedStatus(task) {
+        return taskStatusName(task) === "completed";
+      }
+
+      function isDroppedStatus(task) {
+        return taskStatusName(task) === "dropped";
+      }
+
+      function isRemainingStatus(task) {
+        var statusName = taskStatusName(task);
+        return statusName !== "completed" && statusName !== "dropped";
+      }
+
+      function isAvailableStatus(task) {
+        var statusName = taskStatusName(task);
+        return statusName === "available" ||
+          statusName === "dueSoon" ||
+          statusName === "next" ||
+          statusName === "overdue";
+      }
+
+      function projectMatchesView(project, view, allowOnHoldInEverything) {
+        if (!project) { return false; }
+        if (!view || view === "all") { return true; }
+
+        var normalizedView = String(view).toLowerCase();
+        if (normalizedView === "everything") { return true; }
+        var allowOnHold = allowOnHoldInEverything && normalizedView === "everything";
+        var statusName = projectStatusName(project);
+
+        if (statusName === "active") { return normalizedView === "active"; }
+        if (statusName === "onHold") {
+          return allowOnHold || normalizedView === "onhold" || normalizedView === "on_hold";
+        }
+        if (statusName === "dropped") { return normalizedView === "dropped"; }
+        if (statusName === "done") {
+          return normalizedView === "done" || normalizedView === "completed";
+        }
+        return false;
+      }
+
+      function parentAllowsAvailability(task) {
+        var parent = safe(function() { return task.parent; });
+        if (!parent) { return true; }
+        return !isCompletedStatus(parent) && !isDroppedStatus(parent);
+      }
+
+      function isTaskAvailable(task) {
+        if (!parentAllowsAvailability(task)) { return false; }
+
+        var project = safe(function() { return task.containingProject; });
+        if (project) {
+          var projectStatus = projectStatusName(project);
+          if (projectStatus !== "active") { return false; }
+        }
+
+        return isAvailableStatus(task);
+      }
+
+      function parseFilterDate(dateString) {
+        if (!dateString || typeof dateString !== "string") { return null; }
+        var parsed = new Date(dateString);
+        if (isNaN(parsed.getTime())) { return null; }
+        return parsed;
+      }
+
+      function getTaskDateTimestamp(task, getter) {
+        var value = safe(function() { return getter(task); });
+        if (!value || typeof value.getTime !== "function") { return null; }
+        var timestamp = value.getTime();
+        if (isNaN(timestamp)) { return null; }
+        return timestamp;
+      }
+
+      function projectIdentifier(project) {
+        return String(safe(function() { return project.id.primaryKey; }) || "");
+      }
+
+      function projectName(project) {
+        return String(safe(function() { return project.name; }) || "");
+      }
+
+      function resolveProject(projectFilter, projects) {
+        if (!projectFilter || typeof projectFilter !== "string") { return null; }
+        for (var i = 0; i < projects.length; i += 1) {
+          var project = projects[i];
+          if (projectIdentifier(project) === projectFilter || projectName(project) === projectFilter) {
+            return project;
+          }
+        }
+        return null;
+      }
+
+      function tagMatchesFilter(task, filterTags, untaggedOnly) {
+        var tags = safe(function() { return task.tags; }) || [];
+        if (untaggedOnly) {
+          return tags.length === 0;
+        }
+
+        for (var i = 0; i < tags.length; i += 1) {
+          var tag = tags[i];
+          var tagID = String(safe(function() { return tag.id.primaryKey; }) || "");
+          var tagName = String(safe(function() { return tag.name; }) || "");
+          for (var j = 0; j < filterTags.length; j += 1) {
+            var filterTag = filterTags[j];
+            if (tagID === filterTag || tagName === filterTag) {
+              return true;
+            }
+          }
+        }
+
+        return false;
+      }
+
+      function taskToPayload(task) {
+        var project = hasField("projectID") || hasField("projectName") ? safe(function() { return task.containingProject; }) : null;
+        var tags = (hasField("tagIDs") || hasField("tagNames")) ? (safe(function() { return task.tags; }) || []) : [];
+        var dueDate = hasField("dueDate") ? safe(function() { return task.dueDate; }) : null;
+        var plannedDate = hasField("plannedDate") ? safe(function() { return task.plannedDate; }) : null;
+        var deferDate = hasField("deferDate") ? safe(function() { return task.deferDate; }) : null;
+        var completionDate = hasField("completionDate") ? safe(function() { return task.completionDate; }) : null;
 
         return {
-          id: hasField("id") ? String(safe(function() { return t.id(); }) || "") : null,
-          name: hasField("name") ? String(safe(function() { return t.name(); }) || "") : null,
-          note: hasField("note") ? safe(function() { return t.note(); }) : null,
-          projectID: hasField("projectID") && project ? String(safe(function() { return project.id(); }) || "") : null,
-          projectName: hasField("projectName") && project ? String(safe(function() { return project.name(); }) || "") : null,
-          tagIDs: hasField("tagIDs") ? tags.map(function(tag) { return String(safe(function() { return tag.id(); }) || ""); }) : null,
-          tagNames: hasField("tagNames") ? tags.map(function(tag) { return String(safe(function() { return tag.name(); }) || ""); }) : null,
+          id: hasField("id") ? String(safe(function() { return task.id.primaryKey; }) || "") : null,
+          name: hasField("name") ? String(safe(function() { return task.name; }) || "") : null,
+          note: hasField("note") ? safe(function() { return task.note; }) : null,
+          projectID: hasField("projectID") && project ? projectIdentifier(project) : null,
+          projectName: hasField("projectName") && project ? projectName(project) : null,
+          tagIDs: hasField("tagIDs") ? tags.map(function(tag) { return String(safe(function() { return tag.id.primaryKey; }) || ""); }) : null,
+          tagNames: hasField("tagNames") ? tags.map(function(tag) { return String(safe(function() { return tag.name; }) || ""); }) : null,
           dueDate: hasField("dueDate") && dueDate ? dueDate.toISOString() : null,
+          plannedDate: hasField("plannedDate") && plannedDate ? plannedDate.toISOString() : null,
           deferDate: hasField("deferDate") && deferDate ? deferDate.toISOString() : null,
-          completed: hasField("completed") ? Boolean(safe(function() { return t.completed(); })) : null,
-          flagged: hasField("flagged") ? Boolean(safe(function() { return t.flagged(); })) : null,
-          estimatedMinutes: hasField("estimatedMinutes") ? safe(function() { return t.estimatedMinutes(); }) : null,
-          available: hasField("available") ? Boolean(safe(function() { return t.isAvailable(); })) : null
+          completionDate: hasField("completionDate") && completionDate ? completionDate.toISOString() : null,
+          completed: hasField("completed") ? isCompletedStatus(task) : null,
+          flagged: hasField("flagged") ? Boolean(safe(function() { return task.flagged; })) : null,
+          estimatedMinutes: hasField("estimatedMinutes") ? safe(function() { return task.estimatedMinutes; }) : null,
+          available: hasField("available") ? isTaskAvailable(task) : null
         };
-      });
+      }
 
-      var nextCursor = (offset + limit < total) ? String(offset + limit) : null;
-      return JSON.stringify({ items: items, nextCursor: nextCursor });
+      var allProjects = toTaskArray(safe(function() { return flattenedProjects; }));
+      var allTasks = toTaskArray(safe(function() { return flattenedTasks; }));
+      var inboxView = (typeof filter.inboxView === "string") ? filter.inboxView.toLowerCase() : "available";
+      var isEverything = inboxView === "everything";
+      var isRemaining = inboxView === "remaining";
+      var projectView = (typeof filter.projectView === "string") ? filter.projectView.toLowerCase() : null;
+      var availableOnly = (typeof filter.availableOnly === "boolean")
+        ? filter.availableOnly
+        : (filter.completed === true ? false : !isRemaining && !isEverything);
+
+      var baseTasks = [];
+      if (filter.inboxOnly === true) {
+        baseTasks = inboxTasksArray();
+      } else {
+        var project = resolveProject(filter.project, allProjects);
+        if (filter.project && !project) {
+          baseTasks = [];
+        } else if (project) {
+          baseTasks = toTaskArray(safe(function() { return project.flattenedTasks; }));
+        } else {
+          baseTasks = allTasks;
+        }
+      }
+
+      var filterState = {
+        completed: filter.completed,
+        flagged: filter.flagged,
+        availableOnly: availableOnly,
+        projectFilter: filter.project,
+        projectView: projectView,
+        dueBefore: filter.dueBefore ? parseFilterDate(filter.dueBefore) : null,
+        dueAfter: filter.dueAfter ? parseFilterDate(filter.dueAfter) : null,
+        plannedBefore: filter.plannedBefore ? parseFilterDate(filter.plannedBefore) : null,
+        plannedAfter: filter.plannedAfter ? parseFilterDate(filter.plannedAfter) : null,
+        deferBefore: filter.deferBefore ? parseFilterDate(filter.deferBefore) : null,
+        deferAfter: filter.deferAfter ? parseFilterDate(filter.deferAfter) : null,
+        completedBefore: filter.completedBefore ? parseFilterDate(filter.completedBefore) : null,
+        completedAfter: filter.completedAfter ? parseFilterDate(filter.completedAfter) : null,
+        tags: Array.isArray(filter.tags) ? filter.tags : null,
+        untaggedOnly: Array.isArray(filter.tags) && filter.tags.length === 0,
+        maxEstimatedMinutes: filter.maxEstimatedMinutes,
+        minEstimatedMinutes: filter.minEstimatedMinutes
+      };
+
+      function matchesFilters(task) {
+        var project = safe(function() { return task.containingProject; });
+
+        if (filterState.completed !== undefined) {
+          if (isCompletedStatus(task) !== filterState.completed) { return false; }
+        } else if (!isEverything) {
+          if (!isRemainingStatus(task)) { return false; }
+        }
+
+        if (filterState.flagged !== undefined) {
+          if (Boolean(safe(function() { return task.flagged; })) !== filterState.flagged) { return false; }
+        }
+
+        if (filterState.availableOnly && !isTaskAvailable(task)) { return false; }
+
+        if (filterState.projectFilter) {
+          if (!project) { return false; }
+          if (projectIdentifier(project) !== filterState.projectFilter && projectName(project) !== filterState.projectFilter) {
+            return false;
+          }
+        }
+
+        if (filterState.projectView) {
+          if (!projectMatchesView(project, filterState.projectView, true)) { return false; }
+        }
+
+        if (filterState.dueBefore) {
+          var dueBefore = getTaskDateTimestamp(task, function(item) { return item.dueDate; });
+          if (dueBefore === null || dueBefore > filterState.dueBefore.getTime()) { return false; }
+        }
+        if (filterState.dueAfter) {
+          var dueAfter = getTaskDateTimestamp(task, function(item) { return item.dueDate; });
+          if (dueAfter === null || dueAfter < filterState.dueAfter.getTime()) { return false; }
+        }
+        if (filterState.deferBefore) {
+          var deferBefore = getTaskDateTimestamp(task, function(item) { return item.deferDate; });
+          if (deferBefore === null || deferBefore > filterState.deferBefore.getTime()) { return false; }
+        }
+        if (filterState.deferAfter) {
+          var deferAfter = getTaskDateTimestamp(task, function(item) { return item.deferDate; });
+          if (deferAfter === null || deferAfter < filterState.deferAfter.getTime()) { return false; }
+        }
+        if (filterState.plannedBefore) {
+          var plannedBefore = getTaskDateTimestamp(task, function(item) { return item.plannedDate; });
+          if (plannedBefore === null || plannedBefore > filterState.plannedBefore.getTime()) { return false; }
+        }
+        if (filterState.plannedAfter) {
+          var plannedAfter = getTaskDateTimestamp(task, function(item) { return item.plannedDate; });
+          if (plannedAfter === null || plannedAfter < filterState.plannedAfter.getTime()) { return false; }
+        }
+        if (filterState.completedBefore) {
+          var completedBefore = getTaskDateTimestamp(task, function(item) { return item.completionDate; });
+          if (completedBefore === null || completedBefore > filterState.completedBefore.getTime()) { return false; }
+        }
+        if (filterState.completedAfter) {
+          var completedAfter = getTaskDateTimestamp(task, function(item) { return item.completionDate; });
+          if (completedAfter === null || completedAfter < filterState.completedAfter.getTime()) { return false; }
+        }
+        if (filterState.maxEstimatedMinutes !== undefined) {
+          var maxMinutes = safe(function() { return task.estimatedMinutes; });
+          if (maxMinutes === null || maxMinutes === undefined || maxMinutes > filterState.maxEstimatedMinutes) { return false; }
+        }
+        if (filterState.minEstimatedMinutes !== undefined) {
+          var minMinutes = safe(function() { return task.estimatedMinutes; });
+          if (minMinutes === null || minMinutes === undefined || minMinutes < filterState.minEstimatedMinutes) { return false; }
+        }
+
+        if (filterState.tags && !tagMatchesFilter(task, filterState.tags, filterState.untaggedOnly)) {
+          return false;
+        }
+
+        return true;
+      }
+
+      var filteredTasks = [];
+      for (var i = 0; i < baseTasks.length; i += 1) {
+        var task = baseTasks[i];
+        if (matchesFilters(task)) {
+          filteredTasks.push(task);
+        }
+      }
+
+      if (filterState.completed === true || filterState.completedAfter || filterState.completedBefore) {
+        filteredTasks.sort(function(a, b) {
+          var dateA = getTaskDateTimestamp(a, function(item) { return item.completionDate; }) || 0;
+          var dateB = getTaskDateTimestamp(b, function(item) { return item.completionDate; }) || 0;
+          return dateB - dateA;
+        });
+      }
+
+      var pageTasks = filteredTasks.slice(offset, offset + limit);
+      var items = pageTasks.map(taskToPayload);
+      var returnedCount = items.length;
+      var nextCursor = (offset + returnedCount < filteredTasks.length) ? String(offset + returnedCount) : null;
+      var payload = { items: items, nextCursor: nextCursor, returnedCount: returnedCount };
+      if (filter.includeTotalCount === true) {
+        payload.totalCount = filteredTasks.length;
+      }
+
+      return JSON.stringify(payload);
     })();
     """
 }
@@ -519,4 +833,735 @@ private func inboxProbeAltScript() -> String {
       });
     })();
     """
+}
+
+private func taskCountsEvaluateScript(requestJSON: String) -> String {
+    let automationScript = taskCountsOmniAutomationScript(requestJSON: requestJSON)
+    return """
+    (function() {
+      var app = Application('OmniFocus');
+      var script = \(jsStringLiteral(automationScript));
+      var result = app.evaluateJavascript(script);
+      if (Array.isArray(result)) {
+        if (result.length === 0 || result[0] === null || typeof result[0] === "undefined") {
+          return "";
+        }
+        return String(result[0]);
+      }
+      if (result === null || typeof result === "undefined") {
+        return "";
+      }
+      return String(result);
+    })();
+    """
+}
+
+private func projectCountsEvaluateScript(requestJSON: String) -> String {
+    let automationScript = projectCountsOmniAutomationScript(requestJSON: requestJSON)
+    return """
+    (function() {
+      var app = Application('OmniFocus');
+      var script = \(jsStringLiteral(automationScript));
+      var result = app.evaluateJavascript(script);
+      if (Array.isArray(result)) {
+        if (result.length === 0 || result[0] === null || typeof result[0] === "undefined") {
+          return "";
+        }
+        return String(result[0]);
+      }
+      if (result === null || typeof result === "undefined") {
+        return "";
+      }
+      return String(result);
+    })();
+    """
+}
+
+private func taskCountsOmniAutomationScript(requestJSON: String) -> String {
+    return """
+    (function() {
+      var request = \(requestJSON);
+      var filter = request.filter || {};
+
+      function safe(fn) {
+        try { return fn(); } catch (e) { return null; }
+      }
+
+      function toTaskArray(collection) {
+        if (!collection) { return []; }
+        if (Array.isArray(collection)) { return collection; }
+        if (typeof collection.apply === "function") {
+          var items = [];
+          collection.apply(function(item) { items.push(item); });
+          return items;
+        }
+        try {
+          return Array.from(collection);
+        } catch (e) {
+          return [];
+        }
+      }
+
+      function inboxTasksArray() {
+        var inboxCollection = safe(function() { return inbox; });
+        return toTaskArray(inboxCollection);
+      }
+
+      function taskStatusName(task) {
+        var status = safe(function() { return task.taskStatus; });
+        var statusText = String(status);
+        if (statusText.indexOf("Completed") !== -1) { return "completed"; }
+        if (statusText.indexOf("Dropped") !== -1) { return "dropped"; }
+        if (statusText.indexOf("Available") !== -1) { return "available"; }
+        if (statusText.indexOf("DueSoon") !== -1) { return "dueSoon"; }
+        if (statusText.indexOf("Next") !== -1) { return "next"; }
+        if (statusText.indexOf("Overdue") !== -1) { return "overdue"; }
+        if (statusText.indexOf("Blocked") !== -1) { return "blocked"; }
+        if (status === Task.Status.Completed) { return "completed"; }
+        if (status === Task.Status.Dropped) { return "dropped"; }
+        if (status === Task.Status.Available) { return "available"; }
+        if (status === Task.Status.DueSoon) { return "dueSoon"; }
+        if (status === Task.Status.Next) { return "next"; }
+        if (status === Task.Status.Overdue) { return "overdue"; }
+        if (status === Task.Status.Blocked) { return "blocked"; }
+        return "unknown";
+      }
+
+      function projectStatusName(project) {
+        var status = safe(function() { return project.status; });
+        var statusText = String(status);
+        if (statusText.indexOf("OnHold") !== -1) { return "onHold"; }
+        if (statusText.indexOf("Dropped") !== -1) { return "dropped"; }
+        if (statusText.indexOf("Done") !== -1) { return "done"; }
+        if (statusText.indexOf("Active") !== -1) { return "active"; }
+        if (status === Project.Status.OnHold) { return "onHold"; }
+        if (status === Project.Status.Dropped) { return "dropped"; }
+        if (status === Project.Status.Done) { return "done"; }
+        if (status === Project.Status.Active) { return "active"; }
+        return "unknown";
+      }
+
+      function isCompletedStatus(task) {
+        return taskStatusName(task) === "completed";
+      }
+
+      function isDroppedStatus(task) {
+        return taskStatusName(task) === "dropped";
+      }
+
+      function isRemainingStatus(task) {
+        var statusName = taskStatusName(task);
+        return statusName !== "completed" && statusName !== "dropped";
+      }
+
+      function isAvailableStatus(task) {
+        var statusName = taskStatusName(task);
+        return statusName === "available" ||
+          statusName === "dueSoon" ||
+          statusName === "next" ||
+          statusName === "overdue";
+      }
+
+      function projectMatchesView(project, view, allowOnHoldInEverything) {
+        if (!project) { return false; }
+        if (!view || view === "all") { return true; }
+
+        var normalizedView = String(view).toLowerCase();
+        if (normalizedView === "everything") { return true; }
+        var allowOnHold = allowOnHoldInEverything && normalizedView === "everything";
+        var statusName = projectStatusName(project);
+
+        if (statusName === "active") { return normalizedView === "active"; }
+        if (statusName === "onHold") {
+          return allowOnHold || normalizedView === "onhold" || normalizedView === "on_hold";
+        }
+        if (statusName === "dropped") { return normalizedView === "dropped"; }
+        if (statusName === "done") {
+          return normalizedView === "done" || normalizedView === "completed";
+        }
+        return false;
+      }
+
+      function parentAllowsAvailability(task) {
+        var parent = safe(function() { return task.parent; });
+        if (!parent) { return true; }
+        return !isCompletedStatus(parent) && !isDroppedStatus(parent);
+      }
+
+      function isTaskAvailable(task) {
+        if (!parentAllowsAvailability(task)) { return false; }
+
+        var project = safe(function() { return task.containingProject; });
+        if (project) {
+          var projectStatus = projectStatusName(project);
+          if (projectStatus !== "active") { return false; }
+        }
+
+        return isAvailableStatus(task);
+      }
+
+      function parseFilterDate(dateString) {
+        if (!dateString || typeof dateString !== "string") { return null; }
+        var parsed = new Date(dateString);
+        if (isNaN(parsed.getTime())) { return null; }
+        return parsed;
+      }
+
+      function getTaskDateTimestamp(task, getter) {
+        var value = safe(function() { return getter(task); });
+        if (!value || typeof value.getTime !== "function") { return null; }
+        var timestamp = value.getTime();
+        if (isNaN(timestamp)) { return null; }
+        return timestamp;
+      }
+
+      function projectIdentifier(project) {
+        return String(safe(function() { return project.id.primaryKey; }) || "");
+      }
+
+      function projectName(project) {
+        return String(safe(function() { return project.name; }) || "");
+      }
+
+      function resolveProject(projectFilter, projects) {
+        if (!projectFilter || typeof projectFilter !== "string") { return null; }
+        for (var i = 0; i < projects.length; i += 1) {
+          var project = projects[i];
+          if (projectIdentifier(project) === projectFilter || projectName(project) === projectFilter) {
+            return project;
+          }
+        }
+        return null;
+      }
+
+      function tagMatchesFilter(task, filterTags, untaggedOnly) {
+        var tags = safe(function() { return task.tags; }) || [];
+        if (untaggedOnly) {
+          return tags.length === 0;
+        }
+
+        for (var i = 0; i < tags.length; i += 1) {
+          var tag = tags[i];
+          var tagID = String(safe(function() { return tag.id.primaryKey; }) || "");
+          var tagName = String(safe(function() { return tag.name; }) || "");
+          for (var j = 0; j < filterTags.length; j += 1) {
+            var filterTag = filterTags[j];
+            if (tagID === filterTag || tagName === filterTag) {
+              return true;
+            }
+          }
+        }
+
+        return false;
+      }
+
+      var allProjects = toTaskArray(safe(function() { return flattenedProjects; }));
+      var allTasks = toTaskArray(safe(function() { return flattenedTasks; }));
+      var inboxView = (typeof filter.inboxView === "string") ? filter.inboxView.toLowerCase() : "available";
+      var isEverything = inboxView === "everything";
+      var isRemaining = inboxView === "remaining";
+      var projectView = (typeof filter.projectView === "string") ? filter.projectView.toLowerCase() : null;
+      var availableOnly = (typeof filter.availableOnly === "boolean")
+        ? filter.availableOnly
+        : (filter.completed === true ? false : !isRemaining && !isEverything);
+
+      var baseTasks = [];
+      if (filter.inboxOnly === true) {
+        baseTasks = inboxTasksArray();
+      } else {
+        var project = resolveProject(filter.project, allProjects);
+        if (filter.project && !project) {
+          baseTasks = [];
+        } else if (project) {
+          baseTasks = toTaskArray(safe(function() { return project.flattenedTasks; }));
+        } else {
+          baseTasks = allTasks;
+        }
+      }
+
+      var filterState = {
+        completed: filter.completed,
+        flagged: filter.flagged,
+        availableOnly: availableOnly,
+        projectFilter: filter.project,
+        projectView: projectView,
+        dueBefore: filter.dueBefore ? parseFilterDate(filter.dueBefore) : null,
+        dueAfter: filter.dueAfter ? parseFilterDate(filter.dueAfter) : null,
+        plannedBefore: filter.plannedBefore ? parseFilterDate(filter.plannedBefore) : null,
+        plannedAfter: filter.plannedAfter ? parseFilterDate(filter.plannedAfter) : null,
+        deferBefore: filter.deferBefore ? parseFilterDate(filter.deferBefore) : null,
+        deferAfter: filter.deferAfter ? parseFilterDate(filter.deferAfter) : null,
+        completedBefore: filter.completedBefore ? parseFilterDate(filter.completedBefore) : null,
+        completedAfter: filter.completedAfter ? parseFilterDate(filter.completedAfter) : null,
+        tags: Array.isArray(filter.tags) ? filter.tags : null,
+        untaggedOnly: Array.isArray(filter.tags) && filter.tags.length === 0,
+        maxEstimatedMinutes: filter.maxEstimatedMinutes,
+        minEstimatedMinutes: filter.minEstimatedMinutes
+      };
+
+      function matchesFilters(task) {
+        var project = safe(function() { return task.containingProject; });
+
+        if (filterState.completed !== undefined) {
+          if (isCompletedStatus(task) !== filterState.completed) { return false; }
+        } else if (!isEverything) {
+          if (!isRemainingStatus(task)) { return false; }
+        }
+
+        if (filterState.flagged !== undefined) {
+          if (Boolean(safe(function() { return task.flagged; })) !== filterState.flagged) { return false; }
+        }
+
+        if (filterState.availableOnly && !isTaskAvailable(task)) { return false; }
+
+        if (filterState.projectFilter) {
+          if (!project) { return false; }
+          if (projectIdentifier(project) !== filterState.projectFilter && projectName(project) !== filterState.projectFilter) {
+            return false;
+          }
+        }
+
+        if (filterState.projectView) {
+          if (!projectMatchesView(project, filterState.projectView, true)) { return false; }
+        }
+
+        if (filterState.dueBefore) {
+          var dueBefore = getTaskDateTimestamp(task, function(item) { return item.dueDate; });
+          if (dueBefore === null || dueBefore > filterState.dueBefore.getTime()) { return false; }
+        }
+        if (filterState.dueAfter) {
+          var dueAfter = getTaskDateTimestamp(task, function(item) { return item.dueDate; });
+          if (dueAfter === null || dueAfter < filterState.dueAfter.getTime()) { return false; }
+        }
+        if (filterState.deferBefore) {
+          var deferBefore = getTaskDateTimestamp(task, function(item) { return item.deferDate; });
+          if (deferBefore === null || deferBefore > filterState.deferBefore.getTime()) { return false; }
+        }
+        if (filterState.deferAfter) {
+          var deferAfter = getTaskDateTimestamp(task, function(item) { return item.deferDate; });
+          if (deferAfter === null || deferAfter < filterState.deferAfter.getTime()) { return false; }
+        }
+        if (filterState.plannedBefore) {
+          var plannedBefore = getTaskDateTimestamp(task, function(item) { return item.plannedDate; });
+          if (plannedBefore === null || plannedBefore > filterState.plannedBefore.getTime()) { return false; }
+        }
+        if (filterState.plannedAfter) {
+          var plannedAfter = getTaskDateTimestamp(task, function(item) { return item.plannedDate; });
+          if (plannedAfter === null || plannedAfter < filterState.plannedAfter.getTime()) { return false; }
+        }
+        if (filterState.completedBefore) {
+          var completedBefore = getTaskDateTimestamp(task, function(item) { return item.completionDate; });
+          if (completedBefore === null || completedBefore > filterState.completedBefore.getTime()) { return false; }
+        }
+        if (filterState.completedAfter) {
+          var completedAfter = getTaskDateTimestamp(task, function(item) { return item.completionDate; });
+          if (completedAfter === null || completedAfter < filterState.completedAfter.getTime()) { return false; }
+        }
+
+        if (filterState.maxEstimatedMinutes !== undefined) {
+          var maxMinutes = safe(function() { return task.estimatedMinutes; });
+          if (maxMinutes === null || maxMinutes === undefined || maxMinutes > filterState.maxEstimatedMinutes) { return false; }
+        }
+        if (filterState.minEstimatedMinutes !== undefined) {
+          var minMinutes = safe(function() { return task.estimatedMinutes; });
+          if (minMinutes === null || minMinutes === undefined || minMinutes < filterState.minEstimatedMinutes) { return false; }
+        }
+
+        if (filterState.tags && !tagMatchesFilter(task, filterState.tags, filterState.untaggedOnly)) {
+          return false;
+        }
+
+        return true;
+      }
+
+      var counts = { total: 0, completed: 0, available: 0, flagged: 0 };
+      for (var i = 0; i < baseTasks.length; i += 1) {
+        var task = baseTasks[i];
+        if (!matchesFilters(task)) { continue; }
+        counts.total += 1;
+        if (isCompletedStatus(task)) { counts.completed += 1; }
+        if (isTaskAvailable(task)) { counts.available += 1; }
+        if (Boolean(safe(function() { return task.flagged; }))) { counts.flagged += 1; }
+      }
+
+      return JSON.stringify(counts);
+    })();
+    """
+}
+
+private func projectCountsOmniAutomationScript(requestJSON: String) -> String {
+    return """
+    (function() {
+      var request = \(requestJSON);
+      var filter = request.filter || {};
+
+      function safe(fn) {
+        try { return fn(); } catch (e) { return null; }
+      }
+
+      function toTaskArray(collection) {
+        if (!collection) { return []; }
+        if (Array.isArray(collection)) { return collection; }
+        if (typeof collection.apply === "function") {
+          var items = [];
+          collection.apply(function(item) { items.push(item); });
+          return items;
+        }
+        try {
+          return Array.from(collection);
+        } catch (e) {
+          return [];
+        }
+      }
+
+      function taskStatusName(task) {
+        var status = safe(function() { return task.taskStatus; });
+        var statusText = String(status);
+        if (statusText.indexOf("Completed") !== -1) { return "completed"; }
+        if (statusText.indexOf("Dropped") !== -1) { return "dropped"; }
+        if (statusText.indexOf("Available") !== -1) { return "available"; }
+        if (statusText.indexOf("DueSoon") !== -1) { return "dueSoon"; }
+        if (statusText.indexOf("Next") !== -1) { return "next"; }
+        if (statusText.indexOf("Overdue") !== -1) { return "overdue"; }
+        if (statusText.indexOf("Blocked") !== -1) { return "blocked"; }
+        if (status === Task.Status.Completed) { return "completed"; }
+        if (status === Task.Status.Dropped) { return "dropped"; }
+        if (status === Task.Status.Available) { return "available"; }
+        if (status === Task.Status.DueSoon) { return "dueSoon"; }
+        if (status === Task.Status.Next) { return "next"; }
+        if (status === Task.Status.Overdue) { return "overdue"; }
+        if (status === Task.Status.Blocked) { return "blocked"; }
+        return "unknown";
+      }
+
+      function projectStatusName(project) {
+        var status = safe(function() { return project.status; });
+        var statusText = String(status);
+        if (statusText.indexOf("OnHold") !== -1) { return "onHold"; }
+        if (statusText.indexOf("Dropped") !== -1) { return "dropped"; }
+        if (statusText.indexOf("Done") !== -1) { return "done"; }
+        if (statusText.indexOf("Active") !== -1) { return "active"; }
+        if (status === Project.Status.OnHold) { return "onHold"; }
+        if (status === Project.Status.Dropped) { return "dropped"; }
+        if (status === Project.Status.Done) { return "done"; }
+        if (status === Project.Status.Active) { return "active"; }
+        return "unknown";
+      }
+
+      function isCompletedStatus(task) {
+        return taskStatusName(task) === "completed";
+      }
+
+      function isDroppedStatus(task) {
+        return taskStatusName(task) === "dropped";
+      }
+
+      function isRemainingStatus(task) {
+        var statusName = taskStatusName(task);
+        return statusName !== "completed" && statusName !== "dropped";
+      }
+
+      function isAvailableStatus(task) {
+        var statusName = taskStatusName(task);
+        return statusName === "available" ||
+          statusName === "dueSoon" ||
+          statusName === "next" ||
+          statusName === "overdue";
+      }
+
+      function projectMatchesView(project, view, allowOnHoldInEverything) {
+        if (!project) { return false; }
+        if (!view || view === "all") { return true; }
+
+        var normalizedView = String(view).toLowerCase();
+        if (normalizedView === "everything") { return true; }
+        var allowOnHold = allowOnHoldInEverything && normalizedView === "everything";
+        var statusName = projectStatusName(project);
+
+        if (statusName === "active") { return normalizedView === "active"; }
+        if (statusName === "onHold") {
+          return allowOnHold || normalizedView === "onhold" || normalizedView === "on_hold";
+        }
+        if (statusName === "dropped") { return normalizedView === "dropped"; }
+        if (statusName === "done") {
+          return normalizedView === "done" || normalizedView === "completed";
+        }
+        return false;
+      }
+
+      function parentAllowsAvailability(task) {
+        var parent = safe(function() { return task.parent; });
+        if (!parent) { return true; }
+        return !isCompletedStatus(parent) && !isDroppedStatus(parent);
+      }
+
+      function isTaskAvailable(task) {
+        if (!parentAllowsAvailability(task)) { return false; }
+
+        var project = safe(function() { return task.containingProject; });
+        if (project) {
+          var projectStatus = projectStatusName(project);
+          if (projectStatus !== "active") { return false; }
+        }
+
+        return isAvailableStatus(task);
+      }
+
+      function parseFilterDate(dateString) {
+        if (!dateString || typeof dateString !== "string") { return null; }
+        var parsed = new Date(dateString);
+        if (isNaN(parsed.getTime())) { return null; }
+        return parsed;
+      }
+
+      function getTaskDateTimestamp(task, getter) {
+        var value = safe(function() { return getter(task); });
+        if (!value || typeof value.getTime !== "function") { return null; }
+        var timestamp = value.getTime();
+        if (isNaN(timestamp)) { return null; }
+        return timestamp;
+      }
+
+      function getProjectDateTimestamp(project, getter) {
+        var value = safe(function() { return getter(project); });
+        if (!value || typeof value.getTime !== "function") { return null; }
+        var timestamp = value.getTime();
+        if (isNaN(timestamp)) { return null; }
+        return timestamp;
+      }
+
+      function projectIdentifier(project) {
+        return String(safe(function() { return project.id.primaryKey; }) || "");
+      }
+
+      function projectName(project) {
+        return String(safe(function() { return project.name; }) || "");
+      }
+
+      function resolveProject(projectFilter, projects) {
+        if (!projectFilter || typeof projectFilter !== "string") { return null; }
+        for (var i = 0; i < projects.length; i += 1) {
+          var project = projects[i];
+          if (projectIdentifier(project) === projectFilter || projectName(project) === projectFilter) {
+            return project;
+          }
+        }
+        return null;
+      }
+
+      function tagMatchesFilter(task, filterTags, untaggedOnly) {
+        var tags = safe(function() { return task.tags; }) || [];
+        if (untaggedOnly) {
+          return tags.length === 0;
+        }
+
+        for (var i = 0; i < tags.length; i += 1) {
+          var tag = tags[i];
+          var tagID = String(safe(function() { return tag.id.primaryKey; }) || "");
+          var tagName = String(safe(function() { return tag.name; }) || "");
+          for (var j = 0; j < filterTags.length; j += 1) {
+            var filterTag = filterTags[j];
+            if (tagID === filterTag || tagName === filterTag) {
+              return true;
+            }
+          }
+        }
+
+        return false;
+      }
+
+      var allProjects = toTaskArray(safe(function() { return flattenedProjects; }));
+      var allTasks = toTaskArray(safe(function() { return flattenedTasks; }));
+      var completedAfter = filter.completedAfter ? parseFilterDate(filter.completedAfter) : null;
+      var completedBefore = filter.completedBefore ? parseFilterDate(filter.completedBefore) : null;
+      var completedOnly = filter.completed === true;
+
+      if (completedOnly || completedAfter || completedBefore) {
+        var completedProjects = [];
+        for (var i = 0; i < allProjects.length; i += 1) {
+          var completedProject = allProjects[i];
+          if (projectStatusName(completedProject) !== "done") { continue; }
+          var projectCompletionDate = getProjectDateTimestamp(completedProject, function(item) { return item.completionDate; });
+          if (projectCompletionDate === null) { continue; }
+          if (completedAfter && projectCompletionDate < completedAfter.getTime()) { continue; }
+          if (completedBefore && projectCompletionDate > completedBefore.getTime()) { continue; }
+          completedProjects.push(completedProject);
+        }
+
+        var completedProjectIDs = {};
+        for (var projectIndex = 0; projectIndex < completedProjects.length; projectIndex += 1) {
+          var completedProjectID = projectIdentifier(completedProjects[projectIndex]);
+          if (completedProjectID) {
+            completedProjectIDs[completedProjectID] = true;
+          }
+        }
+
+        var completedTaskCount = 0;
+        for (var taskIndex = 0; taskIndex < allTasks.length; taskIndex += 1) {
+          var completedTask = allTasks[taskIndex];
+          var containingProject = safe(function() { return completedTask.containingProject; });
+          if (!containingProject) { continue; }
+          var containingProjectID = projectIdentifier(containingProject);
+          if (!completedProjectIDs[containingProjectID]) { continue; }
+          if (!isCompletedStatus(completedTask)) { continue; }
+
+          var taskCompletionDate = getTaskDateTimestamp(completedTask, function(item) { return item.completionDate; });
+          if (taskCompletionDate === null) { continue; }
+          if (completedAfter && taskCompletionDate < completedAfter.getTime()) { continue; }
+          if (completedBefore && taskCompletionDate > completedBefore.getTime()) { continue; }
+          completedTaskCount += 1;
+        }
+
+        return JSON.stringify({
+          projects: completedProjects.length,
+          actions: completedTaskCount
+        });
+      }
+
+      var rawProjectView = (typeof filter.projectView === "string") ? filter.projectView.toLowerCase() : "remaining";
+      var projectStatusView = (
+        rawProjectView === "active" ||
+        rawProjectView === "onhold" ||
+        rawProjectView === "on_hold" ||
+        rawProjectView === "dropped" ||
+        rawProjectView === "done" ||
+        rawProjectView === "completed" ||
+        rawProjectView === "everything" ||
+        rawProjectView === "all"
+      ) ? rawProjectView : null;
+
+      var derivedCompleted = (typeof filter.completed === "boolean")
+        ? filter.completed
+        : (rawProjectView === "everything" ? undefined : false);
+      var derivedAvailableOnly = (typeof filter.availableOnly === "boolean")
+        ? filter.availableOnly
+        : (rawProjectView === "available");
+
+      var resolvedProject = resolveProject(filter.project, allProjects);
+      var baseTasks = [];
+      if (filter.project && !resolvedProject) {
+        baseTasks = [];
+      } else if (resolvedProject) {
+        baseTasks = toTaskArray(safe(function() { return resolvedProject.flattenedTasks; }));
+      } else {
+        baseTasks = allTasks;
+      }
+
+      var filterState = {
+        completed: derivedCompleted,
+        flagged: filter.flagged,
+        availableOnly: derivedAvailableOnly,
+        projectFilter: filter.project,
+        projectView: projectStatusView,
+        dueBefore: filter.dueBefore ? parseFilterDate(filter.dueBefore) : null,
+        dueAfter: filter.dueAfter ? parseFilterDate(filter.dueAfter) : null,
+        plannedBefore: filter.plannedBefore ? parseFilterDate(filter.plannedBefore) : null,
+        plannedAfter: filter.plannedAfter ? parseFilterDate(filter.plannedAfter) : null,
+        deferBefore: filter.deferBefore ? parseFilterDate(filter.deferBefore) : null,
+        deferAfter: filter.deferAfter ? parseFilterDate(filter.deferAfter) : null,
+        completedBefore: filter.completedBefore ? parseFilterDate(filter.completedBefore) : null,
+        completedAfter: filter.completedAfter ? parseFilterDate(filter.completedAfter) : null,
+        tags: Array.isArray(filter.tags) ? filter.tags : null,
+        untaggedOnly: Array.isArray(filter.tags) && filter.tags.length === 0,
+        maxEstimatedMinutes: filter.maxEstimatedMinutes,
+        minEstimatedMinutes: filter.minEstimatedMinutes
+      };
+
+      function matchesFilters(task) {
+        var project = safe(function() { return task.containingProject; });
+        if (!project) { return false; }
+
+        if (filterState.completed !== undefined) {
+          if (isCompletedStatus(task) !== filterState.completed) { return false; }
+        } else if (rawProjectView !== "everything") {
+          if (!isRemainingStatus(task)) { return false; }
+        }
+
+        if (filterState.flagged !== undefined) {
+          if (Boolean(safe(function() { return task.flagged; })) !== filterState.flagged) { return false; }
+        }
+        if (filterState.availableOnly && !isTaskAvailable(task)) { return false; }
+
+        if (filterState.projectFilter) {
+          if (projectIdentifier(project) !== filterState.projectFilter && projectName(project) !== filterState.projectFilter) {
+            return false;
+          }
+        }
+
+        if (filterState.projectView) {
+          if (!projectMatchesView(project, filterState.projectView, true)) { return false; }
+        }
+
+        if (filterState.dueBefore) {
+          var dueBefore = getTaskDateTimestamp(task, function(item) { return item.dueDate; });
+          if (dueBefore === null || dueBefore > filterState.dueBefore.getTime()) { return false; }
+        }
+        if (filterState.dueAfter) {
+          var dueAfter = getTaskDateTimestamp(task, function(item) { return item.dueDate; });
+          if (dueAfter === null || dueAfter < filterState.dueAfter.getTime()) { return false; }
+        }
+        if (filterState.deferBefore) {
+          var deferBefore = getTaskDateTimestamp(task, function(item) { return item.deferDate; });
+          if (deferBefore === null || deferBefore > filterState.deferBefore.getTime()) { return false; }
+        }
+        if (filterState.deferAfter) {
+          var deferAfter = getTaskDateTimestamp(task, function(item) { return item.deferDate; });
+          if (deferAfter === null || deferAfter < filterState.deferAfter.getTime()) { return false; }
+        }
+        if (filterState.plannedBefore) {
+          var plannedBefore = getTaskDateTimestamp(task, function(item) { return item.plannedDate; });
+          if (plannedBefore === null || plannedBefore > filterState.plannedBefore.getTime()) { return false; }
+        }
+        if (filterState.plannedAfter) {
+          var plannedAfter = getTaskDateTimestamp(task, function(item) { return item.plannedDate; });
+          if (plannedAfter === null || plannedAfter < filterState.plannedAfter.getTime()) { return false; }
+        }
+        if (filterState.completedBefore) {
+          var completedBeforeTimestamp = getTaskDateTimestamp(task, function(item) { return item.completionDate; });
+          if (completedBeforeTimestamp === null || completedBeforeTimestamp > filterState.completedBefore.getTime()) { return false; }
+        }
+        if (filterState.completedAfter) {
+          var completedAfterTimestamp = getTaskDateTimestamp(task, function(item) { return item.completionDate; });
+          if (completedAfterTimestamp === null || completedAfterTimestamp < filterState.completedAfter.getTime()) { return false; }
+        }
+        if (filterState.maxEstimatedMinutes !== undefined) {
+          var maxMinutes = safe(function() { return task.estimatedMinutes; });
+          if (maxMinutes === null || maxMinutes === undefined || maxMinutes > filterState.maxEstimatedMinutes) { return false; }
+        }
+        if (filterState.minEstimatedMinutes !== undefined) {
+          var minMinutes = safe(function() { return task.estimatedMinutes; });
+          if (minMinutes === null || minMinutes === undefined || minMinutes < filterState.minEstimatedMinutes) { return false; }
+        }
+        if (filterState.tags && !tagMatchesFilter(task, filterState.tags, filterState.untaggedOnly)) {
+          return false;
+        }
+
+        return true;
+      }
+
+      var projectIDs = {};
+      var actionCount = 0;
+      for (var baseIndex = 0; baseIndex < baseTasks.length; baseIndex += 1) {
+        var task = baseTasks[baseIndex];
+        if (!matchesFilters(task)) { continue; }
+        var taskProject = safe(function() { return task.containingProject; });
+        if (!taskProject) { continue; }
+        var taskProjectID = projectIdentifier(taskProject);
+        if (taskProjectID) {
+          projectIDs[taskProjectID] = true;
+        }
+        actionCount += 1;
+      }
+
+      return JSON.stringify({
+        projects: Object.keys(projectIDs).length,
+        actions: actionCount
+      });
+    })();
+    """
+}
+
+private func jsStringLiteral(_ value: String) -> String {
+    let data = try? JSONEncoder().encode(value)
+    return data.flatMap { String(data: $0, encoding: .utf8) } ?? "\"\""
 }

--- a/Sources/OmniFocusAutomation/SerializedJXARunner.swift
+++ b/Sources/OmniFocusAutomation/SerializedJXARunner.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+final class SerializedJXARunner: @unchecked Sendable {
+    private let runner: ScriptRunner
+    private let queue: DispatchQueue
+    private let lock = NSLock()
+    private let defaultTimeout: TimeInterval
+
+    init(runner: ScriptRunner, defaultTimeout: TimeInterval = 15.0) {
+        self.runner = runner
+        self.defaultTimeout = defaultTimeout
+        self.queue = DispatchQueue(label: "focusrelay.omni.jxa.serial", qos: .utility)
+    }
+
+    func runJavaScript(_ source: String, timeout: TimeInterval? = nil) throws -> String {
+        let timeout = timeout ?? defaultTimeout
+        let done = DispatchSemaphore(value: 0)
+        let resultBox = ResultBox()
+
+        queue.async { [runner, lock] in
+            lock.lock()
+            defer { lock.unlock() }
+            autoreleasepool {
+                do {
+                    let output = try runner.runJavaScript(source)
+                    resultBox.store(.success(output))
+                } catch {
+                    resultBox.store(.failure(error))
+                }
+            }
+            done.signal()
+        }
+
+        if done.wait(timeout: .now() + timeout) == .timedOut {
+            throw AutomationError.executionFailed("JXA execution timed out after \(Int(timeout))s")
+        }
+
+        guard let result = resultBox.load() else {
+            throw AutomationError.executionFailed("JXA execution failed without a result")
+        }
+        return try result.get()
+    }
+}
+
+private final class ResultBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Result<String, Error>?
+
+    func store(_ result: Result<String, Error>) {
+        lock.lock()
+        value = result
+        lock.unlock()
+    }
+
+    func load() -> Result<String, Error>? {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}

--- a/Tests/OmniFocusIntegrationTests/BridgeClientTests.swift
+++ b/Tests/OmniFocusIntegrationTests/BridgeClientTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+@testable import OmniFocusAutomation
+
+@Test
+func bridgeClientConfigurationDefaults() {
+    let configuration = BridgeClientConfiguration.fromEnvironment([:])
+
+    #expect(configuration.responseTimeout == 45.0)
+    #expect(configuration.responsePollInterval == 0.05)
+}
+
+@Test
+func bridgeClientConfigurationUsesEnvironmentOverrides() {
+    let configuration = BridgeClientConfiguration.fromEnvironment([
+        "FOCUS_RELAY_BRIDGE_RESPONSE_TIMEOUT_SECONDS": "30",
+        "FOCUS_RELAY_BRIDGE_RESPONSE_POLL_MS": "25"
+    ])
+
+    #expect(configuration.responseTimeout == 30.0)
+    #expect(configuration.responsePollInterval == 0.025)
+}
+
+@Test
+func bridgeClientConfigurationIgnoresInvalidEnvironmentOverrides() {
+    let configuration = BridgeClientConfiguration.fromEnvironment([
+        "FOCUS_RELAY_BRIDGE_RESPONSE_TIMEOUT_SECONDS": "0",
+        "FOCUS_RELAY_BRIDGE_RESPONSE_POLL_MS": "-1"
+    ])
+
+    #expect(configuration.responseTimeout == 45.0)
+    #expect(configuration.responsePollInterval == 0.05)
+}
+
+@Test
+func strandedRedispatchDelayIsBounded() {
+    #expect(strandedRedispatchDelay(timeout: 45.0) == 2.0)
+    #expect(abs(strandedRedispatchDelay(timeout: 12.0) - 1.2) < 0.000_001)
+    #expect(strandedRedispatchDelay(timeout: 3.0) == 0.5)
+}

--- a/Tests/OmniFocusIntegrationTests/BridgeClientTests.swift
+++ b/Tests/OmniFocusIntegrationTests/BridgeClientTests.swift
@@ -49,6 +49,13 @@ func strandedRedispatchDelayIsBounded() {
 }
 
 @Test
+func lateStrandedRecoveryGraceIsBounded() {
+    #expect(lateStrandedRecoveryGrace(timeout: 45.0) == 9.0)
+    #expect(abs(lateStrandedRecoveryGrace(timeout: 12.0) - 3.0) < 0.000_001)
+    #expect(lateStrandedRecoveryGrace(timeout: 120.0) == 10.0)
+}
+
+@Test
 func bridgeDispatchTransportDefaultsToURL() {
     #expect(BridgeDispatchTransport.fromEnvironment([:]) == .urlScheme)
     #expect(BridgeDispatchTransport.fromEnvironment(["FOCUS_RELAY_BRIDGE_DISPATCH_TRANSPORT": "url"]) == .urlScheme)
@@ -67,4 +74,35 @@ func buildBridgeDispatchScriptUsesStableDispatchRequestFile() {
     #expect(script.contains("/dispatch/request.json"))
     #expect(!script.contains("var requestId = argument;"))
     #expect(script.contains("handleRequest(requestId, basePath)"))
+}
+
+@Test
+func lateStrandedRecoveryOnlyAppliesToURLTransportWithoutLock() {
+    #expect(shouldAttemptLateStrandedRecovery(
+        transport: .urlScheme,
+        requestExists: true,
+        responseExists: false,
+        lockExists: false
+    ))
+
+    #expect(!shouldAttemptLateStrandedRecovery(
+        transport: .urlScheme,
+        requestExists: true,
+        responseExists: false,
+        lockExists: true
+    ))
+
+    #expect(!shouldAttemptLateStrandedRecovery(
+        transport: .jxaEvaluate,
+        requestExists: true,
+        responseExists: false,
+        lockExists: false
+    ))
+
+    #expect(!shouldAttemptLateStrandedRecovery(
+        transport: .urlScheme,
+        requestExists: false,
+        responseExists: false,
+        lockExists: false
+    ))
 }

--- a/Tests/OmniFocusIntegrationTests/BridgeClientTests.swift
+++ b/Tests/OmniFocusIntegrationTests/BridgeClientTests.swift
@@ -8,28 +8,37 @@ func bridgeClientConfigurationDefaults() {
 
     #expect(configuration.responseTimeout == 45.0)
     #expect(configuration.responsePollInterval == 0.05)
+    #expect(configuration.dispatchTransport == .urlScheme)
+    #expect(configuration.dispatchTimeout == 20.0)
 }
 
 @Test
 func bridgeClientConfigurationUsesEnvironmentOverrides() {
     let configuration = BridgeClientConfiguration.fromEnvironment([
         "FOCUS_RELAY_BRIDGE_RESPONSE_TIMEOUT_SECONDS": "30",
-        "FOCUS_RELAY_BRIDGE_RESPONSE_POLL_MS": "25"
+        "FOCUS_RELAY_BRIDGE_RESPONSE_POLL_MS": "25",
+        "FOCUS_RELAY_BRIDGE_DISPATCH_TRANSPORT": "jxa",
+        "FOCUS_RELAY_BRIDGE_DISPATCH_TIMEOUT_SECONDS": "18"
     ])
 
     #expect(configuration.responseTimeout == 30.0)
     #expect(configuration.responsePollInterval == 0.025)
+    #expect(configuration.dispatchTransport == .jxaEvaluate)
+    #expect(configuration.dispatchTimeout == 18.0)
 }
 
 @Test
 func bridgeClientConfigurationIgnoresInvalidEnvironmentOverrides() {
     let configuration = BridgeClientConfiguration.fromEnvironment([
         "FOCUS_RELAY_BRIDGE_RESPONSE_TIMEOUT_SECONDS": "0",
-        "FOCUS_RELAY_BRIDGE_RESPONSE_POLL_MS": "-1"
+        "FOCUS_RELAY_BRIDGE_RESPONSE_POLL_MS": "-1",
+        "FOCUS_RELAY_BRIDGE_DISPATCH_TIMEOUT_SECONDS": "0"
     ])
 
     #expect(configuration.responseTimeout == 45.0)
     #expect(configuration.responsePollInterval == 0.05)
+    #expect(configuration.dispatchTransport == .urlScheme)
+    #expect(configuration.dispatchTimeout == 20.0)
 }
 
 @Test
@@ -37,4 +46,25 @@ func strandedRedispatchDelayIsBounded() {
     #expect(strandedRedispatchDelay(timeout: 45.0) == 2.0)
     #expect(abs(strandedRedispatchDelay(timeout: 12.0) - 1.2) < 0.000_001)
     #expect(strandedRedispatchDelay(timeout: 3.0) == 0.5)
+}
+
+@Test
+func bridgeDispatchTransportDefaultsToURL() {
+    #expect(BridgeDispatchTransport.fromEnvironment([:]) == .urlScheme)
+    #expect(BridgeDispatchTransport.fromEnvironment(["FOCUS_RELAY_BRIDGE_DISPATCH_TRANSPORT": "url"]) == .urlScheme)
+}
+
+@Test
+func bridgeDispatchTransportSupportsJXA() {
+    #expect(BridgeDispatchTransport.fromEnvironment(["FOCUS_RELAY_BRIDGE_DISPATCH_TRANSPORT": "jxa"]) == .jxaEvaluate)
+    #expect(BridgeDispatchTransport.fromEnvironment(["FOCUS_RELAY_BRIDGE_DISPATCH_TRANSPORT": "JXA"]) == .jxaEvaluate)
+}
+
+@Test
+func buildBridgeDispatchScriptUsesStableDispatchRequestFile() {
+    let script = buildBridgeDispatchScript(basePath: "/tmp/focusrelay")
+
+    #expect(script.contains("/dispatch/request.json"))
+    #expect(!script.contains("var requestId = argument;"))
+    #expect(script.contains("handleRequest(requestId, basePath)"))
 }

--- a/Tests/OmniFocusIntegrationTests/OmniFocusIntegrationTests.swift
+++ b/Tests/OmniFocusIntegrationTests/OmniFocusIntegrationTests.swift
@@ -131,8 +131,12 @@ func bridgeAndJXAListTasksParityLive() async throws {
 
     var scenarios: [(String, TaskFilter)] = [
         ("default", TaskFilter(includeTotalCount: true)),
+        ("defaultNoTotal", TaskFilter(includeTotalCount: false)),
         ("inboxOnly", TaskFilter(inboxOnly: true, includeTotalCount: true)),
+        ("inboxOnlyNoTotal", TaskFilter(inboxOnly: true, includeTotalCount: false)),
         ("availableOnly", TaskFilter(availableOnly: true, includeTotalCount: true)),
+        ("availableOnlyNoTotal", TaskFilter(availableOnly: true, includeTotalCount: false)),
+        ("flaggedOnlyNoTotal", TaskFilter(flagged: true, includeTotalCount: false)),
         ("completedAfterEpoch", TaskFilter(completed: true, completedAfter: Date(timeIntervalSince1970: 0), includeTotalCount: true))
     ]
 

--- a/Tests/OmniFocusIntegrationTests/OmniFocusIntegrationTests.swift
+++ b/Tests/OmniFocusIntegrationTests/OmniFocusIntegrationTests.swift
@@ -88,6 +88,111 @@ func bridgeTaskCountsLive() throws {
 }
 
 @Test
+func bridgeAndJXATaskCountsParityLive() async throws {
+    let env = ProcessInfo.processInfo.environment
+    guard env["FOCUS_RELAY_PARITY_TESTS"] == "1" else {
+        return
+    }
+
+    let bridge = OmniFocusBridgeService()
+    let automation = OmniAutomationService()
+    let scenarios: [(String, TaskFilter)] = [
+        ("default", TaskFilter()),
+        ("inboxOnly", TaskFilter(inboxOnly: true)),
+        ("availableOnly", TaskFilter(availableOnly: true)),
+        ("completedAfterEpoch", TaskFilter(completed: true, completedAfter: Date(timeIntervalSince1970: 0))),
+        ("flaggedOnly", TaskFilter(flagged: true))
+    ]
+
+    for (name, filter) in scenarios {
+        let bridgeCounts = try await retryTaskCounts(service: bridge, filter: filter)
+        let jxaCounts = try await retryTaskCounts(service: automation, filter: filter)
+        #expect(
+            bridgeCounts.total == jxaCounts.total &&
+                bridgeCounts.completed == jxaCounts.completed &&
+                bridgeCounts.available == jxaCounts.available &&
+                bridgeCounts.flagged == jxaCounts.flagged,
+            "Task counts mismatch for scenario=\(name). bridge=\(bridgeCounts) jxa=\(jxaCounts)"
+        )
+    }
+}
+
+@Test
+func bridgeAndJXAListTasksParityLive() async throws {
+    let env = ProcessInfo.processInfo.environment
+    guard env["FOCUS_RELAY_PARITY_TESTS"] == "1" else {
+        return
+    }
+
+    let bridge = OmniFocusBridgeService()
+    let automation = OmniAutomationService()
+    let page = PageRequest(limit: 50)
+    let fields = ["id", "name", "completed", "available", "completionDate"]
+
+    var scenarios: [(String, TaskFilter)] = [
+        ("default", TaskFilter(includeTotalCount: true)),
+        ("inboxOnly", TaskFilter(inboxOnly: true, includeTotalCount: true)),
+        ("availableOnly", TaskFilter(availableOnly: true, includeTotalCount: true)),
+        ("completedAfterEpoch", TaskFilter(completed: true, completedAfter: Date(timeIntervalSince1970: 0), includeTotalCount: true))
+    ]
+
+    let activeProjects = try await bridge.listProjects(
+        page: PageRequest(limit: 10),
+        statusFilter: "active",
+        includeTaskCounts: false,
+        reviewDueBefore: nil,
+        reviewDueAfter: nil,
+        reviewPerspective: false,
+        completed: nil,
+        completedBefore: nil,
+        completedAfter: nil,
+        fields: ["id", "name"]
+    )
+    if let projectID = activeProjects.items.first?.id, !projectID.isEmpty {
+        scenarios.append(("projectScopedSimple", TaskFilter(project: projectID, includeTotalCount: true)))
+    }
+
+    for (name, filter) in scenarios {
+        let bridgePage = try await retryListTasks(service: bridge, filter: filter, page: page, fields: fields)
+        let jxaPage = try await retryListTasks(service: automation, filter: filter, page: page, fields: fields)
+
+        #expect((bridgePage.totalCount ?? -1) == (jxaPage.totalCount ?? -1), "totalCount mismatch on scenario=\(name)")
+        #expect(bridgePage.returnedCount == jxaPage.returnedCount, "returnedCount mismatch on scenario=\(name)")
+        #expect(bridgePage.nextCursor == jxaPage.nextCursor, "nextCursor mismatch on scenario=\(name)")
+
+        let bridgeIDs = bridgePage.items.map(\.id)
+        let jxaIDs = jxaPage.items.map(\.id)
+        #expect(bridgeIDs == jxaIDs, "item ID ordering mismatch on scenario=\(name)")
+    }
+}
+
+@Test
+func bridgeAndJXAProjectCountsParityLive() async throws {
+    let env = ProcessInfo.processInfo.environment
+    guard env["FOCUS_RELAY_PARITY_TESTS"] == "1" else {
+        return
+    }
+
+    let bridge = OmniFocusBridgeService()
+    let automation = OmniAutomationService()
+    let scenarios: [(String, TaskFilter)] = [
+        ("projectViewRemaining", TaskFilter(projectView: "remaining")),
+        ("projectViewActive", TaskFilter(projectView: "active")),
+        ("completedAfterEpoch", TaskFilter(completed: true, completedAfter: Date(timeIntervalSince1970: 0)))
+    ]
+
+    for (name, filter) in scenarios {
+        let bridgeCounts = try await retryProjectCounts(service: bridge, filter: filter)
+        let jxaCounts = try await retryProjectCounts(service: automation, filter: filter)
+        #expect(
+            bridgeCounts.projects == jxaCounts.projects &&
+                bridgeCounts.actions == jxaCounts.actions,
+            "Project counts mismatch for scenario=\(name). bridge=\(bridgeCounts) jxa=\(jxaCounts)"
+        )
+    }
+}
+
+@Test
 func bridgeInboxViewCountsMatchListTasksLive() throws {
     let env = ProcessInfo.processInfo.environment
     guard env["FOCUS_RELAY_BRIDGE_TESTS"] == "1" else {
@@ -259,6 +364,50 @@ func bridgeProjectCountsLive() throws {
     let counts = try client.getProjectCounts(filter: TaskFilter(projectView: "remaining"))
     #expect(counts.projects >= 0)
     #expect(counts.actions >= 0)
+}
+
+@Test
+func bridgeProjectCountsActiveMatchesListTasksTotalLive() async throws {
+    let env = ProcessInfo.processInfo.environment
+    guard env["FOCUS_RELAY_PARITY_TESTS"] == "1" else {
+        return
+    }
+
+    let service = OmniFocusBridgeService()
+    let filter = TaskFilter(
+        completed: false,
+        availableOnly: false,
+        projectView: "active",
+        includeTotalCount: true
+    )
+
+    let counts = try await retryProjectCounts(service: service, filter: filter)
+    let page = try await retryListTasks(service: service, filter: filter, page: PageRequest(limit: 50), fields: ["id"])
+    if let total = page.totalCount {
+        #expect(counts.actions == total)
+    }
+}
+
+@Test
+func jxaProjectCountsActiveMatchesListTasksTotalLive() async throws {
+    let env = ProcessInfo.processInfo.environment
+    guard env["FOCUS_RELAY_PARITY_TESTS"] == "1" else {
+        return
+    }
+
+    let service = OmniAutomationService()
+    let filter = TaskFilter(
+        completed: false,
+        availableOnly: false,
+        projectView: "active",
+        includeTotalCount: true
+    )
+
+    let counts = try await retryProjectCounts(service: service, filter: filter)
+    let page = try await retryListTasks(service: service, filter: filter, page: PageRequest(limit: 50), fields: ["id"])
+    if let total = page.totalCount {
+        #expect(counts.actions == total)
+    }
 }
 
 @Test
@@ -616,5 +765,58 @@ func bridgePlannedDateFiltersReturnOnlyPlannedTasksLive() throws {
     // If there are planned tasks, all returned rows must include plannedDate.
     if !page.items.isEmpty {
         #expect(page.items.allSatisfy { $0.plannedDate != nil })
+    }
+}
+
+private func retryTaskCounts(
+    service: any OmniFocusService,
+    filter: TaskFilter,
+    maxAttempts: Int = 3
+) async throws -> TaskCounts {
+    try await retryOperation(maxAttempts: maxAttempts) {
+        try await service.getTaskCounts(filter: filter)
+    }
+}
+
+private func retryListTasks(
+    service: any OmniFocusService,
+    filter: TaskFilter,
+    page: PageRequest,
+    fields: [String],
+    maxAttempts: Int = 3
+) async throws -> Page<TaskItem> {
+    try await retryOperation(maxAttempts: maxAttempts) {
+        try await service.listTasks(filter: filter, page: page, fields: fields)
+    }
+}
+
+private func retryProjectCounts(
+    service: any OmniFocusService,
+    filter: TaskFilter,
+    maxAttempts: Int = 3
+) async throws -> ProjectCounts {
+    try await retryOperation(maxAttempts: maxAttempts) {
+        try await service.getProjectCounts(filter: filter)
+    }
+}
+
+private func retryOperation<T>(
+    maxAttempts: Int,
+    delaySeconds: TimeInterval = 1.0,
+    _ operation: @escaping () async throws -> T
+) async throws -> T {
+    var attempt = 0
+    while true {
+        attempt += 1
+        do {
+            return try await operation()
+        } catch {
+            let isTimeout = error.localizedDescription.lowercased().contains("timed out")
+                || error.localizedDescription.lowercased().contains("timeout")
+            if !isTimeout || attempt >= maxAttempts {
+                throw error
+            }
+            try? await Task.sleep(nanoseconds: UInt64(delaySeconds * 1_000_000_000))
+        }
     }
 }

--- a/agents.md
+++ b/agents.md
@@ -4,6 +4,10 @@
 - Do not add `swift-testing` as a package dependency.
 - Add or update Swift tests when new functionality is added.
 - Run `swift test` after changes.
+- Production query paths must use only documented Omni Automation APIs.
+- If an Omni Automation property or collection is not documented on the official OmniFocus site, do not use it in core query logic.
+- When in doubt, prefer `flattenedTasks` plus `task.taskStatus` filtering and `flattenedProjects` plus `project.status` filtering.
+- Query-engine changes must follow `docs/omni-automation-contract.md`.
 
 ## Code Review Checklist
 

--- a/docs/PLAN to improve reliability and performance.md
+++ b/docs/PLAN to improve reliability and performance.md
@@ -1,0 +1,242 @@
+# Reset Plan From `master` For The Fastest FocusRelayMCP
+
+Status: Completed on clean branch `exp/master-documented-query-baseline`
+Date: 2026-03-16
+Associated issue: `#19`
+
+## Final Status Update
+
+This plan was executed on the clean branch and is now complete enough to close the optimization phase.
+
+Completed:
+- documented Omni Automation contract was added and enforced
+- benchmark gates and repeatable benchmark tooling were added
+- `get_task_counts` was optimized and validated
+- `list_tasks` was hardened and optimized on `plugin-url`
+- `get_project_counts` was corrected, optimized, and validated
+- corrected transport A/B was completed
+- architecture decision was made to keep `plugin-url`
+
+Rejected during execution:
+- replacing the plugin with pure JXA
+- switching default transport to `plugin-jxa-dispatch`
+- request-scoped availability memoization in `list_tasks`
+
+Deferred to future phases:
+- cache strategy work
+- runtime-pressure recovery beyond the current hardening
+- any additional transport experiments
+
+Primary closeout document:
+- `docs/final-optimization-summary-2026-03-16.md`
+
+## Summary
+- Start over from `master` and treat the previous experimental branch as a learning artifact, not an implementation base.
+- Choose **bridge plugin as the primary architecture** for performance work. Keep **pure JXA** only as a reference implementation for parity and benchmarking, not as the target fastest architecture.
+- Keep **URL + bridge** as the initial baseline from `master`. Do **not** change dispatch transport until query semantics and benchmarks are stable. Re-evaluate **JXA + bridge dispatch** only as a later isolated A/B experiment.
+- Enforce a **documented Omni Automation contract** before any optimization work. No undocumented `project.availableTasks`, `project.remainingTasks`, database `availableTasks`, or database `remainingTasks` in core query paths.
+
+## What I Would Tell My Past Self
+- We mixed too many variables at once: query optimization, dispatch transport, approval-UX fixes, benchmark harness changes, and semantic fixes. That made the results impossible to trust.
+- We benchmarked before we locked semantic invariants. That let us optimize incorrect behavior.
+- We relied on undocumented Omni Automation collections and assumed they behaved consistently across plugin and `evaluateJavascript`. That was the core technical mistake.
+- We used live tests with env gates, which made “green” runs less meaningful than they looked.
+- We over-invested in transport changes before proving the query engine was the dominant bottleneck.
+
+## Architecture Choice
+- **Primary read architecture**: bridge plugin query engine, starting from `master`’s URL dispatch.
+- **Reference architecture**: pure JXA `evaluateJavascript`, used only for parity probes and controlled benchmarks.
+- **Deferred experiment**: JXA dispatch into bridge plugin, but only after query semantics are frozen and benchmark gates are passing.
+
+### Final Result
+- The benchmark evidence on the clean branch supports **keeping `plugin-url`**.
+- Pure JXA is not the production architecture.
+- `plugin-jxa-dispatch` is not the replacement transport.
+
+Supporting document:
+- `docs/transport-decision-2026-03-13.md`
+
+## The Architecture I Would Rebuild
+1. **Bridge query engine only uses documented Omni Automation surface**
+- Enumerate tasks from documented `flattenedTasks` / `project.flattenedTasks`.
+- Enumerate projects from documented `flattenedProjects`.
+- Use `task.taskStatus` and `project.status` as the status source of truth.
+- Derive remaining/available/completed from documented status values, not from convenience pools unless the docs explicitly define them.
+
+2. **Pure JXA is a verifier, not the product path**
+- Implement the same documented query model in JXA.
+- Use it to cross-check counts and ordering on a fixed scenario matrix.
+- Do not use pure JXA latency to drive query-engine design for the main architecture.
+
+3. **Dispatch is isolated from query work**
+- Phase 1: keep `master` transport as-is.
+- Phase 2: once semantics are frozen, run a matched A/B of:
+  - plugin-url
+  - plugin-jxa-dispatch
+- Decide dispatch only from those matched runs.
+
+## Benchmark Strategy I Would Use Instead
+### Benchmark gates before any soak run
+- Reject any run if parity mismatches are nonzero on the scoped scenarios.
+- Reject any run if bridge `get_task_counts` disagrees with bridge `list_tasks.totalCount` where they should match.
+- Reject any run if bridge `get_project_counts(projectView=active)` disagrees with bridge `list_tasks(projectView=active, completed=false, availableOnly=false).totalCount`.
+- Reject any run if OmniFocus approval prompts appear.
+- Reject any run if restart/preflight is not explicit and logged.
+
+### Run sequence
+1. **Baseline on `master`, no code changes**
+- Capture:
+  - plugin-url baseline
+  - pure-JXA baseline
+- Tools:
+  - `get_task_counts`
+  - `list_tasks`
+  - `get_project_counts`
+- Durations:
+  - 10-minute smoke
+  - 1-hour short
+- No overnight yet.
+
+2. **One-tool optimization cycle**
+- Pick one tool only.
+- Lock its semantic contract.
+- Add or update parity tests.
+- Run:
+  - 10-minute smoke
+  - 1-hour short
+  - 3-hour soak
+- Only after 3-hour clean: include it in overnight.
+
+3. **Dispatch experiment only after query work**
+- Same commit, same database, same scenario set.
+- Compare:
+  - plugin-url
+  - plugin-jxa-dispatch
+- Keep pure JXA as reference in the same suite.
+- No query changes allowed during this phase.
+
+### Metrics that actually matter
+- Primary:
+  - p95 latency
+  - timeout rate
+  - parity mismatch count
+- Secondary:
+  - p50/p99
+  - RSS slope for OmniFocus and `focusrelay`
+- Tertiary:
+  - cold-start behavior after restart
+  - approval-prompt incidence
+
+### Final interpretation update
+- The stress profile was useful to expose runtime-pressure failure modes.
+- For future product validation, use the realistic benchmark profile in:
+  - `docs/realistic-benchmark-profile-2026-03-16.md`
+
+### Tool-by-tool acceptance criteria
+- `get_task_counts`
+  - zero parity mismatches
+  - error rate < 1% in 3h
+  - p95 better than master baseline
+  - Status: complete enough for this phase
+- `list_tasks`
+  - zero parity mismatches on IDs, ordering, `totalCount`, and cursor continuity
+  - plugin remains materially faster than pure JXA
+  - Status: complete enough for this phase
+- `get_project_counts`
+  - zero parity mismatches
+  - active-view counts must match the corresponding `list_tasks` contract exactly before benchmarking performance claims
+  - Status: complete enough for this phase
+
+## How I Would Stay On Track Better
+1. **Write a local Omni Automation contract before coding**
+- Add `docs/omni-automation-contract.md`.
+- It should be a short synthesized document, not a copy of the official site.
+- It should list:
+  - allowed documented collections/properties
+  - banned undocumented collections/properties
+  - links to the official docs
+
+2. **Update `AGENTS.md` with a hard rule, not the whole docs**
+- Add a compact section:
+  - “Only use documented Omni Automation APIs in query engines.”
+  - “If an API is not documented on the official site, do not use it in production query paths.”
+  - “When in doubt, prefer `flattenedTasks` + status filtering.”
+- Link `AGENTS.md` to `docs/omni-automation-contract.md` and the official docs.
+- Do not dump the full docs into `AGENTS.md`; synthesize them into enforceable repo rules.
+
+3. **Make semantic checks first-class**
+- Add bridge-vs-JXA parity tests that are on by default only in a clearly named live-test mode.
+- Add a small dev command or test helper that prints per-status counts for a filter.
+- Never benchmark a tool whose parity gate is failing.
+
+4. **Separate orchestration from measurement**
+- No giant chained shell commands.
+- Use explicit steps:
+  - restart
+  - bridge health check
+  - JXA probe
+  - smoke benchmark
+- Store each step’s result separately.
+
+5. **Keep a branch rule**
+- One branch per experiment:
+  - query optimization
+  - dispatch transport
+  - approval UX
+- Never combine them.
+
+## The Step-By-Step Restart Plan
+1. Branch from `master`.
+- Name it something like `exp/master-documented-query-baseline`.
+
+2. Add the contract doc first.
+- `docs/omni-automation-contract.md`
+- No behavior changes yet.
+
+3. Freeze the baseline.
+- Run matched plugin-url and pure-JXA baselines from `master`.
+- Save:
+  - 10-minute smoke
+  - 1-hour short
+- Record benchmark SHA and environment notes.
+
+4. Rebuild `get_task_counts` first.
+- Use only documented APIs.
+- Keep bridge as target path.
+- Use pure JXA as verifier.
+- Benchmark only this tool.
+- Status: completed in this phase.
+
+5. Rebuild `list_tasks` second.
+- Same documented-only model.
+- This is likely the most important performance path.
+- Benchmark only this tool.
+- Status: completed in this phase.
+
+6. Rebuild `get_project_counts` last.
+- Define its contract from `list_tasks` first.
+- Do not invent a separate inclusion model.
+- Benchmark only after parity is exact.
+- Status: completed in this phase.
+
+7. Only then run the dispatch experiment.
+- A/B:
+  - plugin-url
+  - plugin-jxa-dispatch
+- Same commit, same database, same tool set, no query changes.
+- Status: completed in this phase.
+
+## The Prompt I Would Give My Past Self
+“Start from `master`. Do not change dispatch transport, approval UX, and query semantics in the same branch. First create a short local contract from the official Omni Automation docs that lists only documented APIs allowed in query paths. Then freeze baseline benchmarks for plugin-url and pure-JXA on `get_task_counts`, `list_tasks`, and `get_project_counts`. Treat pure JXA as a parity/reference implementation, not the target fastest architecture. Optimize one tool at a time in the bridge plugin using only documented `flattenedTasks`, `flattenedProjects`, `task.taskStatus`, and `project.status`. Before any performance benchmark, require exact parity between bridge and JXA and exact consistency between count tools and their corresponding `list_tasks` totals. Run 10-minute smoke, then 1-hour short, then 3-hour soak. Only after all three tools are semantically stable should you evaluate plugin-jxa-dispatch versus plugin-url as a separate isolated transport experiment.”
+
+## Important Interface / Process Changes
+- Add `docs/omni-automation-contract.md`.
+- Add an `AGENTS.md` rule that production query paths must use documented Omni Automation APIs only.
+- Add explicit parity gates to the benchmark process.
+- No public MCP schema changes are required for the restart.
+
+## Assumptions And Defaults
+- “Fastest” means best p95 latency with acceptable reliability, not just best p50.
+- Maintainability matters: documented-only APIs are the default rule.
+- Bridge plugin remains the primary architecture unless a later isolated A/B proves otherwise.
+- Pure JXA remains a verifier and benchmark reference, not the main product path.

--- a/docs/final-optimization-summary-2026-03-16.md
+++ b/docs/final-optimization-summary-2026-03-16.md
@@ -1,0 +1,172 @@
+# Final Optimization Summary: 2026-03-16
+
+Branch:
+- `exp/master-documented-query-baseline`
+
+Associated issue:
+- `#19` `Performance: Add decision-safe fast paths for list_tasks (plugin + JXA, separate architectures)`
+
+## Final Decision
+
+1. Keep `plugin-url` as the default production architecture.
+2. Do not switch the product to pure JXA.
+3. Do not switch the product to `plugin-jxa-dispatch`.
+4. Treat pure JXA as a parity and benchmark reference path, not the main architecture.
+
+## Why
+
+The clean-branch work answered the architecture question well enough:
+- `plugin-url` remained the best overall production choice after a corrected transport A/B.
+- `plugin-jxa-dispatch` did not improve the system enough to justify a switch.
+- pure JXA simplified the shape of the system on paper, but did not outperform the plugin path on the highest-value tools.
+
+Primary supporting document:
+- `docs/transport-decision-2026-03-13.md`
+
+Primary transport A/B artifact:
+- `docs/benchmarks/transport-ab-safe-20260312-210547/`
+
+## What Was Completed
+
+### 1. Documented-only query discipline
+
+Completed:
+- added `docs/omni-automation-contract.md`
+- updated `agents.md` to require documented Omni Automation APIs in query engines
+- removed reliance on undocumented Omni Automation collections from the clean-branch optimization approach
+
+Outcome:
+- the branch now has a defensible rule for future query work
+- the previous mistake of optimizing against undocumented APIs should not be repeated
+
+### 2. Benchmark process hardening
+
+Completed:
+- added explicit benchmark gate checks
+- added per-tool benchmark commands for:
+  - `get_task_counts`
+  - `list_tasks`
+  - `get_project_counts`
+- added suite scripts and a transport A/B driver
+- separated restart, readiness, semantic gate, and measured benchmark steps
+- added timeout diagnostics for the tools that needed reliability investigation
+
+Outcome:
+- benchmark results on the clean branch are materially more trustworthy than the older mixed-experiment runs
+
+### 3. `get_task_counts`
+
+Completed:
+- documented-only implementation discipline on the clean branch
+- single-pass count path improvements
+- targeted fast paths for the validated benchmark scenarios
+- timeout diagnostics
+
+Outcome:
+- reliability became acceptable in the clean validation runs
+- plugin latency improved materially vs the clean baseline
+- no further `get_task_counts` optimization is justified right now
+
+Representative artifact:
+- `docs/benchmarks/task-counts-1h-post-fast-path-20260314-114300/summary.md`
+
+### 4. `list_tasks`
+
+Completed:
+- timeout recovery hardening on `plugin-url`
+- no-`totalCount` streaming path
+- counted streaming path for simple `includeTotalCount=true` scenarios
+- completion-sorted top-K path for completed-task queries
+- extended benchmark coverage for no-`totalCount` scenarios
+
+Outcome:
+- the clean branch removed the earlier plugin timeout pattern from the validated 1-hour run
+- no-`totalCount` scenarios are materially faster and are now benchmarked directly
+- completion-sorted queries improved without breaking parity
+- the branch is now at the point of diminishing returns for `list_tasks`
+
+Representative artifacts:
+- `docs/benchmarks/list-tasks-1h-post-hardening-20260313-145309/summary.md`
+- `docs/benchmarks/list-tasks-1h-post-stream-fast-path-20260314-2313/summary.md`
+- `docs/benchmarks/list-tasks-1h-post-completion-topk-20260315-1238/summary.md`
+
+### 5. `get_project_counts`
+
+Completed:
+- correctness alignment with the `list_tasks` contract
+- diagnostics for long-run timeout investigation
+- validated 3-hour soak on the clean branch
+
+Outcome:
+- semantics are stable
+- reliability became acceptable in the clean 3-hour soak
+- no further `get_project_counts` optimization is justified right now
+
+Representative artifact:
+- `docs/benchmarks/project-counts-soak-diag-20260309-132541/summary.md`
+
+## What Was Rejected
+
+### 1. Pure JXA as the production architecture
+
+Rejected because:
+- it did not justify replacing the plugin query engine on the high-value read path
+- it does not clearly outperform `plugin-url` in the final clean evidence
+- it moves complexity rather than eliminating it
+
+### 2. `plugin-jxa-dispatch` as the default transport
+
+Rejected because:
+- the corrected A/B did not show an overall system win
+- it did not solve `list_tasks`
+- it regressed `get_project_counts` reliability badly in the corrected transport A/B
+
+### 3. Request-scoped availability memoization in `list_tasks`
+
+Rejected because:
+- it regressed the 1-hour validation run
+- it introduced plugin timeouts without a defensible latency win
+
+Supporting artifact:
+- `docs/benchmarks/list-tasks-1h-post-availability-memo-20260315-2337/summary.md`
+
+Supporting note:
+- `docs/performance-progress-2026-03-15.md`
+
+## What Is Not Worth Optimizing Further Right Now
+
+1. `list_projects`
+2. `list_tags`
+3. transport replacement
+4. additional speculative JS micro-optimizations in `list_tasks`
+
+Reason:
+- the remaining tail cost increasingly reflects OmniFocus runtime pressure and collection access cost under sustained automation load, not clearly bad query code
+- further work here should be treated as a separate phase, not part of this optimization closeout
+
+## Practical Interpretation
+
+The stress benchmarks are harsher than normal single-user MCP usage.
+
+That matters because:
+- the validated clean-branch results are already good enough to justify stopping this optimization phase
+- the remaining worst-case latency tails are not strong evidence that the architecture is wrong
+- they are increasingly evidence that OmniFocus automation itself degrades under sustained pressure
+
+## Final Recommendation
+
+1. Merge the clean-branch optimization work.
+2. Keep `plugin-url` as the default architecture.
+3. Treat this optimization effort as complete.
+4. If future work is needed, open a new phase for either:
+   - realistic benchmark refinement
+   - cache strategy
+   - runtime-pressure recovery policy
+
+## Related Documents
+
+- `docs/PLAN to improve reliability and performance.md`
+- `docs/transport-decision-2026-03-13.md`
+- `docs/performance-progress-2026-03-14.md`
+- `docs/performance-progress-2026-03-15.md`
+- `docs/realistic-benchmark-profile-2026-03-16.md`

--- a/docs/omni-automation-contract.md
+++ b/docs/omni-automation-contract.md
@@ -1,0 +1,80 @@
+# Omni Automation Contract
+
+This document defines the Omni Automation APIs that are allowed in FocusRelay query engines.
+
+Scope:
+- `Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js`
+- `Sources/OmniFocusAutomation/OmniFocusAutomation.swift`
+- Any future query-engine helper that reads OmniFocus data
+
+Primary source:
+- [OmniFocus Omni Automation index](https://omni-automation.com/omnifocus/index.html)
+
+Relevant reference pages:
+- [Database](https://omni-automation.com/omnifocus/database.html)
+- [Project](https://omni-automation.com/omnifocus/project.html)
+- [Task](https://omni-automation.com/omnifocus/task.html)
+
+## Rules
+- Use only documented Omni Automation APIs in production query paths.
+- If an API or collection is not documented on the official site, do not use it in core query logic.
+- Prefer documented collection enumeration plus documented status filtering over convenience pools.
+- Keep plugin and JXA query semantics aligned to the same documented model.
+
+## Allowed documented surfaces
+
+### Database enumeration
+- `flattenedTasks`
+- `flattenedProjects`
+- `flattenedFolders`
+- `inbox`
+- `projects`
+- `tags`
+
+### Project enumeration and status
+- `project.flattenedTasks`
+- `project.tasks`
+- `project.status`
+- `project.task`
+- `project.tags`
+- `project.id`
+- `project.name`
+
+### Task enumeration and status
+- `task.taskStatus`
+- `task.containingProject`
+- `task.parent`
+- `task.tags`
+- `task.id`
+- `task.name`
+- `task.note`
+- `task.flagged`
+- `task.completed`
+- `task.completionDate`
+- `task.dueDate`
+- `task.deferDate`
+- `task.plannedDate`
+- `task.estimatedMinutes`
+- `task.inInbox`
+
+## Allowed derived patterns
+- Enumerate `flattenedTasks` and filter by `task.taskStatus`.
+- Enumerate `flattenedProjects` and filter by `project.status`.
+- Resolve project-scoped task queries from `project.flattenedTasks`.
+- Derive remaining/available/completed views from documented status values.
+
+## Banned undocumented core-query patterns
+Do not use these as the primary production query path unless the official docs explicitly document them in the future.
+
+- `project.remainingTasks`
+- `project.availableTasks`
+- database/global `remainingTasks`
+- database/global `availableTasks`
+- Any query path that depends on undocumented convenience collections for correctness
+
+## Review checklist
+Before merging query-engine changes, verify:
+- Every OmniFocus collection/property used by the query path appears on the official docs pages above.
+- `task.taskStatus` is the source of truth for task state.
+- `project.status` is the source of truth for project state.
+- Benchmarks are not run unless parity and count-contract gates pass.

--- a/docs/performance-progress-2026-03-14.md
+++ b/docs/performance-progress-2026-03-14.md
@@ -1,0 +1,128 @@
+# Performance Progress: 2026-03-14
+
+Branch:
+- `exp/master-documented-query-baseline`
+
+Scope:
+- Clean-branch performance and reliability work after the documented-only reset.
+- Production target remains `plugin-url` unless new evidence disproves the transport decision.
+
+## Current Status
+
+### `get_task_counts`
+
+Status:
+- Optimized
+- Reliability acceptable in the current clean-branch validation runs
+
+Key validation artifacts:
+- `docs/benchmarks/suite-post-listtasks-hardening-20260313-221745/get_task_counts/summary.md`
+- `docs/benchmarks/task-counts-1h-post-fast-path-20260314-114300/summary.md`
+
+Observed change in the 1-hour comparison:
+- plugin p50: `2609ms -> 2108ms`
+- plugin p95: `11078ms -> 9524ms`
+- plugin errors/timeouts: `0 -> 0`
+- parity mismatches: `0`
+
+Conclusion:
+- The documented single-pass + narrow fast-path work improved `get_task_counts` enough to treat it as complete for now.
+- Remaining latency is mostly OmniFocus/runtime pressure rather than obviously inefficient JS filtering.
+
+### `list_tasks`
+
+Status:
+- Reliability hardened
+- Shared-path cleanup validated
+- No-total-count streaming fast path implemented and directly validated
+
+Reliability validation artifacts:
+- Pre-hardening transport A/B baseline:
+  - `docs/benchmarks/transport-ab-safe-20260312-210547/plugin-url/list_tasks/summary.md`
+- Post-hardening 1-hour run:
+  - `docs/benchmarks/list-tasks-1h-post-hardening-20260313-145309/summary.md`
+
+Reliability conclusion:
+- plugin timeout rate dropped from `7.41%` (`8/108`) in the old transport A/B baseline to `0.00%` in the post-hardening 1-hour run.
+- This is the main reason the product continues to stay on `plugin-url`.
+
+Shared-path performance validation artifact:
+- `docs/benchmarks/list-tasks-1h-post-stream-fast-path-20260314-2313/summary.md`
+
+1-hour comparison against the post-hardening baseline:
+- `default`
+  - plugin p50: `8454ms -> 7204ms`
+  - plugin p95: `9355ms -> 8782ms`
+- `inbox_only`
+  - plugin p50: `644ms -> 550ms`
+  - plugin p95: `847ms -> 746ms`
+- `available_only`
+  - plugin p50: `8443ms -> 7345ms`
+  - plugin p95: `9568ms -> 10551ms`
+- `completed_after_anchor`
+  - plugin p50: `7139ms -> 6090ms`
+  - plugin p95: `7729ms -> 8008ms`
+- `flagged_only`
+  - plugin p50: `6999ms -> 6005ms`
+  - plugin p95: `7582ms -> 7685ms`
+- errors/timeouts: `0`
+- parity mismatches: `0`
+
+Interpretation:
+- The shared-path cleanup improved median latency across every benchmarked scenario.
+- Tail latency improved for `default` and `inbox_only`, but was mixed for the other benchmarked scenarios.
+- This is acceptable because reliability stayed clean and the benchmark harness does not exercise the new early-stop branch.
+
+Important benchmark limitation:
+- `BenchmarkListTasksCommand` currently sets `includeTotalCount=true` for every scenario.
+- That means the stock benchmark validates the shared path but not the new no-total-count early-stop path.
+
+Direct no-total-count validation:
+- Timed direct CLI calls on the same branch and runtime state:
+  - `.build/debug/focusrelay list-tasks --available-only true --fields id,name --limit 50`
+    - `real 5.97`
+  - `.build/debug/focusrelay list-tasks --available-only true --include-total-count --fields id,name --limit 50`
+    - `real 8.48`
+
+Conclusion:
+- The early-stop path is real and materially faster when callers do not request totals.
+- Current benchmark coverage should be extended later with explicit no-total-count scenarios before making stronger claims about that path.
+
+### `get_project_counts`
+
+Status:
+- Reliability acceptable
+- Semantics stable on the clean branch
+
+Key artifact:
+- `docs/benchmarks/project-counts-soak-diag-20260309-132541/summary.md`
+
+Result:
+- plugin: `1236/1236` success, `0` errors, `0` timeouts
+- jxa: `1236/1236` success, `0` errors, `0` timeouts
+- parity mismatches: `0`
+
+Conclusion:
+- `get_project_counts` is stable enough for now.
+- It remains slower than desired, but it is no longer the highest-priority blocker.
+
+## Architecture Position
+
+Current position remains unchanged:
+- Keep `plugin-url` as the production default.
+- Do not switch to `plugin-jxa-dispatch`.
+- Do not replace the plugin architecture with pure JXA.
+
+Primary rationale:
+- query semantics are stable enough to compare
+- transport simplification did not beat `plugin-url`
+- recent work improved `plugin-url` reliability enough that transport change is no longer the best lever
+
+Reference:
+- `docs/transport-decision-2026-03-13.md`
+
+## Next Practical Work
+
+1. If `list_tasks` remains the main performance focus, extend benchmark coverage with explicit no-total-count scenarios.
+2. Keep optimization work on `plugin-url`, not transport switching.
+3. Revisit lower-priority tools only after the high-value `list_tasks` path is fully benchmarked for both total-count and no-total-count workloads.

--- a/docs/performance-progress-2026-03-15.md
+++ b/docs/performance-progress-2026-03-15.md
@@ -184,3 +184,34 @@ The next optimization should be careful:
 - Keep `plugin-url` as the production default.
 - Keep optimizing `list_tasks` on the plugin path.
 - Use the extended benchmark for future `list_tasks` changes so no-total-count performance is measured directly rather than inferred.
+
+
+## Availability Memoization Experiment (Reverted)
+
+I tried one more `list_tasks` optimization after the completion-topK change:
+- request-scoped memoization for project availability state
+- request-scoped memoization for parent terminal status
+- reusing the resolved project inside the `availableOnly` filter path
+
+Artifacts:
+- `docs/benchmarks/list-tasks-smoke-post-availability-memo-20260315-2323/summary.md`
+- `docs/benchmarks/list-tasks-1h-post-availability-memo-20260315-2337/summary.md`
+- `docs/benchmarks/list-tasks-1h-post-availability-memo-20260315-2337/timeout-diagnostics.jsonl`
+
+Result:
+- smoke stayed semantically clean (`0` errors, `0` mismatches), but it was not directly comparable to the earlier smoke because it ran longer and accumulated more runtime pressure
+- the 1-hour validation was worse than the prior 1-hour baseline:
+  - plugin `default` p50/p95: `6671/7853 -> 8039/12598`
+  - plugin `available_only` p50/p95: `7041/8842 -> 8882/12508`
+  - plugin picked up `2` timeouts where the previous 1-hour run had `0`
+- timeout diagnostics showed a backed-up bridge queue with `lockExists=true` and no response file for the timed-out requests, plus OmniFocus RSS above `1 GB`
+
+Interpretation:
+- this memoization attempt did not produce a defensible win
+- even if some of the slowdown was environmental, the change did not improve the production path enough to justify keeping it
+- the experiment was reverted so the branch stays on the last proven `list_tasks` implementation
+
+Updated recommendation:
+- keep the completion-topK and streamed paging improvements
+- do not keep the request-scoped availability memoization attempt
+- treat the remaining `list_tasks` cost as dominated by OmniFocus runtime pressure and `flattenedTasks` access, not obviously by repeated JS availability checks

--- a/docs/performance-progress-2026-03-15.md
+++ b/docs/performance-progress-2026-03-15.md
@@ -104,6 +104,41 @@ Interpretation:
 - For the common simple non-inbox workloads, dropping `totalCount` saves roughly `300-400ms` in the smoke run.
 - The plugin path now beats JXA on the no-total-count `default` and `available_only` scenarios in this benchmark.
 
+### 1-hour validation after completion-topK optimization
+
+Artifact:
+- `docs/benchmarks/list-tasks-1h-post-completion-topk-20260315-1238/summary.md`
+
+Compared against the prior 1-hour baseline:
+- `docs/benchmarks/list-tasks-1h-post-stream-fast-path-20260314-2313/summary.md`
+
+Key plugin changes:
+- `default`
+  - p50: `7204ms -> 6671ms`
+  - p95: `8782ms -> 7853ms`
+- `available_only`
+  - p50: `7345ms -> 7041ms`
+  - p95: `10551ms -> 8842ms`
+- `completed_after_anchor`
+  - p50: `6090ms -> 5611ms`
+  - p95: `8008ms -> 8128ms`
+  - p99: `10975ms -> 8884ms`
+- `flagged_only`
+  - p50: `6005ms -> 5796ms`
+  - p95: `7685ms -> 7880ms`
+
+Reliability:
+- plugin errors/timeouts: `0`
+- jxa errors/timeouts: `0`
+- timeout diagnostics: `0`
+- parity mismatches: `1`
+
+Interpretation:
+- The completion-topK path is worth keeping.
+- It reduced median latency on every major benchmarked plugin scenario.
+- It improved the heavy completion-sorted path in the most important way: lower median and much better p99 without introducing failures.
+- Some p95 tails remain mixed, so this is an incremental improvement, not a final answer.
+
 ### Direct command timing retained as supporting evidence
 
 Earlier direct timing, still consistent with the benchmark trend:
@@ -130,19 +165,19 @@ Two distinct paths are now separated clearly:
 ## Next Optimization Target
 
 The next `list_tasks` work should focus on:
-- `completed_after_anchor`
-- any other completion-sorted workloads
+- `available_only` and `default` total-count workloads
+- specifically the cost of repeated availability checks inside the simple streamed path
 
 Reason:
-- simple available/default/flagged/inbox queries now have targeted fast paths
-- completion-sorted queries still fall back to full scan + full sort
-- that is now the clearest remaining high-cost path inside `list_tasks`
+- simple no-total-count workloads are now benchmarked and clearly faster
+- completion-sorted workloads now have a lower-cost top-K path
+- the remaining large cost center is the total-count simple path, especially `available_only`
 
 The next optimization should be careful:
-- preserve exact completion-date ordering
-- preserve cursor semantics
-- preserve total-count semantics
+- preserve exact `isTaskAvailable` semantics
+- preserve `totalCount` semantics
 - avoid introducing undocumented Omni Automation usage
+- prefer memoization or reused status/project state over new query-path branching
 
 ## Current Recommendation
 

--- a/docs/performance-progress-2026-03-15.md
+++ b/docs/performance-progress-2026-03-15.md
@@ -1,0 +1,151 @@
+# Performance Progress: 2026-03-15
+
+Branch:
+- `exp/master-documented-query-baseline`
+
+## Scope
+
+This update continues the clean-branch `list_tasks` work after:
+- transport choice was settled in favor of `plugin-url`
+- reliability hardening removed the old timeout pattern
+- initial streaming work proved that no-total-count workloads could avoid unnecessary full materialization
+
+## What Changed
+
+### 1. Extended `list_tasks` benchmark coverage
+
+Files:
+- `Sources/FocusRelayCLI/BenchmarkListTasksCommand.swift`
+- `Sources/FocusRelayCLI/BenchmarkGateCheckCommand.swift`
+- `Tests/OmniFocusIntegrationTests/OmniFocusIntegrationTests.swift`
+
+Changes:
+- Added explicit no-total-count scenarios to the benchmark:
+  - `default_no_total`
+  - `inbox_only_no_total`
+  - `available_only_no_total`
+  - `flagged_only_no_total`
+- Extended mismatch detection so parity is checked on:
+  - `returnedCount`
+  - `totalCount`
+  - `nextCursor`
+  - first item ID
+  - last item ID
+- Extended the semantic gate with no-total-count `list_tasks` checks.
+- Extended the live bridge-vs-JXA parity test with no-total-count scenarios.
+
+Result:
+- The benchmark now measures the path we actually optimized, rather than only the `includeTotalCount=true` path.
+
+### 2. Continued `list_tasks` optimization on `plugin-url`
+
+File:
+- `Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js`
+
+Change:
+- Added a counted streaming fast path for simple `includeTotalCount=true` queries when completion sorting is not required.
+- This means simple workloads can now:
+  - count matches
+  - collect the requested page
+  - avoid building a full filtered array of matching tasks
+
+The path is currently intended for documented-safe simple scenarios only:
+- default available view
+- inbox-only available view
+- available-only
+- flagged-only
+
+It is intentionally not used for completion-sorted scenarios.
+
+## Validation
+
+### Semantic gate
+
+Artifact:
+- `swift run focusrelay benchmark-gate-check --tool list-tasks`
+
+Result:
+- passed, including the new no-total-count scenarios
+
+Key checks that now pass:
+- `list_tasks_parity_default_no_total`
+- `list_tasks_parity_inbox_only_no_total`
+- `list_tasks_parity_available_only_no_total`
+- `list_tasks_parity_flagged_only_no_total`
+
+### Extended smoke benchmark
+
+Artifact:
+- `docs/benchmarks/list-tasks-smoke-post-counted-stream-20260315-1218/summary.md`
+
+Result:
+- plugin: `0` errors, `0` timeouts
+- jxa: `0` errors, `0` timeouts
+- parity mismatches: `0`
+
+### New no-total-count measurements
+
+Smoke result highlights:
+- `default`
+  - plugin p50 `2004.91ms`
+- `default_no_total`
+  - plugin p50 `1613.52ms`
+- `available_only`
+  - plugin p50 `1950.44ms`
+- `available_only_no_total`
+  - plugin p50 `1614.77ms`
+- `inbox_only`
+  - plugin p50 `223.12ms`
+- `inbox_only_no_total`
+  - plugin p50 `221.81ms`
+
+Interpretation:
+- The no-total-count path is now benchmarked directly.
+- For the common simple non-inbox workloads, dropping `totalCount` saves roughly `300-400ms` in the smoke run.
+- The plugin path now beats JXA on the no-total-count `default` and `available_only` scenarios in this benchmark.
+
+### Direct command timing retained as supporting evidence
+
+Earlier direct timing, still consistent with the benchmark trend:
+- `.build/debug/focusrelay list-tasks --available-only true --fields id,name --limit 50`
+  - `real 5.97`
+- `.build/debug/focusrelay list-tasks --available-only true --include-total-count --fields id,name --limit 50`
+  - `real 8.48`
+
+This remains useful as a spot check showing that early stop is a real wall-clock win.
+
+## What Was Actually Optimized
+
+Two distinct paths are now separated clearly:
+
+1. **No-total-count simple path**
+- Early stop after collecting enough rows for the page.
+- This is where the biggest direct savings appear.
+
+2. **Total-count simple path**
+- Still scans all matching tasks to compute `totalCount`.
+- But it no longer builds a full filtered task array before paging when completion sorting is not required.
+- This is a lower-risk, lower-gain optimization, but it reduces allocation pressure and keeps semantics intact.
+
+## Next Optimization Target
+
+The next `list_tasks` work should focus on:
+- `completed_after_anchor`
+- any other completion-sorted workloads
+
+Reason:
+- simple available/default/flagged/inbox queries now have targeted fast paths
+- completion-sorted queries still fall back to full scan + full sort
+- that is now the clearest remaining high-cost path inside `list_tasks`
+
+The next optimization should be careful:
+- preserve exact completion-date ordering
+- preserve cursor semantics
+- preserve total-count semantics
+- avoid introducing undocumented Omni Automation usage
+
+## Current Recommendation
+
+- Keep `plugin-url` as the production default.
+- Keep optimizing `list_tasks` on the plugin path.
+- Use the extended benchmark for future `list_tasks` changes so no-total-count performance is measured directly rather than inferred.

--- a/docs/realistic-benchmark-profile-2026-03-16.md
+++ b/docs/realistic-benchmark-profile-2026-03-16.md
@@ -1,0 +1,150 @@
+# Realistic Benchmark Profile: 2026-03-16
+
+Branch:
+- `exp/master-documented-query-baseline`
+
+## Purpose
+
+The original optimization work intentionally used aggressive stress benchmarks to expose reliability problems early.
+
+That was useful, but it is not the right default profile for ongoing product validation.
+
+This document defines three benchmark profiles:
+1. smoke validation
+2. realistic single-user validation
+3. stress/diagnostic validation
+
+## Recommended Default Profile
+
+Use the **realistic single-user validation** profile for routine regression checks.
+
+Reason:
+- FocusRelayMCP is a single-user OmniFocus integration
+- normal usage is not a constant 1.5-second hammering loop
+- this profile still exercises long-lived automation behavior without over-weighting unrealistic pressure
+
+## Profile 1: Smoke Validation
+
+Use when:
+- validating a targeted code change before a longer run
+- verifying plugin install + restart + semantic gate before spending more time
+
+Settings:
+- total duration: `10 minutes`
+- warmup calls per transport: `10`
+- interval: `2000ms`
+- cooldown after failure: `3000ms`
+- memory sampling: `60s`
+
+Recommended command:
+```bash
+cd /Users/deverman/Documents/Code/swift/FocusRelayMCP-master-baseline
+caffeinate -dimsu ./scripts/benchmark-suite.sh \
+  --total-hours 0.5 \
+  --warmup-calls 10 \
+  --interval-ms 2000 \
+  --cooldown-ms 3000 \
+  --memory-interval-seconds 60 \
+  --suite-dir docs/benchmarks/smoke-$(date +%Y%m%d-%H%M%S)
+```
+
+## Profile 2: Realistic Single-User Validation
+
+Use when:
+- evaluating whether a change is acceptable for likely real usage
+- checking regressions before merge
+- validating the default production path
+
+Settings:
+- total duration: `1.5 hours`
+- per tool: `30 minutes`
+- warmup calls per transport: `10`
+- interval: `5000ms`
+- cooldown after failure: `5000ms`
+- memory sampling: `60s`
+
+Recommended command:
+```bash
+cd /Users/deverman/Documents/Code/swift/FocusRelayMCP-master-baseline
+caffeinate -dimsu ./scripts/benchmark-suite.sh \
+  --total-hours 1.5 \
+  --warmup-calls 10 \
+  --interval-ms 5000 \
+  --cooldown-ms 5000 \
+  --memory-interval-seconds 60 \
+  --suite-dir docs/benchmarks/realistic-$(date +%Y%m%d-%H%M%S)
+```
+
+Interpretation rule:
+- use this profile to make product decisions
+- do not let the harsher stress profile override this one unless it exposes a deterministic correctness bug
+
+## Profile 3: Stress / Diagnostic Validation
+
+Use when:
+- investigating runtime pressure
+- debugging timeout patterns
+- validating recovery behavior after transport or query-engine changes
+
+Settings:
+- total duration: `3 hours`
+- warmup calls per transport: `20`
+- interval: `1500ms`
+- cooldown after failure: `3000ms`
+- memory sampling: `30s`
+
+Recommended command:
+```bash
+cd /Users/deverman/Documents/Code/swift/FocusRelayMCP-master-baseline
+caffeinate -dimsu ./scripts/benchmark-suite.sh \
+  --total-hours 3 \
+  --warmup-calls 20 \
+  --interval-ms 1500 \
+  --cooldown-ms 3000 \
+  --memory-interval-seconds 30 \
+  --suite-dir docs/benchmarks/stress-$(date +%Y%m%d-%H%M%S)
+```
+
+Interpretation rule:
+- use this profile to diagnose tail behavior and queue pressure
+- do not treat it as the only benchmark that matters for a single-user product
+
+## Transport A/B Profile
+
+Use when:
+- re-evaluating transport only
+- query semantics are already frozen
+- you are explicitly comparing `plugin-url` and `plugin-jxa-dispatch`
+
+Settings:
+- total duration: `3 hours`
+- transport driver: `scripts/benchmark-transport-ab.sh`
+- same interval and cooldown as the stress profile by default
+
+Recommended command:
+```bash
+cd /Users/deverman/Documents/Code/swift/FocusRelayMCP-master-baseline
+RUN_ROOT="docs/benchmarks/transport-ab-$(date +%Y%m%d-%H%M%S)"
+caffeinate -dimsu ./scripts/benchmark-transport-ab.sh \
+  --total-hours 3 \
+  --warmup-calls 20 \
+  --interval-ms 1500 \
+  --cooldown-ms 3000 \
+  --memory-interval-seconds 30 \
+  --run-root "$RUN_ROOT"
+```
+
+## Decision Rules
+
+1. Always run semantic gates before benchmark interpretation.
+2. Use smoke first after a code change.
+3. Use the realistic profile for merge confidence.
+4. Use the stress profile only when investigating reliability or runtime-pressure behavior.
+5. Do not mix query changes and transport changes in the same benchmark program.
+
+## Current Recommendation
+
+For future work on this branch:
+- default benchmark profile: **realistic single-user validation**
+- stress profile: **diagnostic only**
+- transport A/B: **only for isolated transport experiments**

--- a/docs/transport-decision-2026-03-13.md
+++ b/docs/transport-decision-2026-03-13.md
@@ -143,3 +143,27 @@ Until new evidence disproves this decision:
 - do not make architecture decisions from any benchmark run unless the transport implementation is verified first
 - do not compare transports and query changes in the same experiment
 - treat pure JXA as a reference/verification path, not the production architecture
+
+## Post-Decision Validation (2026-03-14)
+
+Subsequent clean-branch work reinforced the decision to stay on `plugin-url`.
+
+Relevant artifacts:
+- Full clean suite after `list_tasks` hardening:
+  - `docs/benchmarks/suite-post-listtasks-hardening-20260313-221745/summary.md`
+- `list_tasks` post-hardening 1-hour run:
+  - `docs/benchmarks/list-tasks-1h-post-hardening-20260313-145309/summary.md`
+- `list_tasks` post-stream-fast-path 1-hour run:
+  - `docs/benchmarks/list-tasks-1h-post-stream-fast-path-20260314-2313/summary.md`
+- Progress note:
+  - `docs/performance-progress-2026-03-14.md`
+
+What changed after the decision:
+- `list_tasks` timeout recovery was hardened on `plugin-url`.
+- The old plugin timeout pattern in the transport A/B no longer reproduced in the clean 1-hour validation run.
+- A later shared-path cleanup and no-total-count streaming path improved `list_tasks` median latency further without introducing new reliability failures.
+
+Updated interpretation:
+- `plugin-url` remains the best current production choice.
+- The transport question is no longer the main optimization lever.
+- Further work should continue to target query/runtime behavior on `plugin-url` rather than transport replacement.

--- a/docs/transport-decision-2026-03-13.md
+++ b/docs/transport-decision-2026-03-13.md
@@ -1,0 +1,145 @@
+# Transport Decision: Keep `plugin-url` As Default
+
+Date: 2026-03-13
+
+Branch at decision time:
+- `exp/master-documented-query-baseline`
+
+Decision:
+- Keep `plugin-url` as the default production transport.
+- Do not switch the product to `plugin-jxa-dispatch`.
+- Do not replace the plugin architecture with pure JXA.
+
+## Context
+
+This decision was made after:
+- rebuilding the benchmark process on the clean baseline branch
+- enforcing documented Omni Automation usage for query logic
+- stabilizing benchmark orchestration with a foreground `caffeinate` run
+- running a corrected transport A/B on the same commit and database
+
+Corrected benchmark root:
+- `docs/benchmarks/transport-ab-safe-20260312-210547`
+
+Corrected benchmark commit:
+- `744dfac568c3beaa090ed91e2d6650545c9909d6`
+
+## Important Correction
+
+An earlier transport A/B result was invalid and must not be used for architecture decisions.
+
+Why it was invalid:
+- the benchmark metadata recorded `FOCUS_RELAY_BRIDGE_DISPATCH_TRANSPORT`
+- but the clean-branch `BridgeClient` was still always using URL dispatch
+- so the earlier "plugin-jxa-dispatch" run was not actually exercising the JXA dispatch path
+
+Fix commit:
+- `8ff72be` `Implement real bridge transport selection`
+
+After that fix, a real JXA-dispatch smoke benchmark for `list_tasks` passed and proved the transport switch was active:
+- `docs/benchmarks/list-tasks-smoke-jxa-dispatch-real-20260310-084429/summary.md`
+
+## Corrected A/B Result
+
+### `get_task_counts`
+
+Artifacts:
+- `docs/benchmarks/transport-ab-safe-20260312-210547/plugin-url/get_task_counts/summary.md`
+- `docs/benchmarks/transport-ab-safe-20260312-210547/plugin-jxa-dispatch/get_task_counts/summary.md`
+
+Result:
+- `plugin-url`
+  - plugin error rate: `0.47%`
+  - plugin p50: `9170ms`
+  - plugin p95: `12858ms`
+- `plugin-jxa-dispatch`
+  - plugin error rate: `0.58%`
+  - plugin p50: `11440ms`
+  - plugin p95: `14551ms`
+
+Conclusion:
+- `plugin-url` is better for `get_task_counts`
+
+### `list_tasks`
+
+Artifacts:
+- `docs/benchmarks/transport-ab-safe-20260312-210547/plugin-url/list_tasks/summary.md`
+- `docs/benchmarks/transport-ab-safe-20260312-210547/plugin-jxa-dispatch/list_tasks/summary.md`
+
+Result:
+- `plugin-url`
+  - plugin timeouts: `8`
+  - plugin errors concentrated across multiple scenarios
+- `plugin-jxa-dispatch`
+  - plugin timeouts: `11`
+  - plugin errors also concentrated across multiple scenarios
+
+Conclusion:
+- neither transport is good enough yet
+- `plugin-jxa-dispatch` did not solve the main reliability problem
+
+### `get_project_counts`
+
+Artifacts:
+- `docs/benchmarks/transport-ab-safe-20260312-210547/plugin-url/get_project_counts/summary.md`
+- `docs/benchmarks/transport-ab-safe-20260312-210547/plugin-jxa-dispatch/get_project_counts/summary.md`
+
+Result:
+- `plugin-url`
+  - plugin error rate: `0.68%`
+  - plugin p50: `12398ms`
+  - plugin p95: `26592ms`
+- `plugin-jxa-dispatch`
+  - plugin error rate: `7.69%`
+  - plugin p50: `11768ms`
+  - plugin p95: `16238ms`
+
+Interpretation:
+- JXA dispatch reduced plugin latency tail in some cases
+- but the reliability regression is too large to accept
+
+Conclusion:
+- `plugin-jxa-dispatch` is not acceptable for `get_project_counts`
+
+## Parity
+
+All corrected A/B summaries reported:
+- mismatch count: `0`
+
+This means the functional comparison is trustworthy.
+
+## Final Decision Rationale
+
+`plugin-url` remains the correct default because:
+- it is better on `get_task_counts`
+- it is materially more reliable on `get_project_counts`
+- `plugin-jxa-dispatch` does not fix `list_tasks`
+- pure JXA still does not justify replacing the plugin architecture
+
+In short:
+- the transport simplification candidate (`plugin-jxa-dispatch`) did not improve the system enough to justify a switch
+- the product should stay on the existing plugin query engine with URL dispatch while reliability work continues
+
+## Follow-up Direction
+
+The next focus should be:
+- `list_tasks` reliability hardening on `plugin-url`
+
+Reason:
+- `list_tasks` is the highest-value read path
+- transport switching did not solve its failure mode
+- the remaining work is runtime/dispatch/query-pressure hardening, not architecture replacement
+
+Related hardening commit after this decision:
+- `9cff631` `Harden list_tasks timeout recovery`
+
+Related smoke validation:
+- `docs/benchmarks/list-tasks-smoke-post-hardening-20260313-063127/summary.md`
+
+## Decision Rules Going Forward
+
+Until new evidence disproves this decision:
+- do not change the default transport away from `plugin-url`
+- do not make architecture decisions from any benchmark run unless the transport implementation is verified first
+- do not compare transports and query changes in the same experiment
+- treat pure JXA as a reference/verification path, not the production architecture

--- a/scripts/benchmark-suite-overnight.sh
+++ b/scripts/benchmark-suite-overnight.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec "${ROOT_DIR}/scripts/benchmark-suite.sh" "$@"

--- a/scripts/benchmark-suite.sh
+++ b/scripts/benchmark-suite.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+TOTAL_HOURS="8"
+WARMUP_CALLS="20"
+INTERVAL_MS="1500"
+COOLDOWN_MS="3000"
+MEMORY_INTERVAL_SECONDS="30"
+COMPLETED_AFTER="2020-01-01T00:00:00Z"
+SUITE_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --total-hours)
+      TOTAL_HOURS="$2"
+      shift 2
+      ;;
+    --warmup-calls)
+      WARMUP_CALLS="$2"
+      shift 2
+      ;;
+    --interval-ms)
+      INTERVAL_MS="$2"
+      shift 2
+      ;;
+    --cooldown-ms)
+      COOLDOWN_MS="$2"
+      shift 2
+      ;;
+    --memory-interval-seconds)
+      MEMORY_INTERVAL_SECONDS="$2"
+      shift 2
+      ;;
+    --completed-after)
+      COMPLETED_AFTER="$2"
+      shift 2
+      ;;
+    --suite-dir)
+      SUITE_DIR="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$SUITE_DIR" ]]; then
+  TS="$(date +%Y%m%d-%H%M%S)"
+  SUITE_DIR="docs/benchmarks/suite-${TS}"
+fi
+
+mkdir -p "$SUITE_DIR"
+SUITE_LOG="${SUITE_DIR}/suite.log"
+
+BIN="./.build/debug/focusrelay"
+if [[ ! -x "$BIN" ]]; then
+  swift build -c debug
+fi
+
+PER_TOOL_HOURS="$(awk "BEGIN { printf \"%.6f\", ($TOTAL_HOURS / 3.0) }")"
+TASK_COUNTS_DIR="${SUITE_DIR}/get_task_counts"
+LIST_TASKS_DIR="${SUITE_DIR}/list_tasks"
+PROJECT_COUNTS_DIR="${SUITE_DIR}/get_project_counts"
+mkdir -p "$TASK_COUNTS_DIR" "$LIST_TASKS_DIR" "$PROJECT_COUNTS_DIR"
+
+log() {
+  printf '%s %s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$*" | tee -a "$SUITE_LOG"
+}
+
+write_metadata() {
+  cat > "${SUITE_DIR}/metadata.md" <<META
+# Benchmark Suite Metadata
+
+- Started: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+- Branch: $(git rev-parse --abbrev-ref HEAD)
+- Commit: $(git rev-parse HEAD)
+- Dispatch transport: ${FOCUS_RELAY_BRIDGE_DISPATCH_TRANSPORT:-url}
+- Total configured hours: ${TOTAL_HOURS}
+- Per tool configured hours: ${PER_TOOL_HOURS}
+- Warmup calls: ${WARMUP_CALLS}
+- Interval ms: ${INTERVAL_MS}
+- Cooldown ms: ${COOLDOWN_MS}
+- Memory interval seconds: ${MEMORY_INTERVAL_SECONDS}
+- Completed-after anchor: ${COMPLETED_AFTER}
+META
+}
+
+run_restart_step() {
+  log "Restart step: quitting OmniFocus"
+  osascript -e 'tell application "OmniFocus" to quit' >/dev/null 2>&1 || true
+  sleep 2
+  log "Restart step: opening OmniFocus"
+  open -a "OmniFocus"
+  sleep 4
+}
+
+run_readiness_gate() {
+  local label="$1"
+  local outdir="$2"
+  local log_file="${outdir}/readiness.log"
+  : > "$log_file"
+  log "Readiness gate start: ${label}"
+  local attempts=0
+  local max_attempts=10
+  while (( attempts < max_attempts )); do
+    attempts=$((attempts + 1))
+    {
+      echo "attempt=${attempts}"
+      "$BIN" bridge-health-check
+      "$BIN" debug-inbox-probe
+    } >> "$log_file" 2>&1 && {
+      log "Readiness gate passed: ${label} attempt=${attempts}"
+      return 0
+    }
+    sleep 2
+  done
+  log "Readiness gate failed: ${label}"
+  return 1
+}
+
+run_semantic_gate() {
+  local scope="$1"
+  local outdir="$2"
+  log "Semantic gate start: scope=${scope}"
+  "$BIN" benchmark-gate-check --tool "$scope" > "${outdir}/gate.json"
+  log "Semantic gate passed: scope=${scope}"
+}
+
+run_bench() {
+  local name="$1"
+  local outdir="$2"
+  shift 2
+  log "Benchmark start: ${name}"
+  echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" > "${outdir}/started_at.txt"
+  "$BIN" "$@" --output-dir "$outdir" 2>&1 | tee "${outdir}/run.log"
+  echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" > "${outdir}/ended_at.txt"
+  log "Benchmark end: ${name}"
+}
+
+write_metadata
+run_restart_step
+
+run_readiness_gate "before get_task_counts" "$TASK_COUNTS_DIR"
+run_semantic_gate "task-counts" "$TASK_COUNTS_DIR"
+run_bench \
+  "get_task_counts" \
+  "$TASK_COUNTS_DIR" \
+  benchmark-task-counts \
+  --duration-hours "$PER_TOOL_HOURS" \
+  --warmup-calls "$WARMUP_CALLS" \
+  --interval-ms "$INTERVAL_MS" \
+  --cooldown-ms "$COOLDOWN_MS" \
+  --memory-interval-seconds "$MEMORY_INTERVAL_SECONDS" \
+  --completed-after "$COMPLETED_AFTER"
+
+run_readiness_gate "before list_tasks" "$LIST_TASKS_DIR"
+run_semantic_gate "list-tasks" "$LIST_TASKS_DIR"
+run_bench \
+  "list_tasks" \
+  "$LIST_TASKS_DIR" \
+  benchmark-list-tasks \
+  --duration-hours "$PER_TOOL_HOURS" \
+  --warmup-calls "$WARMUP_CALLS" \
+  --interval-ms "$INTERVAL_MS" \
+  --cooldown-ms "$COOLDOWN_MS" \
+  --completed-after "$COMPLETED_AFTER"
+
+run_readiness_gate "before get_project_counts" "$PROJECT_COUNTS_DIR"
+run_semantic_gate "project-counts" "$PROJECT_COUNTS_DIR"
+run_bench \
+  "get_project_counts" \
+  "$PROJECT_COUNTS_DIR" \
+  benchmark-project-counts \
+  --duration-hours "$PER_TOOL_HOURS" \
+  --warmup-calls "$WARMUP_CALLS" \
+  --interval-ms "$INTERVAL_MS" \
+  --cooldown-ms "$COOLDOWN_MS" \
+  --memory-interval-seconds "$MEMORY_INTERVAL_SECONDS" \
+  --completed-after "$COMPLETED_AFTER"
+
+cat > "${SUITE_DIR}/summary.md" <<EOF_SUMMARY
+# Benchmark Suite
+
+- Started: $(head -n1 "${TASK_COUNTS_DIR}/started_at.txt" 2>/dev/null || echo "unknown")
+- Ended: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+- Branch: $(git rev-parse --abbrev-ref HEAD)
+- Commit: $(git rev-parse HEAD)
+- Dispatch transport: ${FOCUS_RELAY_BRIDGE_DISPATCH_TRANSPORT:-url}
+- Total configured hours: ${TOTAL_HOURS}
+- Per tool configured hours: ${PER_TOOL_HOURS}
+
+## Artifacts
+
+- Metadata: ${SUITE_DIR}/metadata.md
+- Suite log: ${SUITE_DIR}/suite.log
+- get_task_counts: ${TASK_COUNTS_DIR}/summary.md
+- list_tasks: ${LIST_TASKS_DIR}/summary.md
+- get_project_counts: ${PROJECT_COUNTS_DIR}/summary.md
+EOF_SUMMARY
+
+log "Suite complete: ${SUITE_DIR}"

--- a/scripts/benchmark-transport-ab.sh
+++ b/scripts/benchmark-transport-ab.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+TOTAL_HOURS="3"
+WARMUP_CALLS="20"
+INTERVAL_MS="1500"
+COOLDOWN_MS="3000"
+MEMORY_INTERVAL_SECONDS="30"
+COMPLETED_AFTER="2020-01-01T00:00:00Z"
+RUN_ROOT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --total-hours)
+      TOTAL_HOURS="$2"
+      shift 2
+      ;;
+    --warmup-calls)
+      WARMUP_CALLS="$2"
+      shift 2
+      ;;
+    --interval-ms)
+      INTERVAL_MS="$2"
+      shift 2
+      ;;
+    --cooldown-ms)
+      COOLDOWN_MS="$2"
+      shift 2
+      ;;
+    --memory-interval-seconds)
+      MEMORY_INTERVAL_SECONDS="$2"
+      shift 2
+      ;;
+    --completed-after)
+      COMPLETED_AFTER="$2"
+      shift 2
+      ;;
+    --run-root)
+      RUN_ROOT="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$RUN_ROOT" ]]; then
+  TS="$(date +%Y%m%d-%H%M%S)"
+  RUN_ROOT="docs/benchmarks/transport-ab-${TS}"
+fi
+
+mkdir -p "$RUN_ROOT"
+DRIVER_LOG="${RUN_ROOT}/driver.log"
+
+log() {
+  printf '%s %s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$*" | tee -a "$DRIVER_LOG"
+}
+
+run_suite() {
+  local label="$1"
+  local transport="$2"
+  local suite_dir="${RUN_ROOT}/${label}"
+
+  mkdir -p "$suite_dir"
+  log "START suite ${label} transport=${transport}"
+
+  FOCUS_RELAY_BRIDGE_DISPATCH_TRANSPORT="$transport" \
+    ./scripts/benchmark-suite.sh \
+      --total-hours "$TOTAL_HOURS" \
+      --warmup-calls "$WARMUP_CALLS" \
+      --interval-ms "$INTERVAL_MS" \
+      --cooldown-ms "$COOLDOWN_MS" \
+      --memory-interval-seconds "$MEMORY_INTERVAL_SECONDS" \
+      --completed-after "$COMPLETED_AFTER" \
+      --suite-dir "$suite_dir" \
+      2>&1 | tee "${suite_dir}/launch.log"
+
+  log "END suite ${label} transport=${transport}"
+}
+
+log "RUN ROOT ${RUN_ROOT}"
+run_suite "plugin-url" "url"
+
+log "Inter-suite restart: quitting OmniFocus"
+osascript -e 'tell application "OmniFocus" to quit' >/dev/null 2>&1 || true
+sleep 2
+pkill -x OmniFocus >/dev/null 2>&1 || true
+sleep 2
+log "Inter-suite restart: opening OmniFocus"
+open -a "OmniFocus"
+sleep 6
+
+run_suite "plugin-jxa-dispatch" "jxa"
+log "ALL DONE"

--- a/scripts/install-plugin.sh
+++ b/scripts/install-plugin.sh
@@ -4,140 +4,157 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PLUGIN_SRC="$ROOT_DIR/Plugin/FocusRelayBridge.omnijs"
 
-# Detect OmniFocus plugin directories in priority order
-# Priority: User's custom linked folders > iCloud > Sandbox > Legacy
+echo "🔍 Detecting OmniFocus plugin directories..."
 
-echo "🔍 Detecting OmniFocus plugin directory..."
+export ROOT_DIR
+export PLUGIN_SRC
 
-# Candidate plugin locations (priority order)
-CANDIDATES=()
-SANDBOX_DIR=""
-ICLOUD_DIR=""
-LEGACY_DIR=""
-
-# Priority 1: Check if user has configured custom plugin folders via defaults
-# Use a short timeout because `defaults read` can hang on some systems.
-CUSTOM_PLUGINS=$(
 python3 - <<'PY'
-import subprocess
-try:
-    result = subprocess.run(
-        ["defaults", "read", "com.omnigroup.OmniFocus4", "PlugInFolders"],
-        capture_output=True,
-        text=True,
-        timeout=2,
-    )
-    if result.returncode == 0:
-        print(result.stdout.strip())
-except subprocess.TimeoutExpired:
-    pass
-PY
-)
-
-if [ -n "$CUSTOM_PLUGINS" ]; then
-    # Extract the first custom plugin folder path from plist
-    FIRST_CUSTOM=$(echo "$CUSTOM_PLUGINS" | grep -o '"[^"]*"' | head -1 | tr -d '"')
-    if [ -n "$FIRST_CUSTOM" ] && [ -d "$FIRST_CUSTOM" ]; then
-        PLUGIN_DIR="$FIRST_CUSTOM"
-        echo "✅ Found custom plugin folder: $PLUGIN_DIR"
-    fi
-fi
-
-# Priority 2: Check for OmniFocus 4 sandbox directory (most common)
-if [ -z "${PLUGIN_DIR:-}" ]; then
-    SANDBOX_DIR="$HOME/Library/Containers/com.omnigroup.OmniFocus4/Data/Library/Application Support/Plug-Ins"
-    CANDIDATES+=("$SANDBOX_DIR")
-fi
-
-# Priority 3: Check for iCloud sync directory
-if [ -z "${PLUGIN_DIR:-}" ]; then
-    ICLOUD_DIR="$HOME/Library/Mobile Documents/iCloud~com~omnigroup~OmniFocus/Documents/Plug-Ins"
-    CANDIDATES+=("$ICLOUD_DIR")
-fi
-
-# Priority 4: Legacy Application Support (OmniFocus 3 and earlier)
-if [ -z "${PLUGIN_DIR:-}" ]; then
-    LEGACY_DIR="$HOME/Library/Application Support/OmniFocus/Plug-Ins"
-    CANDIDATES+=("$LEGACY_DIR")
-fi
-
-install_plugin() {
-    PLUGIN_DIR="$1"
-    PLUGIN_SRC="$2"
-    python3 - <<'PY'
+import hashlib
+import json
 import os
 import shutil
 import signal
+import subprocess
 import sys
 
-plugin_dir = os.environ["PLUGIN_DIR"]
+root_dir = os.environ["ROOT_DIR"]
 plugin_src = os.environ["PLUGIN_SRC"]
+plugin_name = "FocusRelayBridge.omnijs"
 timeout_seconds = 5
+
+sandbox_dir = os.path.expanduser(
+    "~/Library/Containers/com.omnigroup.OmniFocus4/Data/Library/Application Support/Plug-Ins"
+)
+icloud_dir = os.path.expanduser(
+    "~/Library/Mobile Documents/iCloud~com~omnigroup~OmniFocus/Documents/Plug-Ins"
+)
+legacy_dir = os.path.expanduser("~/Library/Application Support/OmniFocus/Plug-Ins")
+
 
 def handle_timeout(signum, frame):
     raise TimeoutError("Timed out while accessing plugin directory")
 
-signal.signal(signal.SIGALRM, handle_timeout)
-signal.alarm(timeout_seconds)
 
-try:
-    os.makedirs(plugin_dir, exist_ok=True)
-    dest = os.path.join(plugin_dir, "FocusRelayBridge.omnijs")
-    if os.path.exists(dest):
-        shutil.rmtree(dest)
-    shutil.copytree(plugin_src, dest)
-    signal.alarm(0)
-    print(plugin_dir)
-except TimeoutError:
-    sys.exit(2)
-except Exception as exc:
-    print(f"ERROR: {exc}", file=sys.stderr)
+def read_custom_plugin_dirs():
+    try:
+        result = subprocess.run(
+            ["defaults", "read", "com.omnigroup.OmniFocus4", "PlugInFolders"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except subprocess.TimeoutExpired:
+        return []
+
+    if result.returncode != 0:
+        return []
+
+    try:
+        parsed = json.loads(result.stdout)
+        if isinstance(parsed, list):
+            return [os.path.expanduser(p) for p in parsed if isinstance(p, str) and p]
+    except json.JSONDecodeError:
+        pass
+
+    # Fallback for plist-style output from `defaults read`.
+    dirs = []
+    for line in result.stdout.splitlines():
+        candidate = line.strip().strip('",();')
+        if candidate.startswith("/"):
+            dirs.append(os.path.expanduser(candidate))
+    return dirs
+
+
+def add_target(targets, seen, path, reason, create_if_missing=False):
+    if not path or path in seen:
+        return
+    if create_if_missing or os.path.isdir(path):
+        targets.append((path, reason))
+        seen.add(path)
+
+
+def install_plugin(plugin_dir):
+    signal.signal(signal.SIGALRM, handle_timeout)
+    signal.alarm(timeout_seconds)
+    try:
+        os.makedirs(plugin_dir, exist_ok=True)
+        dest = os.path.join(plugin_dir, plugin_name)
+        if os.path.exists(dest):
+            shutil.rmtree(dest)
+        shutil.copytree(plugin_src, dest)
+        signal.alarm(0)
+        return dest
+    finally:
+        signal.alarm(0)
+
+
+def sha256_file(path):
+    hasher = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+targets = []
+seen = set()
+
+for custom_dir in read_custom_plugin_dirs():
+    add_target(targets, seen, custom_dir, "custom", create_if_missing=False)
+
+add_target(targets, seen, icloud_dir, "icloud", create_if_missing=False)
+add_target(targets, seen, sandbox_dir, "sandbox", create_if_missing=True)
+add_target(targets, seen, legacy_dir, "legacy", create_if_missing=False)
+
+if not targets:
+    print("❌ Failed to detect any OmniFocus plugin directory.", file=sys.stderr)
     sys.exit(1)
+
+print("Detected plugin directories:")
+for path, reason in targets:
+    print(f"  - {path} ({reason})")
+
+installed = []
+errors = []
+for path, reason in targets:
+    try:
+        dest = install_plugin(path)
+        bridge_js = os.path.join(dest, "Resources", "BridgeLibrary.js")
+        installed.append((path, reason, bridge_js, sha256_file(bridge_js)))
+    except TimeoutError:
+        errors.append(f"Timed out accessing {path}")
+    except Exception as exc:
+        errors.append(f"{path}: {exc}")
+
+if not installed:
+    print("❌ Failed to install plugin in any known OmniFocus directory.", file=sys.stderr)
+    for message in errors:
+        print(f"   {message}", file=sys.stderr)
+    sys.exit(1)
+
+print("")
+print("✅ Installed FocusRelayBridge.omnijs to:")
+for path, reason, _, digest in installed:
+    print(f"   {path} ({reason})")
+    print(f"      BridgeLibrary.js sha256: {digest}")
+
+if errors:
+    print("")
+    print("⚠️  Some plugin locations could not be updated:")
+    for message in errors:
+        print(f"   {message}")
+
+if len(installed) > 1:
+    print("")
+    print("ℹ️  Multiple OmniFocus plugin directories were updated to keep duplicate bundles in sync.")
+
+print("")
+print("🔄 IMPORTANT: You MUST restart OmniFocus completely for changes to take effect.")
+print("")
+print("   Run this command:")
+print("   osascript -e 'tell application \"OmniFocus\" to quit' && sleep 2 && open -a \"OmniFocus\"")
+print("")
+print("⚠️  NOTE: The first time you run a query, OmniFocus may ask you to approve")
+print("   the automation script. Click \"Run Script\" when prompted.")
 PY
-}
-
-if [ -n "${PLUGIN_DIR:-}" ]; then
-    CANDIDATES=("$PLUGIN_DIR")
-else
-    CANDIDATES=("${CANDIDATES[@]}")
-fi
-
-PLUGIN_DIR=""
-for candidate in "${CANDIDATES[@]}"; do
-    export PLUGIN_DIR="$candidate"
-    export PLUGIN_SRC
-    if output=$(install_plugin "$candidate" "$PLUGIN_SRC" 2>/dev/null); then
-        PLUGIN_DIR="$output"
-        if [ "$candidate" = "$SANDBOX_DIR" ]; then
-            echo "✅ Found OmniFocus 4 sandbox plugin directory"
-        elif [ "$candidate" = "$ICLOUD_DIR" ]; then
-            echo "✅ Found iCloud-synced plugin directory"
-        elif [ "$candidate" = "$LEGACY_DIR" ]; then
-            echo "⚠️  Using legacy plugin directory (OmniFocus 3 or earlier)"
-        else
-            echo "✅ Found custom plugin folder: $PLUGIN_DIR"
-        fi
-        break
-    else
-        if [ $? -eq 2 ]; then
-            echo "⚠️  Timed out accessing $candidate, trying next location..."
-        fi
-    fi
-done
-
-if [ -z "$PLUGIN_DIR" ]; then
-    echo "❌ Failed to install plugin in any known OmniFocus directory."
-    exit 1
-fi
-
-echo ""
-echo "✅ Successfully installed FocusRelayBridge.omnijs to:"
-echo "   $PLUGIN_DIR"
-echo ""
-echo "🔄 IMPORTANT: You MUST restart OmniFocus completely for changes to take effect."
-echo ""
-echo "   Run this command:"
-echo "   osascript -e 'tell application \"OmniFocus\" to quit' && sleep 2 && open -a \"OmniFocus\""
-echo ""
-echo "⚠️  NOTE: The first time you run a query, OmniFocus will ask you to approve"
-echo "   the automation script. Click \"Run Script\" when prompted."


### PR DESCRIPTION
## Summary
- optimize the documented clean-branch read paths on `plugin-url`
- add benchmark gates, timeout diagnostics, and repeatable benchmark drivers
- keep `plugin-url` as the default transport after corrected transport A/B validation
- add closeout docs, realistic benchmark profile, and the authoritative plan update

## Key implementation changes
- documented Omni Automation contract and agent rule updates
- `get_task_counts` optimization and diagnostics
- `list_tasks` reliability hardening, streamed paging, no-total-count fast path, and completion top-K path
- `get_project_counts` correction, optimization, and timeout diagnostics
- corrected transport selection and transport A/B tooling

## Validation
- `swift test`
- benchmark gate checks for the optimized tools
- clean-branch benchmark artifacts referenced in:
  - `docs/final-optimization-summary-2026-03-16.md`
  - `docs/transport-decision-2026-03-13.md`
  - `docs/performance-progress-2026-03-14.md`
  - `docs/performance-progress-2026-03-15.md`

## Final decisions
- keep `plugin-url` as the default production architecture
- keep pure JXA as a parity and benchmark reference path
- do not switch to `plugin-jxa-dispatch`
- stop this optimization phase here and treat cache/runtime-pressure work as a separate future phase

Closes #19
