### PR TITLE
Fix list_projects empty completion windows (#97)

### DIFF
--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -1399,6 +1399,26 @@
       return ts;
     }
 
+    // PROJECT COMPLETION QUERY MODULE - list_projects completion vs statusFilter
+    // When clients request completed projects by window without overriding statusFilter,
+    // the server default statusFilter is "active". Completion queries must not apply that
+    // active filter first, or every Done project is removed before the completion pass.
+    function isProjectCompletionQuery(filter) {
+      if (!filter || typeof filter !== "object") { return false; }
+      if (filter.completed === true) { return true; }
+      if (filter.completedAfter) { return true; }
+      if (filter.completedBefore) { return true; }
+      return false;
+    }
+
+    function shouldApplyListProjectsStatusFilter(statusFilter, reviewPerspective, isCompletionQuery) {
+      if (reviewPerspective) { return false; }
+      if (isCompletionQuery) { return false; }
+      if (!statusFilter || statusFilter === "all") { return false; }
+      return true;
+    }
+    // END PROJECT COMPLETION QUERY MODULE
+
     // Normalize OmniFocus collections to plain arrays.
     function toTaskArray(collection) {
       if (!collection) { return []; }
@@ -2203,17 +2223,25 @@
           const reviewDueBefore = parseFilterDate(filter.reviewDueBefore, response.warnings);
           const reviewDueAfter = parseFilterDate(filter.reviewDueAfter, response.warnings);
           const reviewCutoff = reviewDueBefore || (reviewPerspective ? new Date() : null);
+
+          // Detect completion queries before status filtering. Default statusFilter is
+          // "active"; applying it first would exclude every Done project and make
+          // completion windows always empty.
+          const completedAfter = filter.completedAfter ? parseFilterDate(filter.completedAfter, response.warnings) : null;
+          const completedBefore = filter.completedBefore ? parseFilterDate(filter.completedBefore, response.warnings) : null;
+          const isCompletionQuery = isProjectCompletionQuery(filter);
           
           let projects = flattenedProjects;
           
-          // Filter by status using Project.Status enum
+          // Filter by status using Project.Status enum.
+          // Completion queries target Done projects only (below); skip statusFilter.
           if (reviewPerspective) {
             projects = projects.filter(p => {
               const status = safe(() => p.status);
               if (!status) return false;
               return status !== Project.Status.Dropped && status !== Project.Status.Done;
             });
-          } else if (statusFilter !== "all") {
+          } else if (shouldApplyListProjectsStatusFilter(statusFilter, false, isCompletionQuery)) {
             projects = projects.filter(p => {
               const status = safe(() => p.status);
               if (!status) return false;
@@ -2241,13 +2269,7 @@
             });
           }
 
-          // Completion date filtering for projects
-          const projectFilter = request.projectFilter || {};
-          const completedAfter = projectFilter.completedAfter ? parseFilterDate(projectFilter.completedAfter, response.warnings) : null;
-          const completedBefore = projectFilter.completedBefore ? parseFilterDate(projectFilter.completedBefore, response.warnings) : null;
-          const completedOnly = projectFilter.completed === true;
-
-          if (completedOnly || completedAfter || completedBefore) {
+          if (isCompletionQuery) {
             projects = projects.filter(p => {
               const status = safe(() => p.status);
               // Only include completed projects (status = Done), exclude dropped
@@ -2256,6 +2278,7 @@
               const completionDate = getProjectDateTimestamp(p, project => project.completionDate);
               if (completionDate === null) return false;
 
+              // Inclusive bounds on both ends (matches task date filters).
               if (completedAfter && completionDate < completedAfter.getTime()) return false;
               if (completedBefore && completionDate > completedBefore.getTime()) return false;
 

--- a/Sources/FocusRelayServer/FocusRelayServer.swift
+++ b/Sources/FocusRelayServer/FocusRelayServer.swift
@@ -60,7 +60,8 @@ public enum FocusRelayServer {
     - Default fields are 'id' and 'name'. When statusFilter='all' or includeTaskCounts=true, the defaults also include 'status'.
 
     COMPLETED PROJECTS (matches OmniFocus Completed perspective):
-    - Use completedAfter/completedBefore with ISO8601 dates to find completed projects in time windows.
+    - Use completed=true and/or completedAfter/completedBefore (ISO8601, inclusive) to find completed projects in time windows.
+    - Completion filters imply Done projects: default statusFilter='active' is ignored for these queries so results are not empty.
     - Excludes dropped projects (only status=done projects with completion dates).
     - Results are sorted by completionDate descending (most recent first).
     - Include 'completionDate' in fields to see when projects were completed.
@@ -276,12 +277,12 @@ public enum FocusRelayServer {
                             ]),
                             "completedAfter": .object([
                                 "type": .string("string"),
-                                "description": .string("ISO8601 datetime. Projects completed after this time (inclusive). Use with completed=true to find completed projects in time windows."),
+                                "description": .string("ISO8601 datetime. Projects completed on or after this time (inclusive). Completion queries ignore default statusFilter=active and return Done projects only."),
                                 "examples": .array([.string("2026-01-01T00:00:00Z")])
                             ]),
                             "completedBefore": .object([
                                 "type": .string("string"),
-                                "description": .string("ISO8601 datetime. Projects completed before this time (exclusive). Use with completed=true to find completed projects in time windows."),
+                                "description": .string("ISO8601 datetime. Projects completed on or before this time (inclusive). Completion queries ignore default statusFilter=active and return Done projects only."),
                                 "examples": .array([.string("2026-02-01T00:00:00Z")])
                             ]),
                             "includeTaskCounts": .object([

--- a/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
+++ b/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
@@ -188,6 +188,8 @@ func projectToolDescriptionGuardsCompletionAndStalledRecommendations() {
     #expect(description.contains("totalTasks=0 means the project is empty or unplanned"))
     #expect(description.contains("If all child tasks are dropped, treat it as a drop/review candidate"))
     #expect(description.contains("availableTasks=0 does not mean a project is stalled"))
+    #expect(description.contains("default statusFilter='active' is ignored"))
+    #expect(description.contains("inclusive"))
 }
 
 @Test

--- a/Tests/OmniFocusIntegrationTests/ListProjectsCompletionFilterTests.swift
+++ b/Tests/OmniFocusIntegrationTests/ListProjectsCompletionFilterTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import JavaScriptCore
+import Testing
+
+/// Regression coverage for #97: completion windows must not be emptied by default statusFilter=active.
+@Test
+func projectCompletionQuerySkipsDefaultActiveStatusFilter() throws {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js")
+    let librarySource = try String(contentsOf: sourceURL, encoding: .utf8)
+    let startMarker = "// PROJECT COMPLETION QUERY MODULE - list_projects completion vs statusFilter"
+    let endMarker = "// END PROJECT COMPLETION QUERY MODULE"
+    guard let start = librarySource.range(of: startMarker),
+          let end = librarySource.range(of: endMarker, range: start.upperBound..<librarySource.endIndex) else {
+        Issue.record("Missing PROJECT COMPLETION QUERY MODULE in BridgeLibrary.js")
+        return
+    }
+    let module = String(librarySource[start.lowerBound..<end.upperBound])
+
+    let context = JSContext()!
+    var exceptionMessage: String?
+    context.exceptionHandler = { _, exception in
+        exceptionMessage = exception?.toString()
+    }
+
+    let script = """
+    \(module)
+    const projects = [
+      { id: "active", status: "Active", completionDate: null },
+      { id: "done-in-window", status: "Done", completionDate: new Date("2026-01-15T12:00:00Z") },
+      { id: "done-out-of-window", status: "Done", completionDate: new Date("2025-01-01T12:00:00Z") },
+      { id: "dropped", status: "Dropped", completionDate: new Date("2026-01-15T12:00:00Z") }
+    ];
+    const filter = {
+      completed: true,
+      completedAfter: "2026-01-01T00:00:00Z",
+      completedBefore: "2026-02-01T00:00:00Z"
+    };
+    const statusFilter = "active";
+    const isCompletionQuery = isProjectCompletionQuery(filter);
+    const applyStatus = shouldApplyListProjectsStatusFilter(statusFilter, false, isCompletionQuery);
+    let filtered = projects;
+    if (applyStatus) {
+      filtered = filtered.filter(p => p.status === "Active");
+    }
+    // Mirror list_projects completion pass (Done + inclusive window).
+    const after = new Date(filter.completedAfter).getTime();
+    const before = new Date(filter.completedBefore).getTime();
+    filtered = filtered.filter(p => {
+      if (p.status !== "Done") return false;
+      if (!p.completionDate) return false;
+      const ts = p.completionDate.getTime();
+      if (ts < after) return false;
+      if (ts > before) return false;
+      return true;
+    });
+    JSON.stringify({
+      isCompletionQuery: isCompletionQuery,
+      applyStatus: applyStatus,
+      ids: filtered.map(p => p.id)
+    });
+    """
+
+    guard let json = context.evaluateScript(script)?.toString(), exceptionMessage == nil else {
+        Issue.record("JS evaluation failed: \(exceptionMessage ?? "no result")")
+        return
+    }
+    struct Result: Decodable {
+        let isCompletionQuery: Bool
+        let applyStatus: Bool
+        let ids: [String]
+    }
+    let decoded = try JSONDecoder().decode(Result.self, from: Data(json.utf8))
+    #expect(decoded.isCompletionQuery)
+    #expect(!decoded.applyStatus)
+    #expect(decoded.ids == ["done-in-window"])
+}
+
+@Test
+func projectCompletionQueryHelpersIgnoreNonCompletionFilters() throws {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js")
+    let librarySource = try String(contentsOf: sourceURL, encoding: .utf8)
+    let startMarker = "// PROJECT COMPLETION QUERY MODULE - list_projects completion vs statusFilter"
+    let endMarker = "// END PROJECT COMPLETION QUERY MODULE"
+    guard let start = librarySource.range(of: startMarker),
+          let end = librarySource.range(of: endMarker, range: start.upperBound..<librarySource.endIndex) else {
+        Issue.record("Missing PROJECT COMPLETION QUERY MODULE in BridgeLibrary.js")
+        return
+    }
+    let module = String(librarySource[start.lowerBound..<end.upperBound])
+
+    let context = JSContext()!
+    let script = """
+    \(module)
+    JSON.stringify({
+      plainActive: isProjectCompletionQuery({ statusFilter: "active" }),
+      completedFalse: isProjectCompletionQuery({ completed: false }),
+      afterOnly: isProjectCompletionQuery({ completedAfter: "2026-01-01T00:00:00Z" }),
+      applyActive: shouldApplyListProjectsStatusFilter("active", false, false),
+      applyAll: shouldApplyListProjectsStatusFilter("all", false, false),
+      applyReview: shouldApplyListProjectsStatusFilter("active", true, false)
+    });
+    """
+    let json = try #require(context.evaluateScript(script)?.toString())
+    struct Result: Decodable {
+        let plainActive: Bool
+        let completedFalse: Bool
+        let afterOnly: Bool
+        let applyActive: Bool
+        let applyAll: Bool
+        let applyReview: Bool
+    }
+    let decoded = try JSONDecoder().decode(Result.self, from: Data(json.utf8))
+    #expect(!decoded.plainActive)
+    #expect(!decoded.completedFalse)
+    #expect(decoded.afterOnly)
+    #expect(decoded.applyActive)
+    #expect(!decoded.applyAll)
+    #expect(!decoded.applyReview)
+}


### PR DESCRIPTION
## Summary
- `list_projects` completion filters no longer apply default `statusFilter=active` first (which made Done results always empty).
- Document that completion queries imply Done projects and use inclusive date bounds.
- JSCore regression tests for the completion/status gate helpers.

## Validation
- `swift test --filter 'projectCompletionQuery|projectToolDescriptionGuards'`
- `swift run focusrelay-dev validate --impact query` (ok)

Closes #97