### PR TITLE
Surface bridge response warnings to server logs and list outputs

### DIFF
--- a/Sources/FocusRelayOutput/OutputModels.swift
+++ b/Sources/FocusRelayOutput/OutputModels.swift
@@ -61,12 +61,14 @@ public struct PageOutput<T: Encodable>: Encodable {
     public let nextCursor: String?
     public let returnedCount: Int
     public let totalCount: Int?
+    public let warnings: [String]?
 
-    public init(items: [T], nextCursor: String? = nil, returnedCount: Int, totalCount: Int? = nil) {
+    public init(items: [T], nextCursor: String? = nil, returnedCount: Int, totalCount: Int? = nil, warnings: [String]? = nil) {
         self.items = items
         self.nextCursor = nextCursor
         self.returnedCount = returnedCount
         self.totalCount = totalCount
+        self.warnings = warnings
     }
 }
 

--- a/Sources/FocusRelayServer/FocusRelayServer.swift
+++ b/Sources/FocusRelayServer/FocusRelayServer.swift
@@ -206,7 +206,11 @@ public enum FocusRelayServer {
             capabilities: .init(tools: .init(listChanged: true))
         )
 
-        let service: OmniFocusService = OmniFocusBridgeService()
+        let bridgeService = OmniFocusBridgeService()
+        bridgeService.setWarningsHandler { warnings, op in
+            logger.warning("Bridge warnings for \(op): \(warnings.joined(separator: " | "))")
+        }
+        let service: OmniFocusService = bridgeService
 
         await server.withMethodHandler(ListTools.self) { _ in
             let tools = [
@@ -724,7 +728,7 @@ public enum FocusRelayServer {
                     let result = try await service.listTasks(filter: filter, page: page, fields: fields)
                     let fieldSet = Set(fields)
                     let items = result.items.map { makeTaskOutput(from: $0, fields: fieldSet) }
-                    let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount)
+                    let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount, warnings: result.warnings)
                     return .init(content: [.text(try encodeJSON(output))])
                 case "get_task":
                     let id = try decodeArgument(String.self, from: params.arguments, key: "id") ?? ""
@@ -768,7 +772,7 @@ public enum FocusRelayServer {
                     )
                     let fieldSet = Set(fields)
                     let items = result.items.map { makeProjectOutput(from: $0, fields: fieldSet, includeTaskCounts: includeTaskCounts) }
-                    let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount)
+                    let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount, warnings: result.warnings)
                     return .init(content: [.text(try encodeJSON(output))])
                 case "list_tags":
                     let hasPage = params.arguments?["page"] != nil
@@ -778,7 +782,7 @@ public enum FocusRelayServer {
                     let result = try await service.listTags(page: page, statusFilter: statusFilter, includeTaskCounts: includeTaskCounts)
                     let fieldSet = Set(["id", "name", "status", "availableTasks", "remainingTasks", "totalTasks"])
                     let items = result.items.map { makeTagOutput(from: $0, fields: fieldSet, includeTaskCounts: includeTaskCounts) }
-                    let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount)
+                    let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount, warnings: result.warnings)
                     return .init(content: [.text(try encodeJSON(output))])
                 case "list_folders":
                     let hasPage = params.arguments?["page"] != nil
@@ -788,7 +792,7 @@ public enum FocusRelayServer {
                     let result = try await service.listFolders(page: page, fields: fields)
                     let fieldSet = Set(fields)
                     let items = result.items.map { makeFolderOutput(from: $0, fields: fieldSet) }
-                    let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount)
+                    let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount, warnings: result.warnings)
                     return .init(content: [.text(try encodeJSON(output))])
                 case "update_tasks":
                     let targetIDs = try decodeArgument([String].self, from: params.arguments, key: "targetIDs") ?? []

--- a/Sources/OmniFocusAutomation/BridgeClient.swift
+++ b/Sources/OmniFocusAutomation/BridgeClient.swift
@@ -9,6 +9,7 @@ final class BridgeClient: @unchecked Sendable {
     private let staleInterval: TimeInterval
     private let dispatchRunner: SerializedJXARunner
     private let configuration: BridgeClientConfiguration
+    var onResponseWarnings: (@Sendable (_ warnings: [String], _ op: String) -> Void)?
 
     init(
         paths: IPCPaths = .default(),
@@ -67,7 +68,7 @@ final class BridgeClient: @unchecked Sendable {
                     available: payload.available ?? false
                 )
             }
-            return Page(items: items, nextCursor: payloadPage.nextCursor, returnedCount: payloadPage.returnedCount, totalCount: payloadPage.totalCount)
+            return Page(items: items, nextCursor: payloadPage.nextCursor, returnedCount: payloadPage.returnedCount, totalCount: payloadPage.totalCount, warnings: response.warnings)
         }
 
         let message = response.error?.message ?? "Unknown bridge error"
@@ -158,7 +159,7 @@ final class BridgeClient: @unchecked Sendable {
                     completionDate: payload.completionDate
                 )
             }
