### PR TITLE
Reject unsupported ProjectPatchMutation fields loudly

### DIFF
--- a/Sources/OmniFocusCore/MutationModels.swift
+++ b/Sources/OmniFocusCore/MutationModels.swift
@@ -336,6 +336,15 @@ public struct ProjectPatchMutation: Codable, Sendable, Equatable {
     }
 
     public func validate() throws {
+        if containsSingletonActions != nil {
+            throw MutationValidationError("containsSingletonActions updates are not supported yet; see the edit-surface consolidation roadmap item.")
+        }
+        if completedByChildren != nil {
+            throw MutationValidationError("completedByChildren updates are not supported yet; see the edit-surface consolidation roadmap item.")
+        }
+        if tags != nil {
+            throw MutationValidationError("Project tag updates are not supported yet; see the edit-surface consolidation roadmap item.")
+        }
         if dueDate != nil && clearDueDate {
             throw MutationValidationError("Project patches cannot set and clear dueDate in the same request.")
         }
@@ -345,7 +354,6 @@ public struct ProjectPatchMutation: Codable, Sendable, Equatable {
         if let reviewInterval, let steps = reviewInterval.steps, steps < 0 {
             throw MutationValidationError("reviewInterval.steps must be zero or greater.")
         }
-        try tags?.validate()
     }
 }
 

--- a/Tests/OmniFocusCoreTests/MutationModelsTests.swift
+++ b/Tests/OmniFocusCoreTests/MutationModelsTests.swift
@@ -188,6 +188,31 @@ func mutationRequestValidationRejectsConflictingTaskDateModes() {
 }
 
 @Test
+func projectPatchValidationRejectsUnsupportedFields() {
+    let unsupported: [ProjectPatchMutation] = [
+        ProjectPatchMutation(containsSingletonActions: true),
+        ProjectPatchMutation(completedByChildren: true),
+        ProjectPatchMutation(tags: TagMutation(clear: true))
+    ]
+
+    for patch in unsupported {
+        let request = MutationRequest(
+            targetType: .project,
+            targetIDs: ["project-1"],
+            operation: MutationOperation(
+                kind: .updateProjects,
+                projectPatch: patch
+            ),
+            previewOnly: true
+        )
+
+        #expect(throws: MutationValidationError.self) {
+            try request.validate()
+        }
+    }
+}
+
+@Test
 func mutationRequestValidationRejectsConflictingProjectDateModes() {
     let request = MutationRequest(
         targetType: .project,


### PR DESCRIPTION
## Summary
- `ProjectPatchMutation.validate()` now throws for `containsSingletonActions`, `completedByChildren`, and `tags` — fields that decode but were silently ignored by the bridge
- Errors reference the consolidation roadmap item (#91) where they're expected to be implemented
- New validation test covering all three fields

## Issue
Closes #107

## Validation impact
`mutation` (validation-only; no write/restore needed)

## Testing
- `swift test --filter OmniFocusCoreTests`: all pass, including new `projectPatchValidationRejectsUnsupportedFields`