### PR TITLE
Fix catalog cache keys for status/count variants

### DIFF
--- a/Sources/OmniFocusAutomation/CatalogCache.swift
+++ b/Sources/OmniFocusAutomation/CatalogCache.swift
@@ -5,6 +5,51 @@ struct CacheKey: Hashable {
     let limit: Int
     let cursor: String?
     let fieldsKey: String
+    let statusFilter: String?
+    let includeTaskCounts: Bool
+
+    private init(
+        limit: Int,
+        cursor: String?,
+        fieldsKey: String,
+        statusFilter: String?,
+        includeTaskCounts: Bool
+    ) {
+        self.limit = limit
+        self.cursor = cursor
+        self.fieldsKey = fieldsKey
+        self.statusFilter = statusFilter
+        self.includeTaskCounts = includeTaskCounts
+    }
+
+    static func projects(
+        page: PageRequest,
+        fields: [String]?,
+        statusFilter: String?,
+        includeTaskCounts: Bool
+    ) -> CacheKey {
+        CacheKey(
+            limit: page.limit,
+            cursor: page.cursor,
+            fieldsKey: (fields ?? []).joined(separator: ","),
+            statusFilter: statusFilter,
+            includeTaskCounts: includeTaskCounts
+        )
+    }
+
+    static func tags(
+        page: PageRequest,
+        statusFilter: String?,
+        includeTaskCounts: Bool
+    ) -> CacheKey {
+        CacheKey(
+            limit: page.limit,
+            cursor: page.cursor,
+            fieldsKey: "",
+            statusFilter: statusFilter,
+            includeTaskCounts: includeTaskCounts
+        )
+    }
 }
 
 struct CacheEntry<T> {

--- a/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
+++ b/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
@@ -32,8 +32,12 @@ public final class OmniFocusBridgeService: OmniFocusService {
     ) async throws -> Page<ProjectItem> {
         let shouldBypassCache = reviewPerspective || reviewDueBefore != nil || reviewDueAfter != nil || completed != nil || completedBefore != nil || completedAfter != nil
         if !shouldBypassCache {
-            let fieldsKey = (fields ?? []).joined(separator: ",")
-            let key = CacheKey(limit: page.limit, cursor: page.cursor, fieldsKey: fieldsKey)
+            let key = CacheKey.projects(
+                page: page,
+                fields: fields,
+                statusFilter: statusFilter,
+                includeTaskCounts: includeTaskCounts
+            )
             if let cached = await cache.getProjects(key: key) {
                 return cached
             }
@@ -68,7 +72,11 @@ public final class OmniFocusBridgeService: OmniFocusService {
     }
 
     public func listTags(page: PageRequest, statusFilter: String?, includeTaskCounts: Bool) async throws -> Page<TagItem> {
-        let key = CacheKey(limit: page.limit, cursor: page.cursor, fieldsKey: "")
+        let key = CacheKey.tags(
+            page: page,
+            statusFilter: statusFilter,
+            includeTaskCounts: includeTaskCounts
+        )
         if let cached = await cache.getTags(key: key) {
             return cached
         }

--- a/Tests/OmniFocusIntegrationTests/CatalogCacheTests.swift
+++ b/Tests/OmniFocusIntegrationTests/CatalogCacheTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Testing
+@testable import OmniFocusAutomation
+import OmniFocusCore
+
+@Test
+func projectCacheKeyMatchesForSameInputs() {
+    let page = PageRequest(limit: 10, cursor: "cursor")
+    let lhs = CacheKey.projects(
+        page: page,
+        fields: ["id", "name"],
+        statusFilter: "active",
+        includeTaskCounts: true
+    )
+    let rhs = CacheKey.projects(
+        page: page,
+        fields: ["id", "name"],
+        statusFilter: "active",
+        includeTaskCounts: true
+    )
+
+    #expect(lhs == rhs)
+}
+
+@Test
+func projectCacheKeySeparatesStatusFilter() {
+    let page = PageRequest(limit: 10, cursor: "cursor")
+    let active = CacheKey.projects(
+        page: page,
+        fields: ["id", "name"],
+        statusFilter: "active",
+        includeTaskCounts: false
+    )
+    let done = CacheKey.projects(
+        page: page,
+        fields: ["id", "name"],
+        statusFilter: "done",
+        includeTaskCounts: false
+    )
+
+    #expect(active != done)
+}
+
+@Test
+func projectCacheKeySeparatesIncludeTaskCounts() {
+    let page = PageRequest(limit: 10, cursor: "cursor")
+    let withoutCounts = CacheKey.projects(
+        page: page,
+        fields: ["id", "name"],
+        statusFilter: "active",
+        includeTaskCounts: false
+    )
+    let withCounts = CacheKey.projects(
+        page: page,
+        fields: ["id", "name"],
+        statusFilter: "active",
+        includeTaskCounts: true
+    )
+
+    #expect(withoutCounts != withCounts)
+}
+
+@Test
+func tagCacheKeySeparatesStatusFilter() {
+    let page = PageRequest(limit: 10, cursor: "cursor")
+    let active = CacheKey.tags(
+        page: page,
+        statusFilter: "active",
+        includeTaskCounts: false
+    )
+    let onHold = CacheKey.tags(
+        page: page,
+        statusFilter: "onHold",
+        includeTaskCounts: false
+    )
+
+    #expect(active != onHold)
+}
+
+@Test
+func tagCacheKeySeparatesIncludeTaskCounts() {
+    let page = PageRequest(limit: 10, cursor: "cursor")
+    let withoutCounts = CacheKey.tags(
+        page: page,
+        statusFilter: "active",
+        includeTaskCounts: false
+    )
+    let withCounts = CacheKey.tags(
+        page: page,
+        statusFilter: "active",
+        includeTaskCounts: true
+    )
+
+    #expect(withoutCounts != withCounts)
+}
+
+@Test
+func catalogCacheSeparatesProjectEntriesByKey() async {
+    let cache = CatalogCache()
+    let page = PageRequest(limit: 10)
+    let summary = ProjectTaskSummary(id: "task-1", name: "Next")
+    let activeKey = CacheKey.projects(
+        page: page,
+        fields: ["id", "name"],
+        statusFilter: "active",
+        includeTaskCounts: false
+    )
+    let doneKey = CacheKey.projects(
+        page: page,
+        fields: ["id", "name"],
+        statusFilter: "done",
+        includeTaskCounts: false
+    )
+    let activePage = Page(
+        items: [ProjectItem(id: "project-active", name: "Active", status: "active", flagged: false, nextTask: summary)],
+        returnedCount: 1,
+        totalCount: 1
+    )
+    let donePage = Page(
+        items: [ProjectItem(id: "project-done", name: "Done", status: "done", flagged: false)],
+        returnedCount: 1,
+        totalCount: 1
+    )
+
+    await cache.setProjects(activePage, key: activeKey, ttl: 60)
+    await cache.setProjects(donePage, key: doneKey, ttl: 60)
+
+    let cachedActive = await cache.getProjects(key: activeKey)
+    let cachedDone = await cache.getProjects(key: doneKey)
+
+    #expect(cachedActive?.items.first?.id == "project-active")
+    #expect(cachedDone?.items.first?.id == "project-done")
+}
+
+@Test
+func catalogCacheSeparatesTagEntriesByKey() async {
+    let cache = CatalogCache()
+    let page = PageRequest(limit: 10)
+    let plainKey = CacheKey.tags(
+        page: page,
+        statusFilter: "active",
+        includeTaskCounts: false
+    )
+    let countedKey = CacheKey.tags(
+        page: page,
+        statusFilter: "active",
+        includeTaskCounts: true
+    )
+    let plainPage = Page(
+        items: [TagItem(id: "tag-1", name: "Inbox", status: "active")],
+        returnedCount: 1,
+        totalCount: 1
+    )
+    let countedPage = Page(
+        items: [TagItem(id: "tag-1", name: "Inbox", status: "active", availableTasks: 2, remainingTasks: 3, totalTasks: 5)],
+        returnedCount: 1,
+        totalCount: 1
+    )
+
+    await cache.setTags(plainPage, key: plainKey, ttl: 60)
+    await cache.setTags(countedPage, key: countedKey, ttl: 60)
+
+    let cachedPlain = await cache.getTags(key: plainKey)
+    let cachedCounted = await cache.getTags(key: countedKey)
+
+    #expect(cachedPlain?.items.first?.totalTasks == nil)
+    #expect(cachedCounted?.items.first?.totalTasks == 5)
+}


### PR DESCRIPTION
## Summary

The catalog cache keys for `list_projects` and `list_tags` only used pagination and fields, so requests with different `statusFilter` or `includeTaskCounts` values could reuse the same cached page.

This change separates those cache entries by filter state and adds regression tests that pin the behavior without relying on live OmniFocus data.

## Changes

- add dedicated project/tag cache-key builders
- include `statusFilter` and `includeTaskCounts` in catalog cache keys
- update `OmniFocusBridgeService` to use the new key builders
- add regression tests for key equality and cache entry separation

## Testing

- `swift test --filter CatalogCacheTests`
- `swift test`

