### PR TITLE
Remove JXA from release binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,9 @@ jobs:
       - name: Build release product
         run: swift build -c release --product focusrelay
 
+      - name: Check release surface
+        run: ./scripts/check-release-surface.sh .build/release/focusrelay
+
   ci:
     if: always()
     needs: [classify, docs, build-and-test]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
           fi
           ./scripts/set-version.sh "$VERSION"
           swift build -c release --product focusrelay
+          ./scripts/check-release-surface.sh .build/release/focusrelay
         
       - name: Package Release
         id: package

--- a/Package.swift
+++ b/Package.swift
@@ -42,10 +42,7 @@ let package = Package(
         ),
         .target(
             name: "OmniFocusAutomation",
-            dependencies: ["OmniFocusCore"],
-            linkerSettings: [
-                .linkedFramework("OSAKit")
-            ]
+            dependencies: ["OmniFocusCore"]
         ),
         .executableTarget(
             name: "FocusRelayCLI",

--- a/Sources/FocusRelayCLI/BenchmarkGateCheckCommand.swift
+++ b/Sources/FocusRelayCLI/BenchmarkGateCheckCommand.swift
@@ -1,3 +1,4 @@
+#if DEBUG
 import ArgumentParser
 import Foundation
 import OmniFocusAutomation
@@ -486,3 +487,4 @@ private extension Array {
         return result
     }
 }
+#endif

--- a/Sources/FocusRelayCLI/BenchmarkListTasksCommand.swift
+++ b/Sources/FocusRelayCLI/BenchmarkListTasksCommand.swift
@@ -1,3 +1,4 @@
+#if DEBUG
 import ArgumentParser
 import Foundation
 import OmniFocusAutomation
@@ -659,3 +660,4 @@ private func listTaskISO8601(_ date: Date) -> String {
     formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
     return formatter.string(from: date)
 }
+#endif

--- a/Sources/FocusRelayCLI/BenchmarkProjectCountsCommand.swift
+++ b/Sources/FocusRelayCLI/BenchmarkProjectCountsCommand.swift
@@ -1,3 +1,4 @@
+#if DEBUG
 import ArgumentParser
 import Foundation
 import OmniFocusAutomation
@@ -931,3 +932,4 @@ private func iso8601(_ date: Date) -> String {
     formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
     return formatter.string(from: date)
 }
+#endif

--- a/Sources/FocusRelayCLI/BenchmarkTaskCountsCommand.swift
+++ b/Sources/FocusRelayCLI/BenchmarkTaskCountsCommand.swift
@@ -1,3 +1,4 @@
+#if DEBUG
 import ArgumentParser
 import Foundation
 import OmniFocusAutomation
@@ -940,3 +941,4 @@ private func iso8601(_ date: Date) -> String {
     formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
     return formatter.string(from: date)
 }
+#endif

--- a/Sources/FocusRelayCLI/FocusRelayCLI.swift
+++ b/Sources/FocusRelayCLI/FocusRelayCLI.swift
@@ -8,11 +8,8 @@ import FocusRelayVersion
 
 @main
 struct FocusRelayCLI: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "focusrelay",
-        abstract: "Query OmniFocus data from the command line or run the MCP server.",
-        version: FocusRelayBuildVersion.current,
-        subcommands: [
+    private static var subcommands: [ParsableCommand.Type] {
+        var commands: [ParsableCommand.Type] = [
             Serve.self,
             ListTasks.self,
             GetTask.self,
@@ -28,14 +25,28 @@ struct FocusRelayCLI: AsyncParsableCommand {
             MoveProjects.self,
             TaskCounts.self,
             ProjectCounts.self,
+            BridgeHealthCheck.self
+        ]
+
+        #if DEBUG
+        commands += [
             DebugInboxProbe.self,
             DebugInboxProbeAlt.self,
-            BridgeHealthCheck.self,
             BenchmarkTaskCounts.self,
             BenchmarkListTasks.self,
             BenchmarkProjectCounts.self,
             BenchmarkGateCheck.self
         ]
+        #endif
+
+        return commands
+    }
+
+    static let configuration = CommandConfiguration(
+        commandName: "focusrelay",
+        abstract: "Query OmniFocus data from the command line or run the MCP server.",
+        version: FocusRelayBuildVersion.current,
+        subcommands: subcommands
     )
 }
 
@@ -564,6 +575,7 @@ struct ProjectCounts: AsyncParsableCommand {
     }
 }
 
+#if DEBUG
 struct DebugInboxProbe: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "debug-inbox-probe",
@@ -591,6 +603,7 @@ struct DebugInboxProbeAlt: AsyncParsableCommand {
         print(try encodeJSON(result))
     }
 }
