### PR TITLE
Add list_folders for project move destination discovery

### DIFF
--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -126,6 +126,34 @@
       };
     }
 
+    function collectionLength(collection) {
+      if (!collection) { return 0; }
+      if (Array.isArray(collection)) { return collection.length; }
+      const length = safe(() => collection.length);
+      return (typeof length === "number" && isFinite(length)) ? Math.trunc(length) : 0;
+    }
+
+    function folderToPayload(folder, fields) {
+      const hasField = (name) => fields.length === 0 || fields.indexOf(name) !== -1;
+      const parent = (hasField("parentID") || hasField("parentName")) ? safe(() => folder.parent) : null;
+      const needsProjectCount = hasField("projectCount") || hasField("childFolderCount");
+      const projects = needsProjectCount ? safe(() => folder.projects) : null;
+      const children = hasField("childFolderCount") ? safe(() => folder.children) : null;
+      const projectCount = collectionLength(projects);
+      const childSectionCount = collectionLength(children);
+      // OmniFocus folder.children includes direct child sections, including projects.
+      const childFolderCount = Math.max(childSectionCount - projectCount, 0);
+
+      return {
+        id: hasField("id") ? String(safe(() => folder.id.primaryKey) || "") : null,
+        name: hasField("name") ? String(safe(() => folder.name) || "") : null,
+        parentID: hasField("parentID") && parent ? String(safe(() => parent.id.primaryKey) || "") : null,
+        parentName: hasField("parentName") && parent ? String(safe(() => parent.name) || "") : null,
+        projectCount: hasField("projectCount") ? projectCount : null,
+        childFolderCount: hasField("childFolderCount") ? childFolderCount : null
+      };
+    }
+
     function normalizeIdentifierArray(values) {
       if (!Array.isArray(values)) { return []; }
       return values
@@ -2291,6 +2319,21 @@
           const nextCursor = (offset + limit < tags.length) ? String(offset + limit) : null;
           const returnedCount = items.length;
           response.data = { items: items, nextCursor: nextCursor, returnedCount: returnedCount, totalCount: tags.length };
+        } else if (request.op === "list_folders") {
+          const fields = request.fields || [];
+          const folders = toTaskArray(safe(() => flattenedFolders));
+          const limit = request.page && request.page.limit ? request.page.limit : 150;
+          let offset = 0;
+          if (request.page && request.page.cursor) {
+            const parsed = parseInt(request.page.cursor, 10);
+            if (!isNaN(parsed) && parsed >= 0) { offset = parsed; }
+          }
+
+          const slice = folders.slice(offset, offset + limit);
+          const items = slice.map(folder => folderToPayload(folder, fields));
+          const nextCursor = (offset + limit < folders.length) ? String(offset + limit) : null;
+          const returnedCount = items.length;
+          response.data = { items: items, nextCursor: nextCursor, returnedCount: returnedCount, totalCount: folders.length };
         } else if (request.op === "get_task") {
           const fields = request.fields || [];
           const taskId = request.id;

--- a/README.md
+++ b/README.md
@@ -328,6 +328,12 @@ Query tags with task counts:
 - `statusFilter`: active, onHold, dropped, all
 - `includeTaskCounts`: Get task counts per tag
 
+### list_folders
+Query folders for project move destinations:
+- Default compact fields: `id`, `name`
+- Optional fields: `parentID`, `parentName`, `projectCount`, `childFolderCount`
+- Use before `move_projects` when the destination folder ID is not already known
+
 ### get_task_counts
 Get aggregate counts for any filter combination. Supports full task filtering including:
 - All task filters: completed, completedAfter/Before, tags, project, availableOnly, etc.
@@ -365,7 +371,7 @@ Project tools:
 - `update_projects`: Field patches such as name, note, flagged, due/defer date, sequential, and review interval.
 - `set_projects_status`: Set project status to `active`, `on_hold`, or `dropped`.
 - `set_projects_completion`: Complete or uncomplete projects with `state: completed` or `state: active`.
-- `move_projects`: Move projects to a known folder ID or omit destination ID to move to the root library.
+- `move_projects`: Move projects to a folder ID discovered with `list_folders`, or omit destination ID to move to the root library.
 
 See [`docs/mutation-workflows.md`](docs/mutation-workflows.md) for CLI and MCP examples.
 

--- a/Sources/FocusRelayCLI/FocusRelayCLI.swift
+++ b/Sources/FocusRelayCLI/FocusRelayCLI.swift
@@ -16,6 +16,7 @@ struct FocusRelayCLI: AsyncParsableCommand {
             GetTask.self,
             ListProjects.self,
             ListTags.self,
+            ListFolders.self,
             UpdateTasks.self,
             SetTasksCompletion.self,
             MoveTasks.self,
@@ -187,6 +188,32 @@ struct ListTags: AsyncParsableCommand {
         let result = try await service.listTags(page: pageRequest, statusFilter: statusFilter, includeTaskCounts: includeTaskCounts)
         let fieldSet: Set<String> = ["id", "name", "status", "availableTasks", "remainingTasks", "totalTasks"]
         let items = result.items.map { makeTagOutput(from: $0, fields: fieldSet, includeTaskCounts: includeTaskCounts) }
+        let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount)
+        print(try encodeJSON(output))
+    }
+}
+
+struct ListFolders: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list-folders",
+        abstract: "List OmniFocus folders for project move destination discovery.",
+        aliases: ["list_folders"]
+    )
+
+    @OptionGroup var page: PageOptions
+
+    @Option(help: "Comma-separated field names to return.")
+    var fields: String?
+
+    func run() async throws {
+        let service = OmniFocusBridgeService()
+        let pageRequest = page.makePageRequest(defaultLimit: 150)
+        let fieldList = FieldList.parse(fields)
+        let selectedFields = fieldList.isEmpty ? ["id", "name"] : fieldList
+
+        let result = try await service.listFolders(page: pageRequest, fields: selectedFields)
+        let fieldSet = Set(selectedFields)
+        let items = result.items.map { makeFolderOutput(from: $0, fields: fieldSet) }
         let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount)
         print(try encodeJSON(output))
     }
