### PR TITLE
Document AI-optimized mutation workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,19 @@ Stop clicking through endless task lists. Just ask:
 - "Find my flagged items"
 - "What did I accomplish this week?"
 
+**AI-Assisted Updates**
+- "Mark these tasks complete after I confirm the preview"
+- "Move these inbox tasks into this project"
+- "Flag these tasks and set a due date"
+- "Put this project on hold"
+
 ## Features
 
 - **Time-based Queries**: Natural language time period filtering
 - **Project Health**: Detect stalled projects and missing next actions
 - **Context Awareness**: Tag-based filtering and availability
 - **Completion Date Filtering**: Query completed tasks/projects by specific date ranges
+- **Safe Write Tools**: Preview, verify, and mutate task/project fields, completion, status, and moves
 - **Smart Filtering**: By tags, due dates, defer dates, completion, duration
 - **Timezone Aware**: Automatic local timezone detection and handling
 - **High Performance**: Single-pass filtering with early exit optimization
@@ -211,9 +218,45 @@ focusrelay bridge-health-check
 
 # List tasks with total count (shows returnedCount and totalCount)
 focusrelay list-tasks --fields name --limit 10 --include-total-count
+
+# Preview a task field update before mutating
+focusrelay update-tasks <task-id> --flagged true --preview-only --verify --return-fields id,name,flagged
+
+# Complete tasks after preview/confirmation
+focusrelay set-tasks-completion <task-id> --state completed --verify --return-fields id,name,completed
+
+# Move tasks to a project
+focusrelay move-tasks <task-id> --destination-kind project --destination-id <project-id> --verify
+
+# Put a project on hold
+focusrelay set-projects-status <project-id> --status on_hold --preview-only --verify --return-fields id,name,status
 ```
 
 Dates should be ISO8601 (e.g. `2026-02-04T12:00:00Z`).
+
+## Safe Mutation Workflows
+
+FocusRelay includes v1 write tools for task and project updates. The mutation surface is intentionally split into three operation types so AI clients choose predictable tools:
+
+- **Patch tools**: `update_tasks`, `update_projects`
+- **Lifecycle/status tools**: `set_tasks_completion`, `set_projects_completion`, `set_projects_status`
+- **Move tools**: `move_tasks`, `move_projects`
+
+Recommended AI workflow:
+
+1. Read the smallest useful set of candidates with `id,name`.
+2. Run the write with `previewOnly: true`, `verify: true`, and compact `returnFields`.
+3. Ask the user to confirm the preview.
+4. Rerun the same request with `previewOnly: false`.
+
+V1 mutation rules:
+
+- Mutations target IDs only, not names.
+- Bulk writes are homogeneous: one operation kind and one shared patch/state/destination applied to all IDs.
+- Mixed-operation `batch_mutate_tasks` is intentionally out of scope.
+- Successful non-preview writes invalidate the project/tag cache.
+
+See [AI-Optimized Mutation Workflows](docs/mutation-workflows.md) for CLI and MCP examples.
 
 ## Usage Examples
 
@@ -245,6 +288,14 @@ Dates should be ISO8601 (e.g. `2026-02-04T12:00:00Z`).
 - "How many projects did I complete this month?" (count without listing)
 - "How many tasks are in my inbox?"
 - "Show me completed tasks"
+
+### Mutation Workflows
+- "Preview marking these tasks complete, then ask me before doing it"
+- "Move these inbox tasks into this project"
+- "Add the Mac tag to these tasks"
+- "Clear the due date on these tasks"
+- "Put this project on hold"
+- "Move this project into my Travel folder"
 
 ### Completed Perspective Parity
 All completion queries match the OmniFocus Completed perspective:
@@ -305,6 +356,43 @@ Query projects with status and task counts:
 Query tags with task counts:
 - `statusFilter`: active, onHold, dropped, all
 - `includeTaskCounts`: Get task counts per tag
+
+### update_tasks
+Apply one shared task field patch to one or more task IDs:
+- Supports: `name`, `note`, `noteAppend`, `flagged`, `estimatedMinutes`, `dueDate`, `clearDueDate`, `deferDate`, `clearDeferDate`, tag add/remove/set/clear
+- Does not complete or move tasks
+- Use `previewOnly`, `verify`, and `returnFields` for safe low-token workflows
+
+### set_tasks_completion
+Complete or uncomplete one or more task IDs:
+- `state`: `completed` or `active`
+- Handles repeating-task completion behavior and reports advancement in result messages
+
+### move_tasks
+Move or reparent one or more task IDs:
+- `destinationKind`: `inbox`, `project`, or `parent_task`
+- Omit `destinationID` for inbox moves
+- Use `position`: `beginning` or `ending`
+
+### update_projects
+Apply one shared project field patch to one or more project IDs:
+- Supports: `name`, `note`, `noteAppend`, `flagged`, `dueDate`, `clearDueDate`, `deferDate`, `clearDeferDate`, `sequential`, `reviewInterval`
+- Does not change status, completion, or folder location
+
+### set_projects_status
+Set project status for one or more project IDs:
+- `status`: `active`, `on_hold`, or `dropped`
+
+### set_projects_completion
+Complete or reactivate one or more project IDs:
+- `state`: `completed` or `active`
+- Handles repeating-project completion behavior and reports advancement in result messages
+
+### move_projects
+Move one or more project IDs to a folder or the root library:
+- `destinationKind`: `folder`
+- Set `destinationID` to a folder ID, or omit it to move to the root library
+- Use `position`: `beginning` or `ending`
 
 ### get_task_counts
 Get aggregate counts for any filter combination. Supports full task filtering including:

--- a/docs/mcp-best-practices.md
+++ b/docs/mcp-best-practices.md
@@ -30,6 +30,7 @@
 7) Explicit safety boundaries
 - For write actions, include dry-run or preview modes.
 - Require explicit confirmation for bulk writes.
+- For FocusRelay mutations, use `previewOnly`, `verify`, and compact `returnFields`; see [`mutation-workflows.md`](./mutation-workflows.md).
 
 8) Timeouts + retries
 - Short timeouts with clear errors.
@@ -59,7 +60,7 @@
 
 5) Cache where it matters
 - Short TTL cache for lists of projects/tags.
-- Invalidate on write operations (when we add writes).
+- Invalidate project/tag catalog caches after successful non-preview write operations.
 
 6) Avoid macOS UI activation
 - Use `open -g` when triggering OmniFocus.

--- a/docs/mutation-workflows.md
+++ b/docs/mutation-workflows.md
@@ -1,0 +1,379 @@
+# AI-Optimized Mutation Workflows
+
+This guide documents the v1 FocusRelay write surface for CLI and MCP clients.
+It is designed for low-token AI workflows: read only the IDs and fields you need,
+preview the intended write, then mutate with verification when the user approves.
+
+## V1 Rules
+
+- Mutations target IDs only. Do not mutate by name.
+- Bulk writes are homogeneous: one operation kind, one shared patch/state/destination, many IDs.
+- `update_*` tools edit fields only.
+- `set_*_completion` tools own completion lifecycle transitions.
+- `set_projects_status` owns project status transitions.
+- `move_*` tools own structural moves.
+- Mixed-operation batch mutation is intentionally out of scope for v1.
+- Task queries are always fresh. Project and tag catalog caches are invalidated after successful non-preview writes.
+
+## Shared Safety Options
+
+Use these on every write workflow:
+
+- `previewOnly`: validates targets and shared operation without mutating OmniFocus.
+- `verify`: reads back the final state after mutation and reports verification failures.
+- `returnFields`: returns only selected fields in per-item results to keep output compact.
+
+Recommended default for AI clients:
+
+```json
+{
+  "previewOnly": true,
+  "verify": true,
+  "returnFields": ["id", "name"]
+}
+```
+
+After the user confirms the preview, send the same request with `previewOnly: false`.
+
+## Tool Selection
+
+| Intent | MCP tool | CLI command |
+| --- | --- | --- |
+| Edit task fields | `update_tasks` | `focusrelay update-tasks` |
+| Complete or uncomplete tasks | `set_tasks_completion` | `focusrelay set-tasks-completion` |
+| Move/reparent tasks | `move_tasks` | `focusrelay move-tasks` |
+| Edit project fields | `update_projects` | `focusrelay update-projects` |
+| Change project active/on-hold/dropped status | `set_projects_status` | `focusrelay set-projects-status` |
+| Complete or reactivate projects | `set_projects_completion` | `focusrelay set-projects-completion` |
+| Move projects to folder/root library | `move_projects` | `focusrelay move-projects` |
+
+Do not use `update_tasks` or `update_projects` for completion, status, or move behavior.
+
+## Read Before Write
+
+Use the smallest read that can identify the correct target IDs:
+
+```bash
+focusrelay list-tasks --fields id,name --limit 20 --inbox-only true
+focusrelay list-projects --fields id,name,status --status active --limit 20
+focusrelay list-tags --fields id,name --limit 50
+```
+
+For MCP clients, request the same compact fields:
+
+```json
+{
+  "fields": ["id", "name"],
+  "page": { "limit": 20 }
+}
+```
+
+When a mutation needs tag, project, or parent-task IDs, read those IDs first.
+Do not ask the model to infer IDs from names already shown in prior conversation unless
+the ID is still visible in context. Folder IDs are not exposed by a dedicated v1
+read tool yet; use `move_projects` folder moves only when the folder ID is already
+known, or omit `destinationID` to move projects to the root library.
+
+## Task Field Patches
+
+Use `update_tasks` for task field edits only.
+
+Supported v1 fields:
+
+- `name`
+- `note`
+- `noteAppend`
+- `flagged`
+- `estimatedMinutes`
+- `dueDate`
+- `clearDueDate`
+- `deferDate`
+- `clearDeferDate`
+- `tags.add`
+- `tags.remove`
+- `tags.set`
+- `tags.clear`
+
+CLI preview:
+
+```bash
+focusrelay update-tasks task-id-1 task-id-2 \
+  --flagged true \
+  --due-date 2026-04-18T12:00:00Z \
+  --preview-only \
+  --verify \
+  --return-fields id,name,flagged,dueDate
+```
+
+MCP preview:
+
+```json
+{
+  "targetIDs": ["task-id-1", "task-id-2"],
+  "taskPatch": {
+    "flagged": true,
+    "dueDate": "2026-04-18T12:00:00Z"
+  },
+  "previewOnly": true,
+  "verify": true,
+  "returnFields": ["id", "name", "flagged", "dueDate"]
+}
+```
+
+To clear dates, use explicit clear flags:
+
+```bash
+focusrelay update-tasks task-id-1 --clear-due-date --verify --return-fields id,name,dueDate
+```
+
+## Task Completion Lifecycle
+
+Use `set_tasks_completion` for complete and uncomplete.
+
+CLI:
+
+```bash
+focusrelay set-tasks-completion task-id-1 task-id-2 \
+  --state completed \
+  --preview-only \
+  --verify \
+  --return-fields id,name,completed,completionDate
+```
+
+MCP:
+
+```json
+{
+  "targetIDs": ["task-id-1", "task-id-2"],
+  "completion": { "state": "completed" },
+  "previewOnly": true,
+  "verify": true,
+  "returnFields": ["id", "name", "completed", "completionDate"]
+}
+```
+
+Use `state: "active"` to uncomplete tasks. Repeating tasks may advance to the next
+occurrence; the result message reports that behavior.
+
+## Task Moves
+
+Use `move_tasks` for inbox, project, and parent-task moves.
+
+CLI:
+
+```bash
+focusrelay move-tasks task-id-1 task-id-2 \
+  --destination-kind project \
+  --destination-id project-id \
+  --position ending \
+  --preview-only \
+  --verify \
+  --return-fields id,name,projectID,projectName
+```
+
+MCP:
+
+```json
+{
+  "targetIDs": ["task-id-1", "task-id-2"],
+  "move": {
+    "destinationKind": "project",
+    "destinationID": "project-id",
+    "position": "ending"
+  },
+  "previewOnly": true,
+  "verify": true,
+  "returnFields": ["id", "name", "projectID", "projectName"]
+}
+```
+
+Destination kinds:
+
+- `inbox`: omit `destinationID`.
+- `project`: set `destinationID` to a project ID.
+- `parent_task`: set `destinationID` to a parent task ID.
+
+## Project Field Patches
+
+Use `update_projects` for project field edits only.
+
+Supported v1 fields:
+
+- `name`
+- `note`
+- `noteAppend`
+- `flagged`
+- `dueDate`
+- `clearDueDate`
+- `deferDate`
+- `clearDeferDate`
+- `sequential`
+- `reviewInterval`
+
+CLI:
+
+```bash
+focusrelay update-projects project-id-1 \
+  --note-append "Reviewed by AI assistant." \
+  --review-steps 1 \
+  --review-unit weeks \
+  --preview-only \
+  --verify \
+  --return-fields id,name,note,reviewInterval
+```
+
+MCP:
+
+```json
+{
+  "targetIDs": ["project-id-1"],
+  "projectPatch": {
+    "noteAppend": "Reviewed by AI assistant.",
+    "reviewInterval": { "steps": 1, "unit": "weeks" }
+  },
+  "previewOnly": true,
+  "verify": true,
+  "returnFields": ["id", "name", "note", "reviewInterval"]
+}
+```
+
+## Project Status
+
+Use `set_projects_status` for active/on-hold/dropped transitions.
+
+CLI:
+
+```bash
+focusrelay set-projects-status project-id-1 \
+  --status on_hold \
+  --preview-only \
+  --verify \
+  --return-fields id,name,status
+```
+
+MCP:
+
+```json
+{
+  "targetIDs": ["project-id-1"],
+  "projectStatus": { "status": "on_hold" },
+  "previewOnly": true,
+  "verify": true,
+  "returnFields": ["id", "name", "status"]
+}
+```
+
+Supported statuses: `active`, `on_hold`, `dropped`.
+
+## Project Completion Lifecycle
+
+Use `set_projects_completion` for complete and reactivate.
+
+CLI:
+
+```bash
+focusrelay set-projects-completion project-id-1 \
+  --state completed \
+  --preview-only \
+  --verify \
+  --return-fields id,name,status,completionDate
+```
+
+MCP:
+
+```json
+{
+  "targetIDs": ["project-id-1"],
+  "completion": { "state": "completed" },
+  "previewOnly": true,
+  "verify": true,
+  "returnFields": ["id", "name", "status", "completionDate"]
+}
+```
+
+Use `state: "active"` to reactivate projects. Repeating projects may advance to the
+next occurrence; the result message reports that behavior.
+
+## Project Moves
+
+Use `move_projects` to move projects to a folder or back to the root library.
+
+Move to a folder:
+
+```bash
+focusrelay move-projects project-id-1 \
+  --destination-kind folder \
+  --destination-id folder-id \
+  --position ending \
+  --preview-only \
+  --verify \
+  --return-fields id,name,status
+```
+
+Move to the root library by omitting `destinationID`:
+
+```bash
+focusrelay move-projects project-id-1 \
+  --destination-kind folder \
+  --position ending \
+  --preview-only \
+  --verify \
+  --return-fields id,name,status
+```
+
+MCP folder move:
+
+```json
+{
+  "targetIDs": ["project-id-1"],
+  "move": {
+    "destinationKind": "folder",
+    "destinationID": "folder-id",
+    "position": "ending"
+  },
+  "previewOnly": true,
+  "verify": true,
+  "returnFields": ["id", "name", "status"]
+}
+```
+
+MCP root-library move:
+
+```json
+{
+  "targetIDs": ["project-id-1"],
+  "move": {
+    "destinationKind": "folder",
+    "position": "ending"
+  },
+  "previewOnly": true,
+  "verify": true,
+  "returnFields": ["id", "name", "status"]
+}
+```
+
+## Low-Token AI Patterns
+
+Prefer this sequence:
+
+1. Read candidates with `fields: ["id", "name"]` and a small `limit`.
+2. Ask the user to confirm the intended target names if the write is destructive or bulk.
+3. Run the mutation with `previewOnly: true`, `verify: true`, and minimal `returnFields`.
+4. Summarize the preview count and target names.
+5. After confirmation, rerun with `previewOnly: false`.
+6. Report only failed items and a compact success summary.
+
+Avoid this sequence:
+
+1. Reading all projects, tags, tasks, notes, and counts up front.
+2. Sending long notes back in `returnFields` unless the user explicitly asked for note content.
+3. Combining field edits, lifecycle changes, and moves in one conceptual instruction.
+
+## Out Of Scope In V1
+
+- Name-based mutation targeting.
+- Mixed `batch_mutate_tasks` operations.
+- Creating tasks, projects, tags, or folders.
+- Planned-date writes.
+- Project tag mutations.
+- Folder creation or folder rename/delete.

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -62,7 +62,14 @@ This document captures real-world use cases and questions users ask AI about the
 **MCP Tools Needed**:
 - `list_tasks` with inbox filter
 - `list_projects` (for categorization context)
-- Write tools (future): `update_task`, `move_task_to_project`
+- `update_tasks` for shared field/tag patches
+- `move_tasks` for moving tasks to projects or parent tasks
+
+**AI Workflow**:
+1. Read inbox tasks with `fields: ["id", "name"]`.
+2. Read candidate projects with `fields: ["id", "name"]`.
+3. Preview one homogeneous move or patch at a time.
+4. Ask for confirmation before sending the non-preview mutation.
 
 ---
 
@@ -81,7 +88,7 @@ This document captures real-world use cases and questions users ask AI about the
 **MCP Tools Needed**:
 - `list_tasks` with estimatedMinutes field
 - `list_tasks` with due date filters
-- Write tools (future): `update_task` to set estimates
+- `update_tasks` to set one shared estimate on selected task IDs
 
 ---
 
@@ -99,7 +106,8 @@ This document captures real-world use cases and questions users ask AI about the
 **MCP Tools Needed**:
 - `list_projects` (to find related project)
 - `get_task` (to check for duplicates)
-- Write tools (future): `create_task`, `create_project`
+- Not supported in v1: task/project creation
+- Supported adjacent tools: `update_tasks`, `move_tasks`, `update_projects` for organizing existing items
 
 ---
 
@@ -290,50 +298,67 @@ This document captures real-world use cases and questions users ask AI about the
 
 **MCP Tools Needed**:
 - `list_projects` (to avoid duplicates)
-- Write tools (future): `create_project`, `create_task`, `add_subtask`
+- Not supported in v1: project/task creation and subtask creation
+- Supported adjacent tools: `update_projects`, `move_projects`, `set_projects_status`
 
 ---
 
 ## Implementation Status
 
-### Read-Only Use Cases (Current Capabilities)
+### Read Use Cases
 ✅ **Working Today**:
 - Daily planning with available tasks
 - Project priority analysis
 - Basic task listing by project
 - Flagged item identification
+- Date-based task and project queries
+- Duration filtering
+- Tag-based queries
+- Completed task/project analysis
 
-⚠️ **Partial** (Needs Enhancement):
-- Date-based queries (need date range filters)
-- Duration filtering (need min/max filters)
-- Tag-based queries (need tag filter)
-- Completed task analysis (need completion dates)
+### V1 Write Use Cases
+✅ **Working Today With Preview/Verify**:
+- Task field updates through `update_tasks`
+- Task complete/uncomplete through `set_tasks_completion`
+- Task inbox/project/parent moves through `move_tasks`
+- Project field updates through `update_projects`
+- Project active/on-hold/dropped transitions through `set_projects_status`
+- Project complete/reactivate through `set_projects_completion`
+- Project folder/root moves through `move_projects`
 
-❌ **Not Yet** (Requires Write Access):
-- Inbox processing/organization
-- Task estimation updates
-- Creating tasks from discussions
-- Project creation
+V1 write constraints:
+- ID-only mutation targeting
+- Homogeneous bulk only
+- Read-before-write recommended
+- `previewOnly` and `verify` recommended for AI clients
+- Mixed batch mutation is not supported
+
+❌ **Not Yet**:
+- Creating tasks, projects, tags, or folders
+- Mixed-operation batch mutation
+- Name-based mutation targeting
+- Planned-date writes
+- Project tag mutations
+
+See [AI-Optimized Mutation Workflows](mutation-workflows.md) for CLI and MCP examples.
 
 ## Priority Roadmap
 
-### Phase 1: Read-Only Enhancement (High Priority)
-1. Add date range filters (`dueBefore`, `dueAfter`, etc.)
-2. Add duration filtering (`maxEstimatedMinutes`)
-3. Add tag-based filtering
-4. Add creation and completion dates
+### Phase 1: Read/Write Reliability
+1. Keep read trust parity aligned with OmniFocus perspectives.
+2. Keep mutation preview/verify behavior consistent across CLI and MCP.
+3. Maintain cache invalidation after successful writes.
 
-### Phase 2: Search & Discovery (Medium Priority)
-1. Add `search_projects` tool
-2. Add `search_tags` tool
-3. Add per-project task counts
-4. Add analytics endpoints
+### Phase 2: Search & Discovery
+1. Add `search_projects` tool.
+2. Add `search_tags` tool.
+3. Add richer analytics endpoints.
 
-### Phase 3: Write Operations (Future)
-1. Task creation tools
-2. Task update tools
-3. Inbox processing automation
-4. Project management tools
+### Phase 3: Creation And Advanced Writes
+1. Task creation tools.
+2. Project creation tools.
+3. Folder/tag creation tools.
+4. Mixed-operation batch mutation only if a clear AI-safety contract is defined.
 
 ## Success Metrics
 


### PR DESCRIPTION
## Summary
- Adds `docs/mutation-workflows.md` covering the full v1 mutation surface for CLI and MCP clients.
- Documents the patch vs lifecycle/status vs move split, homogeneous bulk-only rule, ID-only targeting, `previewOnly`, `verify`, and compact `returnFields`.
- Updates README examples and tool reference with safe mutation workflows.
- Updates use cases and MCP best practices now that v1 write tools exist.

## Stack / merge order
Depends on PR #51. Merge order remains:
1. #49
2. #50
3. #51
4. this PR

## Notes
- The mutation guide explicitly calls out that folder IDs are not exposed by a dedicated v1 read tool yet, so `move_projects` folder moves require an already-known folder ID. Root-library moves omit `destinationID`.

## Validation
- `swift test`
- `git diff --check`

Refs #36