### PR TITLE
Use inclusive completedBefore bound in get_project_counts task count

### DIFF
--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -2928,9 +2928,10 @@
               if (projectIds.has(pid) && isCompletedStatus(t)) {
                 const taskCompletionDate = getTaskDateTimestamp(t, task => task.completionDate);
                 if (taskCompletionDate === null) { return; }
-                // Only count tasks completed in the same window
+                // Only count tasks completed in the same window (inclusive bounds,
+                // matching the project-level filter and list_tasks date filters).
                 if ((!completedAfter || taskCompletionDate >= completedAfter.getTime()) &&
-                    (!completedBefore || taskCompletionDate < completedBefore.getTime())) {
+                    (!completedBefore || taskCompletionDate <= completedBefore.getTime())) {
                   completedTaskCount++;
                 }
               }


### PR DESCRIPTION
## Summary
- Fixes the task-level `completedBefore` comparison in the `get_project_counts` completion-window path to be inclusive (`<=`), matching the project-level filter and the documented inclusive-bound contract.

## Issue
Closes #103

## Validation impact
`query`

## Testing
- Bridge-side one-line comparison change; live query UAT to be run in the combined plugin-validation session before merge.