### PR TITLE
Accept fractional ISO8601 in MCP decode (#99)

### DIFF
--- a/Sources/FocusRelayServer/FocusRelayServer.swift
+++ b/Sources/FocusRelayServer/FocusRelayServer.swift
@@ -949,8 +949,8 @@ public enum FocusRelayServer {
     static func decodeArgument<T: Decodable>(_ type: T.Type, from args: [String: Value]?, key: String) throws -> T? {
         guard let value = args?[key] else { return nil }
         let data = try JSONEncoder().encode(value)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        // Match bridge payload decoding: fractional and standard ISO8601.
+        let decoder = BridgeDateDecoding.makeJSONDecoder()
         return try decoder.decode(T.self, from: data)
     }
 }
@@ -1000,7 +1000,5 @@ private func decodeStringArray(_ value: Value?) -> [String]? {
     guard let value else { return nil }
     let data = try? JSONEncoder().encode(value)
     guard let data else { return nil }
-    let decoder = JSONDecoder()
-    decoder.dateDecodingStrategy = .iso8601
     return try? JSONDecoder().decode([String].self, from: data)
 }

--- a/Sources/OmniFocusAutomation/BridgeDateDecoding.swift
+++ b/Sources/OmniFocusAutomation/BridgeDateDecoding.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum BridgeDateDecoding {
+public enum BridgeDateDecoding {
     private static let fractionalISO8601Formatter = LockedISO8601Formatter(
         formatOptions: [.withInternetDateTime, .withFractionalSeconds]
     )
@@ -9,13 +9,13 @@ enum BridgeDateDecoding {
         formatOptions: [.withInternetDateTime]
     )
 
-    static func makeJSONDecoder() -> JSONDecoder {
+    public static func makeJSONDecoder() -> JSONDecoder {
         let decoder = JSONDecoder()
         configure(decoder)
         return decoder
     }
 
-    static func configure(_ decoder: JSONDecoder) {
+    public static func configure(_ decoder: JSONDecoder) {
         decoder.dateDecodingStrategy = .custom { decoder in
             try decodeDate(from: decoder)
         }

--- a/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
+++ b/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
@@ -24,6 +24,36 @@ func mcpArgumentBoundaryDecodesSparseTaskFieldPatches() throws {
 }
 
 @Test
+func mcpArgumentBoundaryDecodesFractionalISO8601Dates() throws {
+    let fractional = try FocusRelayServer.decodeArgument(
+        TaskPatchMutation.self,
+        from: ["taskPatch": .object(["dueDate": .string("2026-07-15T09:00:00.000Z")])],
+        key: "taskPatch"
+    )
+    let standard = try FocusRelayServer.decodeArgument(
+        TaskPatchMutation.self,
+        from: ["taskPatch": .object(["dueDate": .string("2026-07-15T09:00:00Z")])],
+        key: "taskPatch"
+    )
+    let fractionalDue = try #require(fractional?.dueDate)
+    let standardDue = try #require(standard?.dueDate)
+    #expect(abs(fractionalDue.timeIntervalSince(standardDue)) < 0.001)
+
+    let filter = try FocusRelayServer.decodeArgument(
+        TaskFilter.self,
+        from: [
+            "filter": .object([
+                "completedAfter": .string("2026-01-31T00:00:00.123Z"),
+                "completedBefore": .string("2026-02-01T00:00:00.456Z")
+            ])
+        ],
+        key: "filter"
+    )
+    #expect(filter?.completedAfter != nil)
+    #expect(filter?.completedBefore != nil)
+}
+
+@Test
 func everyPublicSparseTaskPatchSurvivesMCPValueDecoding() throws {
     let cases: [[String: Value]] = [
         ["name": .string("Renamed")],


### PR DESCRIPTION
## Summary
- MCP `decodeArgument` uses `BridgeDateDecoding` (fractional + standard ISO8601).
- `BridgeDateDecoding` is public for shared server/bridge use.
- Server tests cover fractional taskPatch and task filter dates.

## Validation
- `swift test --filter mcpArgumentBoundaryDecodesFractional`

Closes #99