### PR TITLE
Document AI-optimized mutation workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Stop clicking through endless task lists. Just ask:
 - "Find my flagged items"
 - "What did I accomplish this week?"
 
+**Safe Task And Project Updates**
+- "Flag these tasks and set the due date"
+- "Complete these tasks after I confirm the IDs"
+- "Move these inbox tasks into the right project"
+- "Put this project on hold"
+- "Move this project back to the root library"
+
 ## Features
 
 - **Time-based Queries**: Natural language time period filtering
@@ -39,6 +46,7 @@ Stop clicking through endless task lists. Just ask:
 - **Context Awareness**: Tag-based filtering and availability
 - **Completion Date Filtering**: Query completed tasks/projects by specific date ranges
 - **Smart Filtering**: By tags, due dates, defer dates, completion, duration
+- **V1 Write Tools**: Update, complete/uncomplete, and move tasks/projects with preview and verification support
 - **Timezone Aware**: Automatic local timezone detection and handling
 - **High Performance**: Single-pass filtering with early exit optimization
 
@@ -211,9 +219,23 @@ focusrelay bridge-health-check
 
 # List tasks with total count (shows returnedCount and totalCount)
 focusrelay list-tasks --fields name --limit 10 --include-total-count
+
+# Preview a task field patch before writing
+focusrelay update-tasks <task-id> --flagged true --preview-only --return-fields id,name,flagged
+
+# Complete tasks with post-write verification
+focusrelay set-tasks-completion <task-id> --state completed --verify --return-fields id,name,completed,completionDate
+
+# Move tasks to a project
+focusrelay move-tasks <task-id> --destination-kind project --destination-id <project-id> --verify --return-fields id,name,projectID,projectName
+
+# Put a project on hold
+focusrelay set-projects-status <project-id> --status on_hold --verify --return-fields id,name,status
 ```
 
 Dates should be ISO8601 (e.g. `2026-02-04T12:00:00Z`).
+
+For write workflows, tool routing, and low-token MCP examples, see [`docs/mutation-workflows.md`](docs/mutation-workflows.md).
 
 ## Usage Examples
 
@@ -323,6 +345,29 @@ Get counts of projects and actions. Supports completion date filtering:
 - **Use case**: "How many projects did I complete this month?" without listing all items
 
 Example: Count projects completed in the last 30 days
+
+### Mutation tools
+FocusRelay v1 write tools are available through both MCP and CLI. They use the same shared request models and validation rules.
+
+Core rules:
+- Mutations target IDs only; use read tools first to resolve names to IDs.
+- Bulk writes are homogeneous; one call applies one shared patch, state, or destination to every ID.
+- Use `previewOnly` before risky or bulk writes.
+- Use `verify` for post-write readback.
+- Use `returnFields` to keep responses compact.
+
+Task tools:
+- `update_tasks`: Field patches such as name, note, flagged, estimated minutes, due/defer date, and tag add/remove/set/clear.
+- `set_tasks_completion`: Complete or uncomplete tasks with `state: completed` or `state: active`.
+- `move_tasks`: Move tasks to inbox, a project, or a parent task.
+
+Project tools:
+- `update_projects`: Field patches such as name, note, flagged, due/defer date, sequential, and review interval.
+- `set_projects_status`: Set project status to `active`, `on_hold`, or `dropped`.
+- `set_projects_completion`: Complete or uncomplete projects with `state: completed` or `state: active`.
+- `move_projects`: Move projects to a known folder ID or omit destination ID to move to the root library.
+
+See [`docs/mutation-workflows.md`](docs/mutation-workflows.md) for CLI and MCP examples.
 
 ## Timezone Handling
 

--- a/docs/mutation-workflows.md
+++ b/docs/mutation-workflows.md
@@ -1,0 +1,234 @@
+# Mutation Workflows For CLI And MCP
+
+FocusRelay v1 write tools are designed to be low-token, deterministic, and easy for AI agents to route correctly. The core split is:
+
+- Use `update_*` for field patches.
+- Use `set_*_completion` for complete or uncomplete lifecycle changes.
+- Use `set_projects_status` for project active, on-hold, or dropped state.
+- Use `move_*` for structural moves.
+
+## Core Rules
+
+- Mutations target IDs only. Use read tools first to find IDs; do not mutate by name.
+- Bulk calls are homogeneous. One call applies one shared patch, state, or destination to every ID.
+- Single-item writes use the same tools as bulk writes with one ID.
+- Use `previewOnly=true` before risky or bulk writes.
+- Use `verify=true` for real writes when the agent needs readback confidence.
+- Use `returnFields` to keep responses compact.
+- Do not mix unrelated writes in one call. `batch_mutate_tasks` is intentionally out of scope for v1.
+
+## Tool Routing
+
+| Intent | MCP tool | CLI command |
+| --- | --- | --- |
+| Rename, flag, note, due/defer date, estimate, or task tags | `update_tasks` | `focusrelay update-tasks` |
+| Complete or uncomplete tasks | `set_tasks_completion` | `focusrelay set-tasks-completion` |
+| Move tasks to inbox, project, or parent task | `move_tasks` | `focusrelay move-tasks` |
+| Rename, flag, note, due/defer date, sequential, or review interval | `update_projects` | `focusrelay update-projects` |
+| Set project active, on-hold, or dropped | `set_projects_status` | `focusrelay set-projects-status` |
+| Complete or uncomplete projects | `set_projects_completion` | `focusrelay set-projects-completion` |
+| Move projects to a folder or root library | `move_projects` | `focusrelay move-projects` |
+
+## Read Before Write
+
+Use this pattern for both CLI and MCP:
+
+1. Read candidates with only the fields needed to identify the target.
+2. Ask the user to confirm if the target is ambiguous or the write is broad.
+3. Preview the mutation with the target IDs.
+4. Execute with `verify=true` and minimal `returnFields`.
+
+CLI example:
+
+```bash
+focusrelay list-tasks --search "intro call" --fields id,name,projectName,tagNames --limit 5
+focusrelay update-tasks task-1 --flagged true --preview-only --return-fields id,name,flagged
+focusrelay update-tasks task-1 --flagged true --verify --return-fields id,name,flagged
+```
+
+MCP example:
+
+```json
+{
+  "tool": "update_tasks",
+  "arguments": {
+    "targetIDs": ["task-1"],
+    "taskPatch": { "flagged": true },
+    "previewOnly": true,
+    "returnFields": ["id", "name", "flagged"]
+  }
+}
+```
+
+## Low-Token Output
+
+Default mutation responses are compact. Add `returnFields` only when the next step needs those fields.
+
+Good field sets:
+
+- Task patch: `["id", "name", "flagged", "dueDate", "deferDate"]`
+- Task completion: `["id", "name", "completed", "completionDate"]`
+- Task move: `["id", "name", "projectID", "projectName"]`
+- Project patch/status: `["id", "name", "status", "flagged"]`
+- Project completion: `["id", "name", "status", "completionDate"]`
+
+Avoid returning notes unless the user needs note content.
+
+## CLI Examples
+
+### Task Patches
+
+Set and clear fields:
+
+```bash
+focusrelay update-tasks task-1 task-2 --flagged true --verify --return-fields id,name,flagged
+focusrelay update-tasks task-1 --due-date 2026-04-18T16:00:00Z --verify --return-fields id,name,dueDate
+focusrelay update-tasks task-1 --clear-due-date --verify --return-fields id,name,dueDate
+focusrelay update-tasks task-1 --estimated-minutes 30 --verify --return-fields id,name,estimatedMinutes
+```
+
+Rename and note changes:
+
+```bash
+focusrelay update-tasks task-1 --name "Send intro call notes" --verify --return-fields id,name
+focusrelay update-tasks task-1 --note-append "Follow up after call." --verify --return-fields id,name
+```
+
+Tags use tag IDs:
+
+```bash
+focusrelay list-tags --include-task-counts
+focusrelay update-tasks task-1 --tag-add tag-1 --verify --return-fields id,name,tagIDs,tagNames
+focusrelay update-tasks task-1 --tag-remove tag-1 --verify --return-fields id,name,tagIDs,tagNames
+```
+
+### Task Completion
+
+```bash
+focusrelay set-tasks-completion task-1 task-2 --state completed --verify --return-fields id,name,completed,completionDate
+focusrelay set-tasks-completion task-1 --state active --verify --return-fields id,name,completed,completionDate
+```
+
+For repeating tasks, OmniFocus may complete an occurrence and advance the original task. Use `verify=true` and read the returned message.
+
+### Task Moves
+
+```bash
+focusrelay move-tasks task-1 --destination-kind inbox --verify --return-fields id,name,projectID,projectName
+focusrelay move-tasks task-1 task-2 --destination-kind project --destination-id project-1 --verify --return-fields id,name,projectID,projectName
+focusrelay move-tasks task-1 --destination-kind parent_task --destination-id parent-task-1 --position ending --verify --return-fields id,name
+```
+
+### Project Patches
+
+```bash
+focusrelay update-projects project-1 --flagged true --verify --return-fields id,name,flagged
+focusrelay update-projects project-1 --due-date 2026-04-30T16:00:00Z --verify --return-fields id,name,dueDate
+focusrelay update-projects project-1 --sequential true --verify --return-fields id,name
+focusrelay update-projects project-1 --review-steps 1 --review-unit weeks --verify --return-fields id,name,reviewInterval
+```
+
+### Project Status And Completion
+
+Use status for active/on-hold/dropped. Use completion for done/active lifecycle.
+
+```bash
+focusrelay set-projects-status project-1 --status on_hold --verify --return-fields id,name,status
+focusrelay set-projects-status project-1 --status active --verify --return-fields id,name,status
+focusrelay set-projects-completion project-1 --state completed --verify --return-fields id,name,status,completionDate
+focusrelay set-projects-completion project-1 --state active --verify --return-fields id,name,status,completionDate
+```
+
+### Project Moves
+
+Move to a known folder ID, or omit `--destination-id` to move to the root library.
+
+```bash
+focusrelay move-projects project-1 --destination-kind folder --destination-id folder-1 --verify --return-fields id,name,status
+focusrelay move-projects project-1 --destination-kind folder --verify --return-fields id,name,status
+```
+
+V1 does not include a public folder discovery tool. Agents must not invent folder IDs; use `move_projects` only when the destination folder ID is known, or omit `destinationID` for a root-library move.
+
+## MCP Examples
+
+The JSON blocks below are MCP tool arguments. Call the tool named in each heading.
+
+### Bulk Task Update
+
+```json
+{
+  "targetIDs": ["task-1", "task-2"],
+  "taskPatch": {
+    "flagged": true,
+    "dueDate": "2026-04-18T16:00:00Z"
+  },
+  "previewOnly": true,
+  "returnFields": ["id", "name", "flagged", "dueDate"]
+}
+```
+
+Call `update_tasks` again with `"previewOnly": false` and `"verify": true` after confirmation.
+
+### Complete Tasks
+
+```json
+{
+  "targetIDs": ["task-1", "task-2"],
+  "completion": { "state": "completed" },
+  "verify": true,
+  "returnFields": ["id", "name", "completed", "completionDate"]
+}
+```
+
+### Move Tasks To A Project
+
+```json
+{
+  "targetIDs": ["task-1", "task-2"],
+  "move": {
+    "destinationKind": "project",
+    "destinationID": "project-1",
+    "position": "ending"
+  },
+  "verify": true,
+  "returnFields": ["id", "name", "projectID", "projectName"]
+}
+```
+
+### Update Project Status
+
+```json
+{
+  "targetIDs": ["project-1"],
+  "projectStatus": { "status": "on_hold" },
+  "verify": true,
+  "returnFields": ["id", "name", "status"]
+}
+```
+
+### Move Projects
+
+```json
+{
+  "targetIDs": ["project-1"],
+  "move": {
+    "destinationKind": "folder",
+    "destinationID": "folder-1",
+    "position": "ending"
+  },
+  "verify": true,
+  "returnFields": ["id", "name", "status"]
+}
+```
+
+For root-library moves, omit `destinationID`.
+
+## Safety Notes
+
+- Prefer preview for every bulk write.
+- Ask for confirmation before real writes when the user has not explicitly approved the exact IDs and operation.
+- Do not use `update_tasks` to complete tasks; use `set_tasks_completion`.
+- Do not use `update_projects` to complete, drop, or move projects; use the lifecycle/status/move tools.
+- Do not mutate by name. Names are only for read-side discovery and user confirmation.
+- Do not attempt create/delete/repeat-rule/planned-date writes in v1.

--- a/docs/omni-automation-write-contract.md
+++ b/docs/omni-automation-write-contract.md
@@ -9,6 +9,7 @@ Scope:
 
 Workflow companion:
 - [`docs/mutation-change-checklist.md`](./mutation-change-checklist.md)
+- [`docs/mutation-workflows.md`](./mutation-workflows.md)
 
 Primary source:
 - [OmniFocus Omni Automation index](https://omni-automation.com/omnifocus/index.html)

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -62,7 +62,9 @@ This document captures real-world use cases and questions users ask AI about the
 **MCP Tools Needed**:
 - `list_tasks` with inbox filter
 - `list_projects` (for categorization context)
-- Write tools (future): `update_task`, `move_task_to_project`
+- `update_tasks` (rename, flag, tag, due/defer dates, estimates)
+- `move_tasks` (move inbox items to a project or parent task)
+- Future: `create_task`, `create_project` when an inbox item needs a new destination
 
 ---
 
@@ -81,7 +83,7 @@ This document captures real-world use cases and questions users ask AI about the
 **MCP Tools Needed**:
 - `list_tasks` with estimatedMinutes field
 - `list_tasks` with due date filters
-- Write tools (future): `update_task` to set estimates
+- `update_tasks` to set estimates
 
 ---
 
@@ -100,6 +102,7 @@ This document captures real-world use cases and questions users ask AI about the
 - `list_projects` (to find related project)
 - `get_task` (to check for duplicates)
 - Write tools (future): `create_task`, `create_project`
+- Current write tools can update or move existing tasks, but cannot create new tasks/projects in v1
 
 ---
 
@@ -159,6 +162,8 @@ This document captures real-world use cases and questions users ask AI about the
 - `list_tasks` by project
 - `get_project_counts`
 - `get_task_counts`
+- `set_projects_status` (put projects on hold, reactivate, or drop)
+- `set_projects_completion` (complete or uncomplete projects)
 
 ---
 
@@ -296,44 +301,64 @@ This document captures real-world use cases and questions users ask AI about the
 
 ## Implementation Status
 
-### Read-Only Use Cases (Current Capabilities)
+### Current Read Capabilities
 ✅ **Working Today**:
 - Daily planning with available tasks
 - Project priority analysis
 - Basic task listing by project
 - Flagged item identification
+- Date-based queries for due, defer, planned, and completed windows
+- Duration filtering with estimated minutes
+- Tag-based task filtering
+- Completed task/project analysis
+- Project and task counts
 
-⚠️ **Partial** (Needs Enhancement):
-- Date-based queries (need date range filters)
-- Duration filtering (need min/max filters)
-- Tag-based queries (need tag filter)
-- Completed task analysis (need completion dates)
+### Current Write Capabilities
+✅ **Working Today**:
+- Update existing task fields with `update_tasks`
+- Complete or uncomplete tasks with `set_tasks_completion`
+- Move tasks to inbox, project, or parent task with `move_tasks`
+- Update existing project fields with `update_projects`
+- Set project active/on-hold/dropped status with `set_projects_status`
+- Complete or uncomplete projects with `set_projects_completion`
+- Move projects to a known folder ID or root library with `move_projects`
 
-❌ **Not Yet** (Requires Write Access):
-- Inbox processing/organization
-- Task estimation updates
-- Creating tasks from discussions
-- Project creation
+⚠️ **Important Constraints**:
+- Writes target IDs only; use read tools first to resolve names to IDs.
+- Bulk writes are homogeneous; one call applies one patch, state, or destination to all IDs.
+- Use `previewOnly` before risky or broad changes.
+- Use `verify` and compact `returnFields` for post-write readback.
+
+❌ **Not Yet In V1**:
+- Creating tasks, projects, folders, or tags
+- Deleting tasks or projects
+- Mixed-operation `batch_mutate_tasks`
+- Name-based or fuzzy mutation targeting
+- Planned-date writes
+- Public folder discovery for project moves
 
 ## Priority Roadmap
 
-### Phase 1: Read-Only Enhancement (High Priority)
-1. Add date range filters (`dueBefore`, `dueAfter`, etc.)
-2. Add duration filtering (`maxEstimatedMinutes`)
-3. Add tag-based filtering
-4. Add creation and completion dates
+### Phase 1: Read And Write Foundation
+1. Date range filters (`dueBefore`, `dueAfter`, completion windows)
+2. Duration filtering (`maxEstimatedMinutes`)
+3. Tag-based filtering
+4. Completion date parity
+5. V1 mutation tools for existing tasks and projects
 
 ### Phase 2: Search & Discovery (Medium Priority)
 1. Add `search_projects` tool
 2. Add `search_tags` tool
 3. Add per-project task counts
-4. Add analytics endpoints
+4. Add folder discovery for project moves
+5. Add analytics endpoints
 
-### Phase 3: Write Operations (Future)
+### Phase 3: Creation And Advanced Writes (Future)
 1. Task creation tools
-2. Task update tools
-3. Inbox processing automation
-4. Project management tools
+2. Project creation tools
+3. Inbox processing automation that can create missing destinations
+4. Delete/archive tools with explicit confirmation
+5. Advanced batch workflows if a clear safe contract emerges
 
 ## Success Metrics
 


### PR DESCRIPTION
## Summary

Closes #36.

Adds user-facing docs for the shipped v1 mutation surface:

- new `docs/mutation-workflows.md` with CLI and MCP routing guidance
- README examples and mutation tool overview
- `docs/use-cases.md` status refresh so shipped write tools are no longer described as future
- write contract link to the workflow companion doc

## Notes

The docs emphasize the locked v1 constraints:

- ID-only mutation targeting
- homogeneous bulk writes only
- patch vs lifecycle/status vs move tool split
- `previewOnly`, `verify`, and compact `returnFields`
- explicit out-of-scope items including mixed `batch_mutate_tasks`, create/delete tools, planned-date writes, and folder discovery

## Validation

- `git diff --check`
- `swift test` passed: 95 Swift Testing tests