@@ -459,7 +486,7 @@ struct MoveProjects: AsyncParsableCommand {
     @Option(help: "Destination kind: folder. Omit destination-id to move to the root library.")
     var destinationKind: MutationMoveDestinationKind = .folder
 
-    @Option(help: "Destination folder ID. Omit to move to the root library.")
+    @Option(help: "Destination folder ID from list-folders. Omit to move to the root library.")
     var destinationID: String?
 
     @Option(help: "Placement within the destination: beginning or ending.")

--- a/Sources/FocusRelayOutput/OutputModels.swift
+++ b/Sources/FocusRelayOutput/OutputModels.swift
@@ -153,6 +153,31 @@ public struct TagOutput: Encodable {
     }
 }
 
+public struct FolderOutput: Encodable {
+    public let id: String?
+    public let name: String?
+    public let parentID: String?
+    public let parentName: String?
+    public let projectCount: Int?
+    public let childFolderCount: Int?
+
+    public init(
+        id: String?,
+        name: String?,
+        parentID: String?,
+        parentName: String?,
+        projectCount: Int?,
+        childFolderCount: Int?
+    ) {
+        self.id = id
+        self.name = name
+        self.parentID = parentID
+        self.parentName = parentName
+        self.projectCount = projectCount
+        self.childFolderCount = childFolderCount
+    }
+}
+
 public func makeTaskOutput(from task: TaskItem, fields: Set<String>) -> TaskOutput {
     TaskOutput(
         id: fields.contains("id") ? task.id : nil,
@@ -204,6 +229,17 @@ public func makeTagOutput(from tag: TagItem, fields: Set<String>, includeTaskCou
         availableTasks: includeTaskCounts ? tag.availableTasks : nil,
         remainingTasks: includeTaskCounts ? tag.remainingTasks : nil,
         totalTasks: includeTaskCounts ? tag.totalTasks : nil
+    )
+}
+
+public func makeFolderOutput(from folder: FolderItem, fields: Set<String>) -> FolderOutput {
+    FolderOutput(
+        id: fields.contains("id") ? folder.id : nil,
+        name: fields.contains("name") ? folder.name : nil,
+        parentID: fields.contains("parentID") ? folder.parentID : nil,
+        parentName: fields.contains("parentName") ? folder.parentName : nil,
+        projectCount: fields.contains("projectCount") ? folder.projectCount : nil,
+        childFolderCount: fields.contains("childFolderCount") ? folder.childFolderCount : nil
     )
 }
 

--- a/Sources/FocusRelayServer/FocusRelayServer.swift
+++ b/Sources/FocusRelayServer/FocusRelayServer.swift
@@ -235,6 +235,27 @@ public enum FocusRelayServer {
                     annotations: .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false)
                 ),
                 Tool(
+                    name: "list_folders",
+                    description: "List OmniFocus folders with pagination for project move destination discovery. Use this before move_projects when moving projects into a folder. Compact default fields are id and name; request parentID, parentName, projectCount, or childFolderCount when needed.",
+                    inputSchema: toolSchema(
+                        properties: [
+                            "page": .object([
+                                "type": .string("object"),
+                                "properties": .object([
+                                    "limit": .object(["type": .string("integer")]),
+                                    "cursor": .object(["type": .string("string")])
+                                ])
+                            ]),
+                            "fields": .object([
+                                "type": .string("array"),
+                                "description": .string("Specify folder fields to return: id, name, parentID, parentName, projectCount, childFolderCount."),
+                                "items": .object(["type": .string("string")])
+                            ])
+                        ]
+                    ),
+                    annotations: .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false)
+                ),
+                Tool(
                     name: "update_tasks",
                     description: "Apply one shared task field patch to multiple task IDs. Supports name, note replace, note append, flagged, estimated minutes, due date set/clear, defer date set/clear, and deterministic tag add/remove/set/clear operations.\n\nV1 constraints:\n- task IDs only\n- one shared patch for all targets\n- no completion changes\n- no moves/reparenting\n- no plannedDate writes\n\nUse previewOnly=true to validate without mutating. Use verify=true to confirm the final state. Use returnFields to request compact post-write task fields in the per-item results.",
                     inputSchema: toolSchema(
@@ -467,7 +488,7 @@ public enum FocusRelayServer {
                 ),
                 Tool(
                     name: "move_projects",
-                    description: "Move multiple project IDs to one shared folder or the root library. This tool owns structural project relocation and keeps folder moves out of update_projects.\n\nV1 constraints:\n- project IDs only\n- one shared destination for all targets\n- supported destination kind: folder\n- omit destinationID to move to the root library\n- supported placement values: beginning, ending\n- no field edits\n- no status changes\n- no completion changes\n\nUse previewOnly=true to validate without mutating. Use verify=true to confirm the final state after the move.",
+                    description: "Move multiple project IDs to one shared folder or the root library. Use list_folders first when the destination folder ID is not already known. This tool owns structural project relocation and keeps folder moves out of update_projects.\n\nV1 constraints:\n- project IDs only\n- one shared destination for all targets\n- supported destination kind: folder\n- omit destinationID to move to the root library\n- supported placement values: beginning, ending\n- no field edits\n- no status changes\n- no completion changes\n\nUse previewOnly=true to validate without mutating. Use verify=true to confirm the final state after the move.",
                     inputSchema: toolSchema(
                         properties: [
                             "targetIDs": .object([
@@ -484,7 +505,7 @@ public enum FocusRelayServer {
                                         "enum": .array([.string("folder")]),
                                         "description": .string("Destination kind. Use folder for both folder and root-library project moves.")
                                     ]),
-                                    "destinationID": propertySchema(type: "string", description: "Destination folder ID. Omit to move projects to the root library."),
+                                    "destinationID": propertySchema(type: "string", description: "Destination folder ID from list_folders. Omit to move projects to the root library."),
                                     "position": .object([
                                         "type": .string("string"),
                                         "enum": .array([.string("beginning"), .string("ending")]),
@@ -645,6 +666,16 @@ public enum FocusRelayServer {
                     let result = try await service.listTags(page: page, statusFilter: statusFilter, includeTaskCounts: includeTaskCounts)
                     let fieldSet = Set(["id", "name", "status", "availableTasks", "remainingTasks", "totalTasks"])
                     let items = result.items.map { makeTagOutput(from: $0, fields: fieldSet, includeTaskCounts: includeTaskCounts) }
+                    let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount)
+                    return .init(content: [.text(try encodeJSON(output))])
+                case "list_folders":
+                    let hasPage = params.arguments?["page"] != nil
+                    let page = hasPage ? (try decodeArgument(PageRequest.self, from: params.arguments, key: "page") ?? PageRequest(limit: 150)) : PageRequest(limit: 150)
+                    let requestedFields = decodeStringArray(params.arguments?["fields"]) ?? []
+                    let fields = requestedFields.isEmpty ? ["id", "name"] : requestedFields
+                    let result = try await service.listFolders(page: page, fields: fields)
+                    let fieldSet = Set(fields)
+                    let items = result.items.map { makeFolderOutput(from: $0, fields: fieldSet) }
                     let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount)
                     return .init(content: [.text(try encodeJSON(output))])
                 case "update_tasks":

--- a/Sources/OmniFocusAutomation/BridgeClient.swift
+++ b/Sources/OmniFocusAutomation/BridgeClient.swift
@@ -201,6 +201,42 @@ final class BridgeClient: @unchecked Sendable {
         throw AutomationError.executionFailed(message)
     }
 
+    func listFolders(page: PageRequest, fields: [String]?) throws -> Page<FolderItem> {
+        let requestId = UUID().uuidString
+        let request = BridgeRequest(
+            schemaVersion: 1,
+            requestId: requestId,
+            op: "list_folders",
+            timestamp: ISO8601DateFormatter().string(from: Date()),
+            userTimeZone: TimeZone.current.identifier,
+            id: nil,
+            filter: nil,
+            tagFilter: nil,
+            projectFilter: nil,
+            mutation: nil,
+            fields: fields,
+            page: page
+        )
+
+        let response: BridgeResponse<Page<FolderItemPayload>> = try sendRequest(request, responseType: Page<FolderItemPayload>.self)
+        if response.ok, let payloadPage = response.data {
+            let items = payloadPage.items.map { payload in
+                FolderItem(
+                    id: payload.id ?? "",
+                    name: payload.name ?? "",
+                    parentID: payload.parentID,
+                    parentName: payload.parentName,
+                    projectCount: payload.projectCount,
+                    childFolderCount: payload.childFolderCount
+                )
+            }
+            return Page(items: items, nextCursor: payloadPage.nextCursor, returnedCount: payloadPage.returnedCount, totalCount: payloadPage.totalCount)
+        }
+
+        let message = response.error?.message ?? "Unknown bridge error"
+        throw AutomationError.executionFailed(message)
+    }
+
     func getTask(id: String, fields: [String]?) throws -> TaskItem {
         let requestId = UUID().uuidString
         let request = BridgeRequest(

--- a/Sources/OmniFocusAutomation/OmniFocusAutomation.swift
+++ b/Sources/OmniFocusAutomation/OmniFocusAutomation.swift
@@ -157,6 +157,10 @@ public final class OmniAutomationService: OmniFocusService {
         throw AutomationError.notImplemented
     }
 
+    public func listFolders(page: PageRequest, fields: [String]?) async throws -> Page<FolderItem> {
+        try BridgeClient().listFolders(page: page, fields: fields)
+    }
+
     public func getTaskCounts(filter: TaskFilter) async throws -> TaskCounts {
         let request = TaskCountsRequest(filter: filter)
         let requestData = try requestEncoder.encode(request)

--- a/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
+++ b/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
@@ -85,6 +85,10 @@ public final class OmniFocusBridgeService: OmniFocusService {
         return pageResult
     }
 
+    public func listFolders(page: PageRequest, fields: [String]?) async throws -> Page<FolderItem> {
+        return try client.listFolders(page: page, fields: fields)
+    }
+
     public func getTaskCounts(filter: TaskFilter) async throws -> TaskCounts {
         return try client.getTaskCounts(filter: filter)
     }

--- a/Sources/OmniFocusAutomation/PayloadModels.swift
+++ b/Sources/OmniFocusAutomation/PayloadModels.swift
@@ -57,3 +57,12 @@ struct TagItemPayload: Codable {
     let remainingTasks: Int?
     let totalTasks: Int?
 }
+
+struct FolderItemPayload: Codable {
+    let id: String?
+    let name: String?
+    let parentID: String?
+    let parentName: String?
+    let projectCount: Int?
+    let childFolderCount: Int?
+}

--- a/Sources/OmniFocusCore/OmniFocusCore.swift
+++ b/Sources/OmniFocusCore/OmniFocusCore.swift
@@ -158,6 +158,31 @@ public struct TagItem: Codable, Sendable {
     }
 }
 
+public struct FolderItem: Codable, Sendable {
+    public let id: String
+    public let name: String
+    public let parentID: String?
+    public let parentName: String?
+    public let projectCount: Int?
+    public let childFolderCount: Int?
+
+    public init(
+        id: String,
+        name: String,
+        parentID: String? = nil,
+        parentName: String? = nil,
+        projectCount: Int? = nil,
+        childFolderCount: Int? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.parentID = parentID
+        self.parentName = parentName
+        self.projectCount = projectCount
+        self.childFolderCount = childFolderCount
+    }
+}
+
 public struct TaskCounts: Codable, Sendable {
     public let total: Int
     public let completed: Int
@@ -333,6 +358,7 @@ public protocol OmniFocusService: Sendable {
         fields: [String]?
     ) async throws -> Page<ProjectItem>
     func listTags(page: PageRequest, statusFilter: String?, includeTaskCounts: Bool) async throws -> Page<TagItem>
+    func listFolders(page: PageRequest, fields: [String]?) async throws -> Page<FolderItem>
     func getTaskCounts(filter: TaskFilter) async throws -> TaskCounts
     func getProjectCounts(filter: TaskFilter) async throws -> ProjectCounts
     func performMutation(_ request: MutationRequest) async throws -> MutationResponse

--- a/Tests/FocusRelayCLITests/FocusRelayCLITests.swift
+++ b/Tests/FocusRelayCLITests/FocusRelayCLITests.swift
@@ -166,6 +166,19 @@ func moveProjectsAllowsRootLibraryDestination() throws {
 }
 
 @Test
+func listFoldersParsesFieldsAndPagination() throws {
+    let command = try ListFolders.parse([
+        "--fields", "id,name,parentID",
+        "--limit", "5",
+        "--cursor", "10"
+    ])
+
+    #expect(command.fields == "id,name,parentID")
+    #expect(command.page.limit == 5)
+    #expect(command.page.cursor == "10")
+}
+
+@Test
 func setProjectsCompletionParsesCompletedState() throws {
     let command = try SetProjectsCompletion.parse([
         "project-1",

--- a/Tests/OmniFocusCoreTests/OmniFocusCoreTests.swift
+++ b/Tests/OmniFocusCoreTests/OmniFocusCoreTests.swift
@@ -80,3 +80,24 @@ func projectItemReviewRoundTrip() throws {
     #expect(decoded.reviewInterval?.steps == interval.steps)
     #expect(decoded.reviewInterval?.unit == interval.unit)
 }
+
+@Test
+func folderItemRoundTrip() throws {
+    let folder = FolderItem(
+        id: "folder-1",
+        name: "Travel",
+        parentID: "parent-1",
+        parentName: "Personal",
+        projectCount: 3,
+        childFolderCount: 2
+    )
+
+    let data = try JSONEncoder().encode(folder)
+    let decoded = try JSONDecoder().decode(FolderItem.self, from: data)
+
+    #expect(decoded.id == folder.id)
+    #expect(decoded.name == folder.name)
+    #expect(decoded.parentID == folder.parentID)
+    #expect(decoded.projectCount == folder.projectCount)
+    #expect(decoded.childFolderCount == folder.childFolderCount)
+}

--- a/Tests/OmniFocusIntegrationTests/OmniFocusIntegrationTests.swift
+++ b/Tests/OmniFocusIntegrationTests/OmniFocusIntegrationTests.swift
@@ -549,6 +549,23 @@ func bridgeTagsPagingLive() throws {
     }
 }
 
+@Test
+func bridgeFoldersPagingLive() throws {
+    let env = ProcessInfo.processInfo.environment
+    guard env["FOCUS_RELAY_BRIDGE_TESTS"] == "1" else {
+        return
+    }
+
+    let client = BridgeClient()
+    let first = try client.listFolders(page: PageRequest(limit: 2), fields: ["id", "name"])
+    #expect(first.items.count <= 2)
+    #expect((first.totalCount ?? 0) >= first.items.count)
+    if let cursor = first.nextCursor {
+        let second = try client.listFolders(page: PageRequest(limit: 2, cursor: cursor), fields: ["id", "name", "parentID"])
+        #expect(second.items.count <= 2)
+    }
+}
+
 // MARK: - Status Edge Case Tests
 
 @Test

--- a/docs/mutation-workflows.md
+++ b/docs/mutation-workflows.md
@@ -28,6 +28,9 @@ FocusRelay v1 write tools are designed to be low-token, deterministic, and easy 
 | Set project active, on-hold, or dropped | `set_projects_status` | `focusrelay set-projects-status` |
 | Complete or uncomplete projects | `set_projects_completion` | `focusrelay set-projects-completion` |
 | Move projects to a folder or root library | `move_projects` | `focusrelay move-projects` |
+| Discover project folder IDs before moves | `list_folders` | `focusrelay list-folders` |
+
+Do not use `update_tasks` or `update_projects` for completion, status, or move behavior.
 
 ## Read Before Write
 
@@ -61,6 +64,8 @@ MCP example:
 ```
 
 ## Low-Token Output
+
+When a mutation needs tag, project, parent-task, or folder IDs, read those IDs first. Do not ask the model to infer IDs from names already shown in prior conversation unless the ID is still visible in context. Use `list_folders` before folder moves when the folder ID is not already known, or omit `destinationID` to move projects to the root library.
 
 Default mutation responses are compact. Add `returnFields` only when the next step needs those fields.
 
@@ -144,11 +149,12 @@ focusrelay set-projects-completion project-1 --state active --verify --return-fi
 Move to a known folder ID, or omit `--destination-id` to move to the root library.
 
 ```bash
+focusrelay list-folders --fields id,name,parentID,parentName --limit 50
 focusrelay move-projects project-1 --destination-kind folder --destination-id folder-1 --verify --return-fields id,name,status
 focusrelay move-projects project-1 --destination-kind folder --verify --return-fields id,name,status
 ```
 
-V1 does not include a public folder discovery tool. Agents must not invent folder IDs; use `move_projects` only when the destination folder ID is known, or omit `destinationID` for a root-library move.
+Agents must not invent folder IDs. Use `list_folders` when the destination folder ID is not already known.
 
 ## MCP Examples
 
@@ -208,6 +214,17 @@ Call `update_tasks` again with `"previewOnly": false` and `"verify": true` after
 ```
 
 ### Move Projects
+
+Before a folder move, call `list_folders` with compact fields if you do not already have the folder ID:
+
+```json
+{
+  "fields": ["id", "name", "parentID", "parentName"],
+  "limit": 50
+}
+```
+
+Then call `move_projects`:
 
 ```json
 {

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -312,6 +312,7 @@ This document captures real-world use cases and questions users ask AI about the
 - Tag-based task filtering
 - Completed task/project analysis
 - Project and task counts
+- Folder destination discovery through `list_folders`
 
 ### Current Write Capabilities
 ✅ **Working Today**:
@@ -335,7 +336,6 @@ This document captures real-world use cases and questions users ask AI about the
 - Mixed-operation `batch_mutate_tasks`
 - Name-based or fuzzy mutation targeting
 - Planned-date writes
-- Public folder discovery for project moves
 
 ## Priority Roadmap
 


### PR DESCRIPTION
## Summary
- add `list_folders` MCP tool and `focusrelay list-folders` CLI command for project move destination discovery
- add shared `FolderItem` output model, bridge request/response plumbing, pagination, and compact field selection
- update `move_projects` docs/tool descriptions to point users to `list_folders` instead of requiring known folder IDs

## Validation
- `node --check Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js`
- `git diff --check origin/master..HEAD`
- `swift test`
- `./scripts/install-plugin.sh`, full OmniFocus restart, `bridge-health-check`
- live smoke: `./.build/debug/focusrelay list-folders --fields id,name --limit 5`
- live smoke: `./.build/debug/focusrelay list-folders --fields id,name,parentID,parentName,projectCount,childFolderCount --limit 2`

Closes #53
