### PR TITLE
Accept cursor-only page objects on list tools

### DIFF
--- a/Sources/FocusRelayServer/FocusRelayServer.swift
+++ b/Sources/FocusRelayServer/FocusRelayServer.swift
@@ -956,7 +956,15 @@ public enum FocusRelayServer {
     }
 
     static func decodePageRequest(from args: [String: Value]?, defaultLimit: Int) throws -> PageRequest {
-        let page = try decodeArgument(PageRequest.self, from: args, key: "page") ?? PageRequest(limit: defaultLimit)
+        guard var pageValue = args?["page"] else {
+            return PageRequest(limit: defaultLimit)
+        }
+        if case .object(var pageObject) = pageValue, pageObject["limit"] == nil {
+            pageObject["limit"] = .int(defaultLimit)
+            pageValue = .object(pageObject)
+        }
+        let data = try JSONEncoder().encode(pageValue)
+        let page = try BridgeDateDecoding.makeJSONDecoder().decode(PageRequest.self, from: data)
         guard page.limit >= 1 else {
             throw MutationValidationError("page.limit must be at least 1.")
         }

--- a/Sources/FocusRelayServer/FocusRelayServer.swift
+++ b/Sources/FocusRelayServer/FocusRelayServer.swift
@@ -721,7 +721,7 @@ public enum FocusRelayServer {
                         logger.error("Failed to decode filter: \(String(describing: error))")
                         return .init(content: [.text("Error decoding filter: \(error)")], isError: true)
                     }
-                    let page = try decodePageRequest(from: params.arguments, defaultLimit: 50)
+                    let page = try decodePageRequest(from: params)
                     let requestedFields = decodeStringArray(params.arguments?["fields"]) ?? []
                     let fields = requestedFields.isEmpty ? ["id", "name"] : requestedFields
                     let result = try await service.listTasks(filter: filter, page: page, fields: fields)
@@ -741,7 +741,7 @@ public enum FocusRelayServer {
                     let output = makeTaskOutput(from: result, fields: fieldSet)
                     return .init(content: [.text(try encodeJSON(output))])
                 case "list_projects":
-                    let page = try decodePageRequest(from: params.arguments, defaultLimit: 150)
+                    let page = try decodePageRequest(from: params)
                     let statusFilter = try decodeArgument(String.self, from: params.arguments, key: "statusFilter") ?? "active"
                     let includeTaskCounts = try decodeArgument(Bool.self, from: params.arguments, key: "includeTaskCounts") ?? false
                     let reviewDueBefore = try decodeArgument(Date.self, from: params.arguments, key: "reviewDueBefore")
@@ -773,7 +773,7 @@ public enum FocusRelayServer {
                     let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount, warnings: result.warnings)
                     return .init(content: [.text(try encodeJSON(output))])
                 case "list_tags":
-                    let page = try decodePageRequest(from: params.arguments, defaultLimit: 150)
+                    let page = try decodePageRequest(from: params)
                     let statusFilter = try decodeArgument(String.self, from: params.arguments, key: "statusFilter") ?? "active"
                     let includeTaskCounts = try decodeArgument(Bool.self, from: params.arguments, key: "includeTaskCounts") ?? false
                     let result = try await service.listTags(page: page, statusFilter: statusFilter, includeTaskCounts: includeTaskCounts)
@@ -782,7 +782,7 @@ public enum FocusRelayServer {
                     let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount, warnings: result.warnings)
                     return .init(content: [.text(try encodeJSON(output))])
                 case "list_folders":
-                    let page = try decodePageRequest(from: params.arguments, defaultLimit: 150)
+                    let page = try decodePageRequest(from: params)
                     let requestedFields = decodeStringArray(params.arguments?["fields"]) ?? []
                     let fields = requestedFields.isEmpty ? ["id", "name"] : requestedFields
                     let result = try await service.listFolders(page: page, fields: fields)
@@ -969,6 +969,19 @@ public enum FocusRelayServer {
             throw MutationValidationError("page.limit must be at least 1.")
         }
         return page
+    }
+
+    static func decodePageRequest(from params: CallTool.Parameters) throws -> PageRequest {
+        let defaultLimit: Int
+        switch params.name {
+        case "list_tasks":
+            defaultLimit = 50
+        case "list_projects", "list_tags", "list_folders":
+            defaultLimit = 150
+        default:
+            throw MutationValidationError("Tool \(params.name) does not accept page arguments.")
+        }
+        return try decodePageRequest(from: params.arguments, defaultLimit: defaultLimit)
     }
 }
 

--- a/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
+++ b/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
@@ -309,3 +309,20 @@ func pageRequestValidationAcceptsOmittedAndPositiveLimits() throws {
     #expect(explicit.limit == 25)
     #expect(explicit.cursor == "50")
 }
+
+@Test
+func pageRequestAppliesToolDefaultLimitWhenCursorSentAlone() throws {
+    let taskPage = try FocusRelayServer.decodePageRequest(
+        from: ["page": .object(["cursor": .string("50")])],
+        defaultLimit: 50
+    )
+    #expect(taskPage.limit == 50)
+    #expect(taskPage.cursor == "50")
+
+    let projectPage = try FocusRelayServer.decodePageRequest(
+        from: ["page": .object(["cursor": .string("150")])],
+        defaultLimit: 150
+    )
+    #expect(projectPage.limit == 150)
+    #expect(projectPage.cursor == "150")
+}

--- a/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
+++ b/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import FocusRelayServer
 import FocusRelayVersion
@@ -325,4 +326,34 @@ func pageRequestAppliesToolDefaultLimitWhenCursorSentAlone() throws {
     )
     #expect(projectPage.limit == 150)
     #expect(projectPage.cursor == "150")
+}
+
+@Test
+func cursorOnlyPagesApplyDefaultsAtMCPWireBoundary() throws {
+    let cases = [
+        (tool: "list_tasks", cursor: "50", expectedLimit: 50),
+        (tool: "list_projects", cursor: "150", expectedLimit: 150)
+    ]
+
+    for testCase in cases {
+        let data = Data(
+            """
+            {
+              "jsonrpc": "2.0",
+              "id": 1,
+              "method": "tools/call",
+              "params": {
+                "name": "\(testCase.tool)",
+                "arguments": {"page": {"cursor": "\(testCase.cursor)"}}
+              }
+            }
+            """.utf8
+        )
+        let request = try JSONDecoder().decode(Request<CallTool>.self, from: data)
+        let page = try FocusRelayServer.decodePageRequest(from: request.params)
+
+        #expect(request.method == CallTool.name)
+        #expect(page.limit == testCase.expectedLimit)
+        #expect(page.cursor == testCase.cursor)
+    }
 }


### PR DESCRIPTION
## Summary
- `decodePageRequest` injects the tool default limit when a `page` object omits `limit`, so cursor-only pagination (`{"page":{"cursor":"50"}}`) works instead of throwing `keyNotFound`.
- All list handlers resolve their default through the decoded `CallTool.Parameters`, keeping tool-to-default routing under direct MCP wire coverage.
- Root-caused from a real opencode/Kimi session transcript: the initial `list_tasks` call without `page` succeeded; its cursor-only follow-up failed with "The data could not be read because it is missing."

## Issue
Closes #118

## Validation impact
`server-wire`

## Testing
- Raw JSON-RPC `tools/call` requests cover cursor-only pages at the MCP wire boundary for 50- and 150-item defaults.
- FocusRelayServerTests: 16/16 pass.
- `swift run focusrelay-dev validate --impact server-wire`: 151 tests and the release build pass.
- Existing MCP SDK `Content.text` deprecation warnings are unchanged and tracked by #75.
