### PR TITLE
Update swift-sdk to 0.12.0 for Swift 6.3 compatibility

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "042c043bc91172c15b5f1d87ae77dc0abb7acbcd01cef21f5a1c4bdd2c52c0cd",
+  "originHash" : "782d24fcf473fc18ccb73efd332d4744e8210ad20c9ee707f3795816d21b2aa2",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -20,6 +20,24 @@
       }
     },
     {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    },
+    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
@@ -29,12 +47,21 @@
       }
     },
     {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "cd6710454f25733900e133c6caf5188952763c36",
+        "version" : "2.98.0"
+      }
+    },
+    {
       "identity" : "swift-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
-        "revision" : "c0407a0b52677cb395d824cac2879b963075ba8c",
-        "version" : "0.10.2"
+        "revision" : "6132fd4b5b4217ce4717c4775e4607f5c3120129",
+        "version" : "0.12.0"
       }
     },
     {


### PR DESCRIPTION
## Summary

Update `modelcontextprotocol/swift-sdk` from `0.10.2` to `0.12.0` so the package builds cleanly on Swift 6.3.1 / Xcode 26.4.1.

## Why

The pinned `0.10.2` dependency fails to compile in `NetworkTransport.swift` under Swift 6.3 with `SendingRisksDataRace` errors. Upstream fixed this class of failure and notes that the fix is available in `v0.12.0`.

## Change

- update `Package.resolved`
- move `swift-sdk` from `0.10.2` to `0.12.0`
- accept the new transitive pins required by the upstream SDK release

## Validation

- [x] `swift test`

## Upstream references

- modelcontextprotocol/swift-sdk issue #203
- modelcontextprotocol/swift-sdk issue #211
- modelcontextprotocol/swift-sdk PR #209
- modelcontextprotocol/swift-sdk PR #212