-            return Page(items: items, nextCursor: payloadPage.nextCursor, returnedCount: payloadPage.returnedCount, totalCount: payloadPage.totalCount)
+            return Page(items: items, nextCursor: payloadPage.nextCursor, returnedCount: payloadPage.returnedCount, totalCount: payloadPage.totalCount, warnings: response.warnings)
         }
 
         let message = response.error?.message ?? "Unknown bridge error"
@@ -195,7 +196,7 @@ final class BridgeClient: @unchecked Sendable {
                     totalTasks: payload.totalTasks
                 )
             }
-            return Page(items: items, nextCursor: payloadPage.nextCursor, returnedCount: payloadPage.returnedCount, totalCount: payloadPage.totalCount)
+            return Page(items: items, nextCursor: payloadPage.nextCursor, returnedCount: payloadPage.returnedCount, totalCount: payloadPage.totalCount, warnings: response.warnings)
         }
 
         let message = response.error?.message ?? "Unknown bridge error"
@@ -231,7 +232,7 @@ final class BridgeClient: @unchecked Sendable {
                     childFolderCount: payload.childFolderCount
                 )
             }
-            return Page(items: items, nextCursor: payloadPage.nextCursor, returnedCount: payloadPage.returnedCount, totalCount: payloadPage.totalCount)
+            return Page(items: items, nextCursor: payloadPage.nextCursor, returnedCount: payloadPage.returnedCount, totalCount: payloadPage.totalCount, warnings: response.warnings)
         }
 
         let message = response.error?.message ?? "Unknown bridge error"
@@ -453,6 +454,9 @@ final class BridgeClient: @unchecked Sendable {
                 responseType: responseType
             )
             removeIfExists(url: dispatchRequestURL)
+            if let warnings = response.warnings, !warnings.isEmpty {
+                onResponseWarnings?(warnings, request.op)
+            }
             return response
         } catch {
             if !isTimeoutError(error) {

--- a/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
+++ b/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
@@ -10,6 +10,10 @@ public final class OmniFocusBridgeService: OmniFocusService {
         self.client = BridgeClient()
     }
 
+    public func setWarningsHandler(_ handler: (@Sendable (_ warnings: [String], _ op: String) -> Void)?) {
+        client.onResponseWarnings = handler
+    }
+
     public func listTasks(filter: TaskFilter, page: PageRequest, fields: [String]?) async throws -> Page<TaskItem> {
         return try client.listTasks(filter: filter, page: page, fields: fields)
     }

--- a/Sources/OmniFocusCore/OmniFocusCore.swift
+++ b/Sources/OmniFocusCore/OmniFocusCore.swift
@@ -215,12 +215,14 @@ public struct Page<T: Codable & Sendable>: Codable, Sendable {
     public let nextCursor: String?
     public let returnedCount: Int
     public let totalCount: Int?
+    public let warnings: [String]?
 
-    public init(items: [T], nextCursor: String? = nil, returnedCount: Int, totalCount: Int? = nil) {
+    public init(items: [T], nextCursor: String? = nil, returnedCount: Int, totalCount: Int? = nil, warnings: [String]? = nil) {
         self.items = items
         self.nextCursor = nextCursor
         self.returnedCount = returnedCount
         self.totalCount = totalCount
+        self.warnings = warnings
     }
 }
 

--- a/Tests/OmniFocusCoreTests/OmniFocusCoreTests.swift
+++ b/Tests/OmniFocusCoreTests/OmniFocusCoreTests.swift
@@ -46,6 +46,23 @@ func pageDefaults() {
 }
 
 @Test
+func pageWarningsRoundTripAndAbsenceTolerance() throws {
+    let tagged = Page(
+        items: [TagItem(id: "tag-1", name: "Home", status: "active")],
+        returnedCount: 1,
+        totalCount: 1,
+        warnings: ["Invalid date filter value: not-a-date"]
+    )
+    let data = try JSONEncoder().encode(tagged)
+    let decoded = try JSONDecoder().decode(Page<TagItem>.self, from: data)
+    #expect(decoded.warnings == ["Invalid date filter value: not-a-date"])
+
+    let withoutWarnings = #"{"items":[],"returnedCount":0}"#.data(using: .utf8)!
+    let legacy = try JSONDecoder().decode(Page<TagItem>.self, from: withoutWarnings)
+    #expect(legacy.warnings == nil)
+}
+
+@Test
 func projectItemReviewRoundTrip() throws {
     let interval = ReviewInterval(steps: 2, unit: "weeks")
     let project = ProjectItem(


### PR DESCRIPTION
## Summary
- `BridgeClient.onResponseWarnings` handler fires for any response carrying warnings; the MCP server registers it and logs via its logger
- `Page<T>` and `PageOutput` gain optional `warnings` (additive, decode-tolerant), so list tool results surface bridge warnings
- Bridge list methods inject response warnings into returned pages
- New Codable round-trip test incl. absence tolerance for warning-free payloads

## Issue
Closes #108

## Validation impact
`server-wire`

## Testing
- `swift build` clean; full `swift test` suite passes (146 tests)