### PR TITLE
Validate page.limit on list tools

### DIFF
--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -1970,7 +1970,7 @@
           }
           
           const includeTotalCount = filter.includeTotalCount === true;
-          const limit = request.page && request.page.limit ? request.page.limit : 50;
+          const limit = request.page && request.page.limit ? Math.max(1, request.page.limit) : 50;
           const offset = request.page && request.page.cursor ? parseInt(request.page.cursor, 10) : 0;
           const safeOffset = Number.isFinite(offset) && offset > 0 ? offset : 0;
           const requiresCompletionSort = filterState.completed === true || filterState.completedAfterTs !== null || filterState.completedBeforeTs !== null;
@@ -2310,7 +2310,7 @@
             });
           }
 
-          const limit = request.page && request.page.limit ? request.page.limit : 150;
+          const limit = request.page && request.page.limit ? Math.max(1, request.page.limit) : 150;
           let offset = 0;
           if (request.page && request.page.cursor) {
             const parsed = parseInt(request.page.cursor, 10);
@@ -2436,7 +2436,7 @@
             });
           }
           
-          const limit = request.page && request.page.limit ? request.page.limit : 150;
+          const limit = request.page && request.page.limit ? Math.max(1, request.page.limit) : 150;
           let offset = 0;
           if (request.page && request.page.cursor) {
             const parsed = parseInt(request.page.cursor, 10);
@@ -2485,7 +2485,7 @@
         } else if (request.op === "list_folders") {
           const fields = request.fields || [];
           const folders = toTaskArray(safe(() => flattenedFolders));
-          const limit = request.page && request.page.limit ? request.page.limit : 150;
+          const limit = request.page && request.page.limit ? Math.max(1, request.page.limit) : 150;
           let offset = 0;
           if (request.page && request.page.cursor) {
             const parsed = parseInt(request.page.cursor, 10);

--- a/Sources/FocusRelayServer/FocusRelayServer.swift
+++ b/Sources/FocusRelayServer/FocusRelayServer.swift
@@ -219,7 +219,7 @@ public enum FocusRelayServer {
                             "page": .object([
                                 "type": .string("object"),
                                 "properties": .object([
-                                    "limit": .object(["type": .string("integer")]),
+                                    "limit": .object(["type": .string("integer"), "minimum": .int(1)]),
                                     "cursor": .object(["type": .string("string")])
                                 ])
                             ]),
@@ -260,7 +260,7 @@ public enum FocusRelayServer {
                             "page": .object([
                                 "type": .string("object"),
                                 "properties": .object([
-                                    "limit": .object(["type": .string("integer")]),
+                                    "limit": .object(["type": .string("integer"), "minimum": .int(1)]),
                                     "cursor": .object(["type": .string("string")])
                                 ])
                             ]),
@@ -327,7 +327,7 @@ public enum FocusRelayServer {
                             "page": .object([
                                 "type": .string("object"),
                                 "properties": .object([
-                                    "limit": .object(["type": .string("integer")]),
+                                    "limit": .object(["type": .string("integer"), "minimum": .int(1)]),
                                     "cursor": .object(["type": .string("string")])
                                 ])
                             ]),
@@ -354,7 +354,7 @@ public enum FocusRelayServer {
                             "page": .object([
                                 "type": .string("object"),
                                 "properties": .object([
-                                    "limit": .object(["type": .string("integer")]),
+                                    "limit": .object(["type": .string("integer"), "minimum": .int(1)]),
                                     "cursor": .object(["type": .string("string")])
                                 ])
                             ]),
@@ -717,8 +717,7 @@ public enum FocusRelayServer {
                         logger.error("Failed to decode filter: \(String(describing: error))")
                         return .init(content: [.text("Error decoding filter: \(error)")], isError: true)
                     }
-                    let hasPage = params.arguments?["page"] != nil
-                    let page = hasPage ? (try decodeArgument(PageRequest.self, from: params.arguments, key: "page") ?? PageRequest(limit: 50)) : PageRequest(limit: 50)
+                    let page = try decodePageRequest(from: params.arguments, defaultLimit: 50)
                     let requestedFields = decodeStringArray(params.arguments?["fields"]) ?? []
                     let fields = requestedFields.isEmpty ? ["id", "name"] : requestedFields
                     let result = try await service.listTasks(filter: filter, page: page, fields: fields)
@@ -738,8 +737,7 @@ public enum FocusRelayServer {
                     let output = makeTaskOutput(from: result, fields: fieldSet)
                     return .init(content: [.text(try encodeJSON(output))])
                 case "list_projects":
-                    let hasPage = params.arguments?["page"] != nil
-                    let page = hasPage ? (try decodeArgument(PageRequest.self, from: params.arguments, key: "page") ?? PageRequest(limit: 150)) : PageRequest(limit: 150)
+                    let page = try decodePageRequest(from: params.arguments, defaultLimit: 150)
                     let statusFilter = try decodeArgument(String.self, from: params.arguments, key: "statusFilter") ?? "active"
                     let includeTaskCounts = try decodeArgument(Bool.self, from: params.arguments, key: "includeTaskCounts") ?? false
                     let reviewDueBefore = try decodeArgument(Date.self, from: params.arguments, key: "reviewDueBefore")
@@ -771,8 +769,7 @@ public enum FocusRelayServer {
                     let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount)
                     return .init(content: [.text(try encodeJSON(output))])
                 case "list_tags":
-                    let hasPage = params.arguments?["page"] != nil
-                    let page = hasPage ? (try decodeArgument(PageRequest.self, from: params.arguments, key: "page") ?? PageRequest(limit: 150)) : PageRequest(limit: 150)
+                    let page = try decodePageRequest(from: params.arguments, defaultLimit: 150)
                     let statusFilter = try decodeArgument(String.self, from: params.arguments, key: "statusFilter") ?? "active"
                     let includeTaskCounts = try decodeArgument(Bool.self, from: params.arguments, key: "includeTaskCounts") ?? false
                     let result = try await service.listTags(page: page, statusFilter: statusFilter, includeTaskCounts: includeTaskCounts)
@@ -781,8 +778,7 @@ public enum FocusRelayServer {
                     let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount)
                     return .init(content: [.text(try encodeJSON(output))])
                 case "list_folders":
-                    let hasPage = params.arguments?["page"] != nil
-                    let page = hasPage ? (try decodeArgument(PageRequest.self, from: params.arguments, key: "page") ?? PageRequest(limit: 150)) : PageRequest(limit: 150)
+                    let page = try decodePageRequest(from: params.arguments, defaultLimit: 150)
                     let requestedFields = decodeStringArray(params.arguments?["fields"]) ?? []
                     let fields = requestedFields.isEmpty ? ["id", "name"] : requestedFields
                     let result = try await service.listFolders(page: page, fields: fields)
@@ -953,6 +949,14 @@ public enum FocusRelayServer {
         // Match bridge payload decoding: fractional and standard ISO8601.
         let decoder = BridgeDateDecoding.makeJSONDecoder()
         return try decoder.decode(T.self, from: data)
+    }
+
+    static func decodePageRequest(from args: [String: Value]?, defaultLimit: Int) throws -> PageRequest {
+        let page = try decodeArgument(PageRequest.self, from: args, key: "page") ?? PageRequest(limit: defaultLimit)
+        guard page.limit >= 1 else {
+            throw MutationValidationError("page.limit must be at least 1.")
+        }
+        return page
     }
 }
 

--- a/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
+++ b/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
@@ -279,3 +279,33 @@ func sharedTaskFilterSchemaCoversCompleteModelSurface() {
     }
     #expect(includeTotalCount["default"] == .bool(false))
 }
+
+@Test
+func pageRequestValidationRejectsNonPositiveLimits() throws {
+    #expect(throws: (any Error).self) {
+        try FocusRelayServer.decodePageRequest(
+            from: ["page": .object(["limit": .int(-5)])],
+            defaultLimit: 50
+        )
+    }
+    #expect(throws: (any Error).self) {
+        try FocusRelayServer.decodePageRequest(
+            from: ["page": .object(["limit": .int(0)])],
+            defaultLimit: 50
+        )
+    }
+}
+
+@Test
+func pageRequestValidationAcceptsOmittedAndPositiveLimits() throws {
+    let defaulted = try FocusRelayServer.decodePageRequest(from: [:], defaultLimit: 150)
+    #expect(defaulted.limit == 150)
+    #expect(defaulted.cursor == nil)
+
+    let explicit = try FocusRelayServer.decodePageRequest(
+        from: ["page": .object(["limit": .int(25), "cursor": .string("50")])],
+        defaultLimit: 150
+    )
+    #expect(explicit.limit == 25)
+    #expect(explicit.cursor == "50")
+}


### PR DESCRIPTION
## Summary
- Adds `minimum: 1` to `page.limit` in all list tool schemas
- Adds `FocusRelayServer.decodePageRequest` which rejects non-positive limits with a clear error at the MCP argument boundary
- Defensive `Math.max(1, ...)` clamps at all four bridge pagination sites
- New wire-level tests for negative/zero/omitted/positive limits

## Issue
Closes #105

## Validation impact
`server-wire`

## Testing
- `swift test --filter FocusRelayServerTests`: 14/14 pass