### PR TITLE
Treat completed=false as remaining semantics (#98)

### DIFF
--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -1223,6 +1223,26 @@
     }
 
     /**
+     * Match the shared completed filter against remaining/completed contract.
+     * - completed === true  → only Completed tasks
+     * - completed === false → remaining (not completed/dropped, parent chain allows)
+     * - completed omitted   → remaining unless everythingView is true
+     */
+    function matchesCompletedFilterWithStatus(task, taskStatusValue, completedFilter, everythingView) {
+      if (completedFilter === true) {
+        return isCompletedStatusValue(taskStatusValue);
+      }
+      if (completedFilter === false || !everythingView) {
+        return isRemainingStatusWithStatus(task, taskStatusValue);
+      }
+      return true;
+    }
+
+    function matchesCompletedFilter(task, completedFilter, everythingView) {
+      return matchesCompletedFilterWithStatus(task, taskStatus(task), completedFilter, everythingView);
+    }
+
+    /**
      * Check if task status indicates availability
      * Note: This checks ONLY the task status, not project/parent status
      * @param {Task} task - OmniFocus task object
@@ -1844,12 +1864,9 @@
           // Helper function to check if a task matches all filters
           function taskMatchesFilters(t, knownTaskStatus, knownProject, knownCompletionTs) {
             const taskStatusValue = knownTaskStatus === undefined ? taskStatus(t) : knownTaskStatus;
-            // Status checks
-            if (filterState.completed !== undefined) {
-              const taskCompleted = isCompletedStatusValue(taskStatusValue);
-              if (taskCompleted !== filterState.completed) return false;
-            } else if (!isEverything) {
-              if (!isRemainingStatusWithStatus(t, taskStatusValue)) return false;
+            // Status checks: completed=false uses remaining (parent chain + not dropped)
+            if (!matchesCompletedFilterWithStatus(t, taskStatusValue, filterState.completed, isEverything)) {
+              return false;
             }
             if (filterState.flagged !== undefined) {
               const taskFlagged = isTaskEffectivelyFlagged(t);
@@ -2708,14 +2725,10 @@
             tasks.forEach(t => {
               const taskStatusValue = taskStatus(t);
               const taskCompleted = isCompletedStatusValue(taskStatusValue);
-              const taskDropped = isDroppedStatusValue(taskStatusValue);
-              const taskRemaining = isRemainingStatusWithStatus(t, taskStatusValue);
               let taskFlagged = null;
 
-              if (filterState.completed !== undefined) {
-                if (taskCompleted !== filterState.completed) return;
-              } else if (!isEverything) {
-                if (!taskRemaining) return;
+              if (!matchesCompletedFilterWithStatus(t, taskStatusValue, filterState.completed, isEverything)) {
+                return;
               }
               afterStatusGateCount += 1;
               if (debugInfo && statusGateSample.length < 5) {
@@ -2994,10 +3007,9 @@
               const project = safe(() => t.containingProject);
               if (!project) { return; }
 
-              if (filterState.completed !== undefined) {
-                if (isCompletedStatus(t) !== filterState.completed) return;
-              } else if (rawProjectView !== "everything") {
-                if (!isRemainingStatus(t)) return;
+              const everythingProjectView = rawProjectView === "everything";
+              if (!matchesCompletedFilter(t, filterState.completed, everythingProjectView)) {
+                return;
               }
 
               if (filterState.flagged !== undefined) {

--- a/Tests/OmniFocusIntegrationTests/CompletedFilterSemanticsTests.swift
+++ b/Tests/OmniFocusIntegrationTests/CompletedFilterSemanticsTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import JavaScriptCore
+import Testing
+
+/// Regression coverage for #98: completed=false uses remaining/parent-chain semantics.
+@Test
+func completedFalseUsesRemainingSemanticsNotJustNotCompleted() throws {
+    let statusModule = try loadStatusModule()
+    let context = JSContext()!
+    var exceptionMessage: String?
+    context.exceptionHandler = { _, exception in
+        exceptionMessage = exception?.toString()
+    }
+
+    let script = """
+    const Task = { Status: {
+      Available: "Available", Next: "Next", DueSoon: "DueSoon", Overdue: "Overdue",
+      Blocked: "Blocked", Completed: "Completed", Dropped: "Dropped"
+    }};
+    const Project = { Status: {
+      Active: "Active", OnHold: "OnHold", Dropped: "Dropped", Done: "Done"
+    }};
+    function safe(fn) { try { return fn(); } catch (_) { return null; } }
+    \(statusModule)
+    function task(status, parent) {
+      return { taskStatus: status, parent: parent || null };
+    }
+    const completedParent = task(Task.Status.Completed);
+    const droppedParent = task(Task.Status.Dropped);
+    const samples = {
+      available: task(Task.Status.Available),
+      blocked: task(Task.Status.Blocked),
+      completed: task(Task.Status.Completed),
+      dropped: task(Task.Status.Dropped),
+      childOfCompleted: task(Task.Status.Available, completedParent),
+      childOfDropped: task(Task.Status.Available, droppedParent)
+    };
+    function evaluate(completedFilter, everythingView) {
+      const out = {};
+      Object.keys(samples).forEach(key => {
+        out[key] = matchesCompletedFilter(samples[key], completedFilter, everythingView);
+      });
+      return out;
+    }
+    JSON.stringify({
+      completedFalse: evaluate(false, false),
+      completedOmitted: evaluate(undefined, false),
+      everything: evaluate(undefined, true),
+      completedTrue: evaluate(true, false)
+    });
+    """
+
+    guard let json = context.evaluateScript(script)?.toString(), exceptionMessage == nil else {
+        Issue.record("JS evaluation failed: \(exceptionMessage ?? "no result")")
+        return
+    }
+
+    struct Sample: Decodable {
+        let available: Bool
+        let blocked: Bool
+        let completed: Bool
+        let dropped: Bool
+        let childOfCompleted: Bool
+        let childOfDropped: Bool
+    }
+    struct Result: Decodable {
+        let completedFalse: Sample
+        let completedOmitted: Sample
+        let everything: Sample
+        let completedTrue: Sample
+    }
+    let decoded = try JSONDecoder().decode(Result.self, from: Data(json.utf8))
+
+    // completed=false must match remaining (exclude dropped + children under completed/dropped parents)
+    #expect(decoded.completedFalse.available)
+    #expect(decoded.completedFalse.blocked)
+    #expect(!decoded.completedFalse.completed)
+    #expect(!decoded.completedFalse.dropped)
+    #expect(!decoded.completedFalse.childOfCompleted)
+    #expect(!decoded.completedFalse.childOfDropped)
+
+    // omitted completed with non-everything view matches remaining
+    #expect(decoded.completedOmitted.available)
+    #expect(!decoded.completedOmitted.dropped)
+    #expect(!decoded.completedOmitted.childOfCompleted)
+
+    // everything includes completed/dropped and hidden children
+    #expect(decoded.everything.available)
+    #expect(decoded.everything.completed)
+    #expect(decoded.everything.dropped)
+    #expect(decoded.everything.childOfCompleted)
+
+    // completed=true is completed-only
+    #expect(!decoded.completedTrue.available)
+    #expect(decoded.completedTrue.completed)
+    #expect(!decoded.completedTrue.dropped)
+}
+
+private func loadStatusModule() throws -> String {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js")
+    let librarySource = try String(contentsOf: sourceURL, encoding: .utf8)
+    let startMarker = "// STATUS MODULE - Single Source of Truth for OmniFocus Status"
+    let endMarker = "// END STATUS MODULE"
+    guard let start = librarySource.range(of: startMarker),
+          let end = librarySource.range(of: endMarker, range: start.upperBound..<librarySource.endIndex) else {
+        throw CompletedFilterTestError.missingStatusModule
+    }
+    return String(librarySource[start.lowerBound..<end.upperBound])
+}
+
+private enum CompletedFilterTestError: Error {
+    case missingStatusModule
+}


### PR DESCRIPTION
## Summary
- `completed=false` now matches remaining tasks: not completed, not dropped, parent chain allows remaining.
- Shared `matchesCompletedFilter` / `matchesCompletedFilterWithStatus` helpers in the status module.
- JSCore regression test for dropped tasks and children of completed/dropped parents.

## Validation
- `swift test --filter completedFalseUsesRemaining`
- Existing project task count status tests still pass

Closes #98