+#endif
 
 struct BridgeHealthCheck: AsyncParsableCommand {
     static let configuration = CommandConfiguration(

--- a/Sources/OmniFocusAutomation/OmniFocusAutomation.swift
+++ b/Sources/OmniFocusAutomation/OmniFocusAutomation.swift
@@ -1,5 +1,7 @@
 import Foundation
+#if DEBUG
 import OSAKit
+#endif
 import OmniFocusCore
 
 public enum AutomationError: Error, LocalizedError {
@@ -19,6 +21,7 @@ public enum AutomationError: Error, LocalizedError {
     }
 }
 
+#if DEBUG
 public final class ScriptRunner: Sendable {
     public init() {}
 
@@ -1998,3 +2001,4 @@ private func jsStringLiteral(_ value: String) -> String {
     let data = try? JSONEncoder().encode(value)
     return data.flatMap { String(data: $0, encoding: .utf8) } ?? "\"\""
 }
+#endif

--- a/agents.md
+++ b/agents.md
@@ -102,7 +102,7 @@ semantic, and UAT checks against that same ready session.
 - Projects and tags use the actor-based `CatalogCache` with a five-minute TTL;
   tasks are intentionally uncached.
 - Plugin URL dispatch is the only production transport; the JXA dispatch
-  option was removed in #80. The pure-JXA query engine remains only as
-  internal parity/benchmark infrastructure, not a production path. Production
-  semantic gates use plugin and native contracts; pass `--include-jxa-parity`
-  only for developer diagnostics.
+  option was removed in #80. The pure-JXA query engine and its benchmark
+  commands compile only in debug builds; release binaries do not link OSAKit.
+  Production semantic gates use plugin and native contracts; pass
+  `--include-jxa-parity` only for developer diagnostics.

--- a/scripts/check-release-surface.sh
+++ b/scripts/check-release-surface.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+binary="${1:-.build/release/focusrelay}"
+
+if [[ ! -x "$binary" ]]; then
+  echo "Release binary is missing or not executable: $binary" >&2
+  exit 1
+fi
+
+help_output="$($binary --help)"
+retired_commands='benchmark-(task-counts|list-tasks|project-counts|gate-check)|debug-inbox-probe'
+retired_symbols='OmniAutomationService|OSAKit|Application\("OmniFocus"\)'
+
+if grep -Eq "$retired_commands" <<<"$help_output"; then
+  echo "Release help exposes developer-only JXA commands." >&2
+  exit 1
+fi
+
+if otool -L "$binary" | grep -Fq '/OSAKit.framework/'; then
+  echo "Release binary links OSAKit." >&2
+  exit 1
+fi
+
+if strings "$binary" | grep -Eq "$retired_commands|$retired_symbols"; then
+  echo "Release binary contains developer-only JXA code or command names." >&2
+  exit 1
+fi
+
+echo "Release surface is JXA-free: $binary"


### PR DESCRIPTION
Closes #80

## What changed

- Compile the pure-JXA query oracle, inbox probes, and benchmark commands only in debug builds.
- Remove OSAKit from the release product's explicit linker settings.
- Keep the developer parity workflow available in normal SwiftPM debug builds.
- Add a release guard to CI and the release workflow that rejects JXA commands, symbols, or OSAKit linkage in the shipped executable.

## Why

PR #117 removed JXA dispatch from production, but the release executable still contained the pure-JXA query engine and exposed its developer benchmark commands. This finishes the ownership boundary promised by #80: users receive one plugin-URL architecture, while developers keep the oracle where it remains useful.

## Acceptance journey

A Homebrew or release user runs `focusrelay --help` and sees only supported commands. The installed executable uses the FocusRelay Bridge, contains no JXA query engine, and does not link OSAKit. A developer building with SwiftPM in debug mode can still run the parity and benchmark commands.

## Validation

Validation impact: `package`. This stage changes release compilation and packaging only; it does not change `BridgeClient`, the plugin, query semantics, mutation behavior, or dispatch logic. The transport-reliability evidence from PR #117 remains applicable, and the exact semantic gate was rerun.

- `swift test`: 149 tests passed; live opt-in tests reported as skipped.
- `swift run focusrelay-dev validate --impact package`: passed.
- `.build/debug/focusrelay benchmark-gate-check --tool all`: 9/9 production and native semantic checks passed; JXA parity was not part of the production gate.
- `swift build -c release --product focusrelay`: passed.
- `./scripts/check-release-surface.sh .build/release/focusrelay`: passed.
- Negative guard check against `.build/debug/focusrelay`: correctly rejected the JXA-enabled debug binary.
- Release-binary live checks: bridge health passed; flagged task count returned 48 total/48 available.

The existing MCP SDK `Content.text` deprecation warnings are unchanged and tracked separately; this PR introduces no new compiler warnings.
