### PR TITLE
Skip per-tag task count work when includeTaskCounts is false

### DIFF
--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -2465,16 +2465,18 @@
               name: String(safe(() => tag.name) || ""),
               status: getTagStatusString(tag)
             };
-            
-            // Get task counts using OmniFocus built-in properties
+
+            // Get task counts using OmniFocus built-in properties only when requested.
             // Note: Per documentation, cleanUp() should be called for accurate counts
-            const availableTasks = safe(() => tag.availableTasks);
-            const remainingTasks = safe(() => tag.remainingTasks);
-            const allTasks = safe(() => tag.tasks);
-            
-            item.availableTasks = availableTasks ? availableTasks.length : 0;
-            item.remainingTasks = remainingTasks ? remainingTasks.length : 0;
-            item.totalTasks = allTasks ? allTasks.length : 0;
+            if (includeTaskCounts) {
+              const availableTasks = safe(() => tag.availableTasks);
+              const remainingTasks = safe(() => tag.remainingTasks);
+              const allTasks = safe(() => tag.tasks);
+
+              item.availableTasks = availableTasks ? availableTasks.length : 0;
+              item.remainingTasks = remainingTasks ? remainingTasks.length : 0;
+              item.totalTasks = allTasks ? allTasks.length : 0;
+            }
             
             return item;
           });


### PR DESCRIPTION
## Summary
- Gates the per-tag count computation in the bridge `list_tags` handler behind `includeTaskCounts` so default calls don't evaluate per-tag task collections.

## Issue
Closes #104

## Validation impact
`query`

## Testing
- Output contract unchanged (server already masks count fields when the flag is false); live UAT in the combined plugin-validation session before merge.