### PR TITLE
Consolidate the Bridge-only benchmark harness

### DIFF
--- a/Sources/FocusRelayCLI/BenchmarkListTasksCommand.swift
+++ b/Sources/FocusRelayCLI/BenchmarkListTasksCommand.swift
@@ -30,31 +30,32 @@ struct BenchmarkListTasks: AsyncParsableCommand {
     var outputDir: String?
 
     func run() async throws {
+        try validateBenchmarkArguments(
+            durationHours: durationHours,
+            warmupCalls: warmupCalls,
+            intervalMS: intervalMS,
+            cooldownMS: cooldownMS
+        )
         let completedAfterDate = try ISO8601DateParser.parse(completedAfter, argumentName: "--completed-after")
         let scenarios = listTaskScenarios(completedAfter: completedAfterDate)
-        let outputURL = try listTaskBenchmarkOutputDirectory(customPath: outputDir)
+        let outputURL = try benchmarkOutputDirectory(customPath: outputDir, defaultPrefix: "list-tasks")
         let rawURL = outputURL.appendingPathComponent("raw.jsonl")
         let timeoutDiagnosticsURL = outputURL.appendingPathComponent("timeout-diagnostics.jsonl")
         let summaryURL = outputURL.appendingPathComponent("summary.md")
-        FileManager.default.createFile(atPath: rawURL.path, contents: nil)
-        FileManager.default.createFile(atPath: timeoutDiagnosticsURL.path, contents: nil)
+        try initializeBenchmarkArtifacts(rawURL: rawURL, memoryURL: nil, timeoutDiagnosticsURL: timeoutDiagnosticsURL)
 
         print("Benchmark output directory: \(outputURL.path)")
         print("Scenarios: \(scenarios.map(\.name).joined(separator: ", "))")
 
-        let pluginService = OmniFocusBridgeService()
-
+        let service = OmniFocusBridgeService()
         var callIndex = 0
-        var stats: [String: [String: ListTaskStats]] = [:]
-
         if warmupCalls > 0 {
-            for _ in 0..<warmupCalls {
-                let scenario = scenarios[callIndex % scenarios.count]
+            for index in 0..<warmupCalls {
+                let scenario = scenarios[benchmarkScenarioIndex(callIndex: index, scenarioCount: scenarios.count)]
                 let event = try await listTaskBenchCall(
-                    transport: "plugin",
                     scenario: scenario,
                     phase: "warmup",
-                    service: pluginService,
+                    service: service,
                     timeoutDiagnosticsURL: timeoutDiagnosticsURL,
                     intervalMS: intervalMS,
                     cooldownMS: cooldownMS,
@@ -62,52 +63,48 @@ struct BenchmarkListTasks: AsyncParsableCommand {
                     rawURL: rawURL
                 )
                 if event.timeout {
-                    await runListTaskTimeoutRecoveryGate()
+                    await runBenchmarkTimeoutRecoveryGate()
                 }
             }
         }
 
-        let start = Date()
-        let end = start.addingTimeInterval(durationHours * 3600)
-        print("Measured phase started at \(listTaskISO8601(start)); ending at \(listTaskISO8601(end))")
-
-        var measuredPairIndex = 0
-        while Date() < end {
-            let scenario = scenarios[listTaskScenarioIndex(pairIndex: measuredPairIndex, scenarioCount: scenarios.count)]
-            measuredPairIndex += 1
-
-            let pluginEvent = try await listTaskBenchCall(
-                transport: "plugin",
+        let measuredStart = Date()
+        let measuredEnd = measuredStart.addingTimeInterval(durationHours * 3600)
+        print("Measured phase started at \(benchmarkISO8601(measuredStart)); ending at \(benchmarkISO8601(measuredEnd))")
+        var scenarioStats: [String: BenchmarkStats] = [:]
+        var scenarioIndex = 0
+        while Date() < measuredEnd {
+            let scenario = scenarios[benchmarkScenarioIndex(callIndex: scenarioIndex, scenarioCount: scenarios.count)]
+            scenarioIndex += 1
+            let event = try await listTaskBenchCall(
                 scenario: scenario,
                 phase: "measured",
-                service: pluginService,
+                service: service,
                 timeoutDiagnosticsURL: timeoutDiagnosticsURL,
                 intervalMS: intervalMS,
                 cooldownMS: cooldownMS,
                 callIndex: &callIndex,
                 rawURL: rawURL
             )
-            ingestListTaskEvent(pluginEvent, into: &stats)
-            if pluginEvent.timeout {
-                await runListTaskTimeoutRecoveryGate()
+            var stats = scenarioStats[event.scenario] ?? BenchmarkStats()
+            stats.ingest(ok: event.ok, timeout: event.timeout, latencyMs: event.latencyMs)
+            scenarioStats[event.scenario] = stats
+            if event.timeout {
+                await runBenchmarkTimeoutRecoveryGate()
             }
-
         }
 
+        let scenarioNames = scenarios.map(\.name)
         let summary = renderListTaskSummary(
-            startedAt: start,
+            startedAt: measuredStart,
             endedAt: Date(),
-            scenarios: scenarios.map(\.name),
-            stats: stats,
-            timeoutDiagnosticCount: listTaskCountLines(in: timeoutDiagnosticsURL)
+            scenarios: scenarioNames,
+            stats: scenarioStats,
+            timeoutDiagnosticCount: benchmarkCountLines(in: timeoutDiagnosticsURL)
         )
         try summary.write(to: summaryURL, atomically: true, encoding: .utf8)
 
-        let missingCoverage = listTaskMissingMeasuredCoverage(
-            scenarios: scenarios.map(\.name),
-            stats: stats
-        )
-
+        let missingCoverage = listTaskMissingMeasuredCoverage(scenarios: scenarioNames, stats: scenarioStats)
         print("Benchmark complete.")
         print("Raw data: \(rawURL.path)")
         print("Summary: \(summaryURL.path)")
@@ -122,7 +119,7 @@ private struct ListTaskScenario {
     let filter: TaskFilter
 }
 
-private struct ListTaskEvent: Codable {
+struct ListTaskEvent: Codable {
     let timestamp: String
     let phase: String
     let callIndex: Int
@@ -139,63 +136,7 @@ private struct ListTaskEvent: Codable {
     let lastItemID: String?
 }
 
-struct ListTaskStats {
-    var success: Int = 0
-    var errors: Int = 0
-    var timeouts: Int = 0
-    var latencies: [Double] = []
-
-    fileprivate mutating func ingest(_ event: ListTaskEvent) {
-        if event.ok {
-            success += 1
-            latencies.append(event.latencyMs)
-        } else {
-            errors += 1
-            if event.timeout { timeouts += 1 }
-        }
-    }
-}
-
 private let listTaskNoMatchSearch = "__focusrelay_benchmark_no_match_7f43d9__"
-
-private struct ListTaskTimeoutQueueSnapshot: Codable {
-    let basePath: String
-    let requestsCount: Int
-    let locksCount: Int
-    let responsesCount: Int
-    let requestExists: Bool?
-    let lockExists: Bool?
-    let responseExists: Bool?
-    let sampleRequests: [String]
-    let sampleLocks: [String]
-    let sampleResponses: [String]
-}
-
-private struct ListTaskTimeoutProcessSnapshot: Codable {
-    let process: String
-    let pid: Int32?
-    let rssKB: Int?
-}
-
-private struct ListTaskTimeoutBridgeHealthSnapshot: Codable {
-    let ok: Bool
-    let detail: String
-}
-
-private struct ListTaskTimeoutDiagnostic: Codable {
-    let timestamp: String
-    let transport: String
-    let scenario: String
-    let phase: String
-    let callIndex: Int
-    let latencyMs: Double
-    let error: String
-    let requestId: String?
-    let queue: ListTaskTimeoutQueueSnapshot
-    let omniFocus: ListTaskTimeoutProcessSnapshot
-    let focusrelay: ListTaskTimeoutProcessSnapshot
-    let bridgeHealth: ListTaskTimeoutBridgeHealthSnapshot?
-}
 
 private func listTaskScenarios(completedAfter: Date) -> [ListTaskScenario] {
     [
@@ -215,17 +156,16 @@ private func listTaskScenarios(completedAfter: Date) -> [ListTaskScenario] {
     ]
 }
 
-func listTaskScenarioIndex(pairIndex: Int, scenarioCount: Int) -> Int {
-    precondition(pairIndex >= 0, "Pair index must be non-negative.")
+func benchmarkScenarioIndex(callIndex: Int, scenarioCount: Int) -> Int {
+    precondition(callIndex >= 0, "Call index must be non-negative.")
     precondition(scenarioCount > 0, "At least one benchmark scenario is required.")
-    return pairIndex % scenarioCount
+    return callIndex % scenarioCount
 }
 
 private func listTaskBenchCall(
-    transport: String,
     scenario: ListTaskScenario,
     phase: String,
-    service: any OmniFocusService,
+    service: OmniFocusBridgeService,
     timeoutDiagnosticsURL: URL,
     intervalMS: Int,
     cooldownMS: Int,
@@ -240,15 +180,15 @@ private func listTaskBenchCall(
             page: PageRequest(limit: 50),
             fields: ["id", "name", "completed", "available", "completionDate"]
         )
-        let elapsed = Date().timeIntervalSince(started) * 1000
-        try await listTaskEnforceInterval(started: started, intervalMS: intervalMS)
+        let latencyMs = Date().timeIntervalSince(started) * 1000
+        try await enforceBenchmarkInterval(started: started, intervalMS: intervalMS)
         let event = ListTaskEvent(
-            timestamp: listTaskISO8601Now(),
+            timestamp: benchmarkISO8601Now(),
             phase: phase,
             callIndex: callIndex,
-            transport: transport,
+            transport: benchmarkTransport,
             scenario: scenario.name,
-            latencyMs: elapsed,
+            latencyMs: latencyMs,
             ok: true,
             timeout: false,
             error: nil,
@@ -258,33 +198,32 @@ private func listTaskBenchCall(
             firstItemID: page.items.first?.id,
             lastItemID: page.items.last?.id
         )
-        try listTaskAppendJSONLine(event, to: rawURL)
+        try appendBenchmarkJSONLine(event, to: rawURL)
         return event
     } catch {
-        let elapsed = Date().timeIntervalSince(started) * 1000
-        let timeout = listTaskIsTimeout(error)
-        try await listTaskEnforceInterval(started: started, intervalMS: intervalMS)
+        let latencyMs = Date().timeIntervalSince(started) * 1000
+        let timeout = isBenchmarkTimeout(error)
+        try await enforceBenchmarkInterval(started: started, intervalMS: intervalMS)
         if cooldownMS > 0 {
             try? await Task.sleep(nanoseconds: UInt64(cooldownMS) * 1_000_000)
         }
         if timeout {
-            let diagnostic = captureListTaskTimeoutDiagnostic(
-                transport: transport,
-                scenario: scenario,
+            let diagnostic = captureBenchmarkTimeoutDiagnostic(
+                scenario: scenario.name,
                 phase: phase,
                 callIndex: callIndex,
-                latencyMs: elapsed,
+                latencyMs: latencyMs,
                 errorMessage: error.localizedDescription
             )
-            try? listTaskAppendJSONLine(diagnostic, to: timeoutDiagnosticsURL)
+            try? appendBenchmarkJSONLine(diagnostic, to: timeoutDiagnosticsURL)
         }
         let event = ListTaskEvent(
-            timestamp: listTaskISO8601Now(),
+            timestamp: benchmarkISO8601Now(),
             phase: phase,
             callIndex: callIndex,
-            transport: transport,
+            transport: benchmarkTransport,
             scenario: scenario.name,
-            latencyMs: elapsed,
+            latencyMs: latencyMs,
             ok: false,
             timeout: timeout,
             error: error.localizedDescription,
@@ -294,37 +233,18 @@ private func listTaskBenchCall(
             firstItemID: nil,
             lastItemID: nil
         )
-        try listTaskAppendJSONLine(event, to: rawURL)
+        try appendBenchmarkJSONLine(event, to: rawURL)
         return event
     }
 }
 
-private func runListTaskTimeoutRecoveryGate() async {
-    let env = ProcessInfo.processInfo.environment
-    let recoveryMs = max(0, env["FOCUS_RELAY_TIMEOUT_RECOVERY_MS"].flatMap(Int.init) ?? 10_000)
-    if recoveryMs > 0 {
-        try? await Task.sleep(nanoseconds: UInt64(recoveryMs) * 1_000_000)
-    }
-    // Lightweight readiness probe before resuming to reduce timeout cascades.
-    _ = try? OmniFocusBridgeService().healthCheck()
-}
-
-private func ingestListTaskEvent(_ event: ListTaskEvent, into stats: inout [String: [String: ListTaskStats]]) {
-    guard event.phase == "measured" else { return }
-    var perScenario = stats[event.scenario] ?? [:]
-    var perTransport = perScenario[event.transport] ?? ListTaskStats()
-    perTransport.ingest(event)
-    perScenario[event.transport] = perTransport
-    stats[event.scenario] = perScenario
-}
-
 func listTaskMissingMeasuredCoverage(
     scenarios: [String],
-    stats: [String: [String: ListTaskStats]]
+    stats: [String: BenchmarkStats]
 ) -> [String] {
     scenarios.compactMap { scenario in
-        let scoped = stats[scenario]?["plugin"] ?? ListTaskStats()
-        return scoped.success + scoped.errors == 0 ? "\(scenario):plugin" : nil
+        let scoped = stats[scenario] ?? BenchmarkStats()
+        return scoped.success + scoped.errors == 0 ? "\(scenario):\(benchmarkTransport)" : nil
     }
 }
 
@@ -332,22 +252,16 @@ private func renderListTaskSummary(
     startedAt: Date,
     endedAt: Date,
     scenarios: [String],
-    stats: [String: [String: ListTaskStats]],
+    stats: [String: BenchmarkStats],
     timeoutDiagnosticCount: Int
 ) -> String {
-    func p(_ values: [Double], _ q: Double) -> String {
-        guard !values.isEmpty else { return "n/a" }
-        let sorted = values.sorted()
-        let idx = Int(Double(sorted.count - 1) * q)
-        return String(format: "%.2f", sorted[idx])
-    }
-
-    var lines: [String] = []
-    lines.append("# list_tasks Benchmark Summary")
-    lines.append("")
-    lines.append("- Started: \(listTaskISO8601(startedAt))")
-    lines.append("- Ended: \(listTaskISO8601(endedAt))")
-    lines.append("- Scenarios: \(scenarios.joined(separator: ", "))")
+    var lines = [
+        "# list_tasks Benchmark Summary",
+        "",
+        "- Started: \(benchmarkISO8601(startedAt))",
+        "- Ended: \(benchmarkISO8601(endedAt))",
+        "- Scenarios: \(scenarios.joined(separator: ", "))"
+    ]
     let missingCoverage = listTaskMissingMeasuredCoverage(scenarios: scenarios, stats: stats)
     lines.append("- Measured coverage complete: \(missingCoverage.isEmpty ? "yes" : "no")")
     if !missingCoverage.isEmpty {
@@ -357,253 +271,17 @@ private func renderListTaskSummary(
     lines.append("## Scenario Stats")
     lines.append("")
     for scenario in scenarios {
+        let scoped = stats[scenario] ?? BenchmarkStats()
+        let total = scoped.success + scoped.errors
         lines.append("### \(scenario)")
-        let scoped = stats[scenario] ?? [:]
-        for transport in ["plugin"] {
-            let s = scoped[transport] ?? ListTaskStats()
-            let total = s.success + s.errors
-            let errorRate = total > 0 ? (Double(s.errors) / Double(total)) * 100.0 : .nan
-            let timeoutRate = total > 0 ? (Double(s.timeouts) / Double(total)) * 100.0 : .nan
-            let er = errorRate.isFinite ? String(format: "%.2f%%", errorRate) : "n/a"
-            let tr = timeoutRate.isFinite ? String(format: "%.2f%%", timeoutRate) : "n/a"
-            lines.append("- \(transport): total=\(total), success=\(s.success), errors=\(s.errors), error_rate=\(er), timeouts=\(s.timeouts), timeout_rate=\(tr), p50_ms=\(p(s.latencies, 0.5)), p95_ms=\(p(s.latencies, 0.95)), p99_ms=\(p(s.latencies, 0.99))")
-        }
+        lines.append(
+            "- \(benchmarkTransport): total=\(total), success=\(scoped.success), errors=\(scoped.errors), error_rate=\(benchmarkFormatPercentage(benchmarkPercentage(part: scoped.errors, total: total))), timeouts=\(scoped.timeouts), timeout_rate=\(benchmarkFormatPercentage(benchmarkPercentage(part: scoped.timeouts, total: total))), p50_ms=\(benchmarkFormatDouble(benchmarkPercentile(scoped.latencies, p: 0.50))), p95_ms=\(benchmarkFormatDouble(benchmarkPercentile(scoped.latencies, p: 0.95))), p99_ms=\(benchmarkFormatDouble(benchmarkPercentile(scoped.latencies, p: 0.99)))"
+        )
         lines.append("")
     }
-
     lines.append("## Timeout Diagnostics")
     lines.append("")
     lines.append("- Diagnostic entries: \(timeoutDiagnosticCount)")
     return lines.joined(separator: "\n")
-}
-
-private func listTaskBenchmarkOutputDirectory(customPath: String?) throws -> URL {
-    if let customPath, !customPath.isEmpty {
-        let url = URL(fileURLWithPath: customPath, relativeTo: URL(fileURLWithPath: FileManager.default.currentDirectoryPath)).standardizedFileURL
-        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
-        return url
-    }
-
-    let formatter = DateFormatter()
-    formatter.locale = Locale(identifier: "en_US_POSIX")
-    formatter.dateFormat = "yyyyMMdd-HHmmss"
-    let timestamp = formatter.string(from: Date())
-    let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-        .appendingPathComponent(".build", isDirectory: true)
-        .appendingPathComponent("benchmarks", isDirectory: true)
-        .appendingPathComponent("list-tasks-\(timestamp)", isDirectory: true)
-    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
-    return url
-}
-
-private func listTaskAppendJSONLine<T: Encodable>(_ value: T, to url: URL) throws {
-    let encoder = JSONEncoder()
-    let data = try encoder.encode(value)
-    guard var line = String(data: data, encoding: .utf8) else { return }
-    line.append("\n")
-    let handle = try FileHandle(forWritingTo: url)
-    defer { try? handle.close() }
-    try handle.seekToEnd()
-    try handle.write(contentsOf: Data(line.utf8))
-}
-
-private func captureListTaskTimeoutDiagnostic(
-    transport: String,
-    scenario: ListTaskScenario,
-    phase: String,
-    callIndex: Int,
-    latencyMs: Double,
-    errorMessage: String
-) -> ListTaskTimeoutDiagnostic {
-    let requestID = listTaskExtractRequestID(from: errorMessage)
-    let baseURL = listTaskDefaultIPCBaseURL()
-    let requestsURL = baseURL.appendingPathComponent("requests", isDirectory: true)
-    let locksURL = baseURL.appendingPathComponent("locks", isDirectory: true)
-    let responsesURL = baseURL.appendingPathComponent("responses", isDirectory: true)
-    let queue = ListTaskTimeoutQueueSnapshot(
-        basePath: baseURL.path,
-        requestsCount: listTaskDirectoryEntryCount(requestsURL),
-        locksCount: listTaskDirectoryEntryCount(locksURL),
-        responsesCount: listTaskDirectoryEntryCount(responsesURL),
-        requestExists: requestID.map { FileManager.default.fileExists(atPath: requestsURL.appendingPathComponent("\($0).json").path) },
-        lockExists: requestID.map { FileManager.default.fileExists(atPath: locksURL.appendingPathComponent("\($0).lock").path) },
-        responseExists: requestID.map { FileManager.default.fileExists(atPath: responsesURL.appendingPathComponent("\($0).json").path) },
-        sampleRequests: listTaskDirectoryEntrySamples(requestsURL),
-        sampleLocks: listTaskDirectoryEntrySamples(locksURL),
-        sampleResponses: listTaskDirectoryEntrySamples(responsesURL)
-    )
-    let omniPID = listTaskCurrentOmniFocusPID()
-    let benchmarkPID = ProcessInfo.processInfo.processIdentifier
-    let bridgeHealth: ListTaskTimeoutBridgeHealthSnapshot?
-    if transport == "plugin" {
-        if let result = try? OmniFocusBridgeService().healthCheck() {
-            bridgeHealth = ListTaskTimeoutBridgeHealthSnapshot(
-                ok: result.ok,
-                detail: "plugin=\(result.plugin ?? "unknown") version=\(result.version ?? "unknown")"
-            )
-        } else {
-            bridgeHealth = ListTaskTimeoutBridgeHealthSnapshot(
-                ok: false,
-                detail: "bridge-health-check failed after timeout"
-            )
-        }
-    } else {
-        bridgeHealth = nil
-    }
-
-    return ListTaskTimeoutDiagnostic(
-        timestamp: listTaskISO8601Now(),
-        transport: transport,
-        scenario: scenario.name,
-        phase: phase,
-        callIndex: callIndex,
-        latencyMs: latencyMs,
-        error: errorMessage,
-        requestId: requestID,
-        queue: queue,
-        omniFocus: ListTaskTimeoutProcessSnapshot(
-            process: "OmniFocus",
-            pid: omniPID,
-            rssKB: omniPID.flatMap(listTaskReadRSSKilobytes(pid:))
-        ),
-        focusrelay: ListTaskTimeoutProcessSnapshot(
-            process: "focusrelay",
-            pid: benchmarkPID,
-            rssKB: listTaskReadRSSKilobytes(pid: benchmarkPID)
-        ),
-        bridgeHealth: bridgeHealth
-    )
-}
-
-private func listTaskExtractRequestID(from message: String) -> String? {
-    let pattern = #"requestId=([A-F0-9-]+)"#
-    guard let regex = try? NSRegularExpression(pattern: pattern) else {
-        return nil
-    }
-    let range = NSRange(message.startIndex..<message.endIndex, in: message)
-    guard let match = regex.firstMatch(in: message, range: range),
-          let matchRange = Range(match.range(at: 1), in: message) else {
-        return nil
-    }
-    return String(message[matchRange])
-}
-
-private func listTaskDirectoryEntryCount(_ url: URL) -> Int {
-    guard let contents = try? FileManager.default.contentsOfDirectory(atPath: url.path) else {
-        return 0
-    }
-    return contents.count
-}
-
-private func listTaskDirectoryEntrySamples(_ url: URL, limit: Int = 5) -> [String] {
-    guard let contents = try? FileManager.default.contentsOfDirectory(atPath: url.path) else {
-        return []
-    }
-    return Array(contents.sorted().prefix(limit))
-}
-
-private func listTaskDefaultIPCBaseURL() -> URL {
-    let home = FileManager.default.homeDirectoryForCurrentUser
-    let container = home
-        .appendingPathComponent("Library", isDirectory: true)
-        .appendingPathComponent("Containers", isDirectory: true)
-        .appendingPathComponent("com.omnigroup.OmniFocus4", isDirectory: true)
-        .appendingPathComponent("Data", isDirectory: true)
-        .appendingPathComponent("Documents", isDirectory: true)
-        .appendingPathComponent("FocusRelayIPC", isDirectory: true)
-
-    if FileManager.default.fileExists(atPath: container.deletingLastPathComponent().path) {
-        return container
-    }
-
-    return home
-        .appendingPathComponent("Library", isDirectory: true)
-        .appendingPathComponent("Caches", isDirectory: true)
-        .appendingPathComponent("focusrelay", isDirectory: true)
-}
-
-private func listTaskCurrentOmniFocusPID() -> Int32? {
-    guard let output = try? listTaskRunProcess(
-        executable: "/usr/bin/pgrep",
-        arguments: ["-x", "OmniFocus"],
-        timeout: 3
-    ) else {
-        return nil
-    }
-    let firstLine = output.split(separator: "\n").first
-    return firstLine.flatMap { Int32($0) }
-}
-
-private func listTaskReadRSSKilobytes(pid: Int32) -> Int? {
-    guard let output = try? listTaskRunProcess(
-        executable: "/bin/ps",
-        arguments: ["-o", "rss=", "-p", String(pid)],
-        timeout: 3
-    ) else {
-        return nil
-    }
-    return Int(output.trimmingCharacters(in: .whitespacesAndNewlines))
-}
-
-@discardableResult
-private func listTaskRunProcess(executable: String, arguments: [String], timeout: TimeInterval = 15) throws -> String {
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: executable)
-    process.arguments = arguments
-    let pipe = Pipe()
-    process.standardOutput = pipe
-    process.standardError = pipe
-    try process.run()
-
-    let deadline = Date().addingTimeInterval(timeout)
-    while process.isRunning && Date() < deadline {
-        Thread.sleep(forTimeInterval: 0.05)
-    }
-
-    if process.isRunning {
-        process.terminate()
-        throw AutomationError.executionFailed("Process \(executable) timed out after \(Int(timeout))s")
-    }
-
-    process.waitUntilExit()
-    let data = pipe.fileHandleForReading.readDataToEndOfFile()
-    let output = String(decoding: data, as: UTF8.self)
-    if process.terminationStatus != 0 {
-        throw AutomationError.executionFailed("Process \(executable) failed: \(output)")
-    }
-    return output
-}
-
-private func listTaskCountLines(in url: URL) -> Int {
-    guard let data = try? Data(contentsOf: url),
-          let text = String(data: data, encoding: .utf8),
-          !text.isEmpty else {
-        return 0
-    }
-    return text.split(separator: "\n").count
-}
-
-private func listTaskIsTimeout(_ error: Error) -> Bool {
-    let message = error.localizedDescription.lowercased()
-    return message.contains("timed out") || message.contains("timeout")
-}
-
-private func listTaskEnforceInterval(started: Date, intervalMS: Int) async throws {
-    guard intervalMS > 0 else { return }
-    let elapsed = Date().timeIntervalSince(started)
-    let target = Double(intervalMS) / 1000.0
-    if elapsed < target {
-        try await Task.sleep(nanoseconds: UInt64((target - elapsed) * 1_000_000_000))
-    }
-}
-
-private func listTaskISO8601Now() -> String {
-    listTaskISO8601(Date())
-}
-
-private func listTaskISO8601(_ date: Date) -> String {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-    return formatter.string(from: date)
 }
 #endif

--- a/Sources/FocusRelayCLI/BenchmarkProjectCountsCommand.swift
+++ b/Sources/FocusRelayCLI/BenchmarkProjectCountsCommand.swift
@@ -4,8 +4,6 @@ import Foundation
 import OmniFocusAutomation
 import OmniFocusCore
 
-private typealias ProjectCountsModel = OmniFocusCore.ProjectCounts
-
 struct BenchmarkProjectCounts: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "benchmark-project-counts",
@@ -38,25 +36,15 @@ struct BenchmarkProjectCounts: AsyncParsableCommand {
     var performPreflight: Bool = false
 
     func run() async throws {
-        guard durationHours > 0 else {
-            throw ValidationError("--duration-hours must be > 0.")
-        }
-        guard warmupCalls >= 0 else {
-            throw ValidationError("--warmup-calls must be >= 0.")
-        }
-        guard intervalMS >= 0 else {
-            throw ValidationError("--interval-ms must be >= 0.")
-        }
-        guard cooldownMS >= 0 else {
-            throw ValidationError("--cooldown-ms must be >= 0.")
-        }
-        guard memoryIntervalSeconds > 0 else {
-            throw ValidationError("--memory-interval-seconds must be > 0.")
-        }
-
+        try validateBenchmarkArguments(
+            durationHours: durationHours,
+            warmupCalls: warmupCalls,
+            intervalMS: intervalMS,
+            cooldownMS: cooldownMS,
+            memoryIntervalSeconds: memoryIntervalSeconds
+        )
         let completedAfterDate = try ISO8601DateParser.parse(completedAfter, argumentName: "--completed-after")
         let scenarios = projectCountBenchmarkScenarios(completedAfter: completedAfterDate)
-
         let directoryURL = try benchmarkOutputDirectory(customPath: outputDir)
         let rawURL = directoryURL.appendingPathComponent("raw.jsonl")
         let memoryURL = directoryURL.appendingPathComponent("memory.csv")
@@ -66,94 +54,85 @@ struct BenchmarkProjectCounts: AsyncParsableCommand {
 
         print("Benchmark output directory: \(directoryURL.path)")
         print("Scenarios: \(scenarios.map(\.name).joined(separator: ", "))")
-
         if performPreflight {
-            runPreflight()
+            runBenchmarkPreflight()
         }
 
-        let benchmarkPID = ProcessInfo.processInfo.processIdentifier
-        let memoryTask = Task.detached(priority: .utility) {
-            while !Task.isCancelled {
-                let timestamp = iso8601Now()
-                if let rss = readRSSKilobytes(pid: benchmarkPID) {
-                    let line = "\(timestamp),focusrelay,\(benchmarkPID),\(rss)\n"
-                    try? appendLine(line, to: memoryURL)
-                }
-
-                if let omniPID = currentOmniFocusPID(), let rss = readRSSKilobytes(pid: omniPID) {
-                    let line = "\(timestamp),OmniFocus,\(omniPID),\(rss)\n"
-                    try? appendLine(line, to: memoryURL)
-                }
-
-                let nanos = UInt64(memoryIntervalSeconds) * 1_000_000_000
-                try? await Task.sleep(nanoseconds: nanos)
-            }
-        }
+        let memoryTask = startBenchmarkMemorySampling(memoryURL: memoryURL, intervalSeconds: memoryIntervalSeconds)
         defer { memoryTask.cancel() }
 
-        let pluginService = OmniFocusBridgeService()
-
-        var statsByTransport: [Transport: StatsAccumulator] = [:]
-        var statsByScenarioTransport: [String: [Transport: StatsAccumulator]] = [:]
+        let service = OmniFocusBridgeService()
         var callIndex = 0
-
         if warmupCalls > 0 {
             print("Warmup phase: \(warmupCalls) calls")
-            try await runWarmup(
-                warmupCalls: warmupCalls,
-                scenarios: scenarios,
-                pluginService: pluginService,
-                rawURL: rawURL,
-                timeoutDiagnosticsURL: timeoutDiagnosticsURL,
-                intervalMS: intervalMS,
-                cooldownMS: cooldownMS,
-                callIndex: &callIndex
-            )
+            for index in 0..<warmupCalls {
+                let scenario = scenarios[index % scenarios.count]
+                let event: CountBenchmarkEvent<OmniFocusCore.ProjectCounts> = try await runCountBenchmarkCall(
+                    scenario: scenario.name,
+                    phase: "warmup",
+                    timeoutDiagnosticsURL: timeoutDiagnosticsURL,
+                    intervalMS: intervalMS,
+                    cooldownMS: cooldownMS,
+                    callIndex: &callIndex
+                ) {
+                    try await service.getProjectCounts(filter: scenario.filter)
+                }
+                try appendBenchmarkJSONLine(event, to: rawURL)
+                if event.timeout {
+                    await runBenchmarkTimeoutRecoveryGate()
+                }
+            }
         }
 
-        let durationSeconds = durationHours * 3600
         let measuredStart = Date()
-        let measuredEnd = measuredStart.addingTimeInterval(durationSeconds)
-        print("Measured phase started at \(iso8601(measuredStart)); ending at \(iso8601(measuredEnd))")
-
+        let measuredEnd = measuredStart.addingTimeInterval(durationHours * 3600)
+        print("Measured phase started at \(benchmarkISO8601(measuredStart)); ending at \(benchmarkISO8601(measuredEnd))")
+        var overallStats = BenchmarkStats()
+        var scenarioStats: [String: BenchmarkStats] = [:]
         var scenarioIndex = 0
         while Date() < measuredEnd {
             let scenario = scenarios[scenarioIndex % scenarios.count]
             scenarioIndex += 1
-
-            let pluginEvent = try await runProjectBenchCall(
-                transport: .plugin,
-                scenario: scenario,
+            let event: CountBenchmarkEvent<OmniFocusCore.ProjectCounts> = try await runCountBenchmarkCall(
+                scenario: scenario.name,
                 phase: "measured",
-                service: pluginService,
                 timeoutDiagnosticsURL: timeoutDiagnosticsURL,
                 intervalMS: intervalMS,
                 cooldownMS: cooldownMS,
                 callIndex: &callIndex
-            )
-            try appendJSONLine(pluginEvent, to: rawURL)
-            accumulate(pluginEvent, byTransport: &statsByTransport, byScenarioTransport: &statsByScenarioTransport)
-            if pluginEvent.timeout {
-                await runTimeoutRecoveryGate()
+            ) {
+                try await service.getProjectCounts(filter: scenario.filter)
             }
-
+            try appendBenchmarkJSONLine(event, to: rawURL)
+            ingestBenchmarkEvent(
+                scenario: event.scenario,
+                ok: event.ok,
+                timeout: event.timeout,
+                latencyMs: event.latencyMs,
+                overall: &overallStats,
+                scenarios: &scenarioStats
+            )
+            if event.timeout {
+                await runBenchmarkTimeoutRecoveryGate()
+            }
         }
 
-        try await writeSummary(
-            to: summaryURL,
+        let summary = renderCountBenchmarkSummary(
+            title: "get_project_counts",
             startedAt: measuredStart,
             endedAt: Date(),
-            memoryURL: memoryURL,
             durationHours: durationHours,
             warmupCalls: warmupCalls,
             intervalMS: intervalMS,
             cooldownMS: cooldownMS,
             memoryIntervalSeconds: memoryIntervalSeconds,
-            timeoutDiagnosticsURL: timeoutDiagnosticsURL,
-            scenarios: scenarios,
-            statsByTransport: statsByTransport,
-            statsByScenarioTransport: statsByScenarioTransport
+            scenarioNames: scenarios.map(\.name),
+            overall: overallStats,
+            scenarios: scenarioStats,
+            memoryURL: memoryURL,
+            timeoutDiagnosticsURL: timeoutDiagnosticsURL
         )
+        try summary.write(to: summaryURL, atomically: true, encoding: .utf8)
 
         print("Benchmark complete.")
         print("Raw data: \(rawURL.path)")
@@ -162,701 +141,21 @@ struct BenchmarkProjectCounts: AsyncParsableCommand {
     }
 }
 
-private struct BenchmarkScenario {
+private struct ProjectCountBenchmarkScenario {
     let name: String
     let filter: TaskFilter
 }
 
-private func projectCountBenchmarkScenarios(completedAfter: Date) -> [BenchmarkScenario] {
+private func projectCountBenchmarkScenarios(completedAfter: Date) -> [ProjectCountBenchmarkScenario] {
     [
-        BenchmarkScenario(name: "project_view_remaining", filter: TaskFilter(projectView: "remaining")),
-        BenchmarkScenario(name: "project_view_active", filter: TaskFilter(projectView: "active")),
-        BenchmarkScenario(name: "project_view_available", filter: TaskFilter(projectView: "available")),
-        BenchmarkScenario(name: "project_view_everything", filter: TaskFilter(projectView: "everything")),
-        BenchmarkScenario(
+        ProjectCountBenchmarkScenario(name: "project_view_remaining", filter: TaskFilter(projectView: "remaining")),
+        ProjectCountBenchmarkScenario(name: "project_view_active", filter: TaskFilter(projectView: "active")),
+        ProjectCountBenchmarkScenario(name: "project_view_available", filter: TaskFilter(projectView: "available")),
+        ProjectCountBenchmarkScenario(name: "project_view_everything", filter: TaskFilter(projectView: "everything")),
+        ProjectCountBenchmarkScenario(
             name: "completed_after_anchor",
             filter: TaskFilter(completed: true, completedAfter: completedAfter)
         )
     ]
-}
-
-private enum Transport: String, Codable, CaseIterable {
-    case plugin
-}
-
-private struct ProjectBenchEvent: Codable {
-    let timestamp: String
-    let phase: String
-    let callIndex: Int
-    let transport: String
-    let scenario: String
-    let latencyMs: Double
-    let ok: Bool
-    let timeout: Bool
-    let error: String?
-    let counts: ProjectCountsModel?
-}
-
-private struct StatsAccumulator {
-    var successCount: Int = 0
-    var errorCount: Int = 0
-    var timeoutCount: Int = 0
-    var latencies: [Double] = []
-
-    mutating func ingest(_ event: ProjectBenchEvent) {
-        if event.ok {
-            successCount += 1
-            latencies.append(event.latencyMs)
-        } else {
-            errorCount += 1
-            if event.timeout {
-                timeoutCount += 1
-            }
-        }
-    }
-}
-
-private struct TimeoutQueueSnapshot: Codable {
-    let basePath: String
-    let requestsCount: Int
-    let locksCount: Int
-    let responsesCount: Int
-    let requestExists: Bool?
-    let lockExists: Bool?
-    let responseExists: Bool?
-    let sampleRequests: [String]
-    let sampleLocks: [String]
-    let sampleResponses: [String]
-}
-
-private struct TimeoutProcessSnapshot: Codable {
-    let process: String
-    let pid: Int32?
-    let rssKB: Int?
-}
-
-private struct TimeoutBridgeHealthSnapshot: Codable {
-    let ok: Bool
-    let detail: String
-}
-
-private struct ProjectTimeoutDiagnostic: Codable {
-    let timestamp: String
-    let transport: String
-    let scenario: String
-    let phase: String
-    let callIndex: Int
-    let latencyMs: Double
-    let error: String
-    let requestId: String?
-    let queue: TimeoutQueueSnapshot
-    let omniFocus: TimeoutProcessSnapshot
-    let focusrelay: TimeoutProcessSnapshot
-    let bridgeHealth: TimeoutBridgeHealthSnapshot?
-}
-
-private func runWarmup(
-    warmupCalls: Int,
-    scenarios: [BenchmarkScenario],
-    pluginService: OmniFocusBridgeService,
-    rawURL: URL,
-    timeoutDiagnosticsURL: URL,
-    intervalMS: Int,
-    cooldownMS: Int,
-    callIndex: inout Int
-) async throws {
-    var scenarioIndex = 0
-    for _ in 0..<warmupCalls {
-        let scenario = scenarios[scenarioIndex % scenarios.count]
-        scenarioIndex += 1
-        let event = try await runProjectBenchCall(
-            transport: .plugin,
-            scenario: scenario,
-            phase: "warmup",
-            service: pluginService,
-            timeoutDiagnosticsURL: timeoutDiagnosticsURL,
-            intervalMS: intervalMS,
-            cooldownMS: cooldownMS,
-            callIndex: &callIndex
-        )
-        try appendJSONLine(event, to: rawURL)
-    }
-
-}
-
-private func runProjectBenchCall(
-    transport: Transport,
-    scenario: BenchmarkScenario,
-    phase: String,
-    service: any OmniFocusService,
-    timeoutDiagnosticsURL: URL,
-    intervalMS: Int,
-    cooldownMS: Int,
-    callIndex: inout Int
-) async throws -> ProjectBenchEvent {
-    callIndex += 1
-    let start = Date()
-    do {
-        let counts = try await service.getProjectCounts(filter: scenario.filter)
-        let elapsed = Date().timeIntervalSince(start)
-        try await enforceInterval(start: start, intervalMS: intervalMS)
-        return ProjectBenchEvent(
-            timestamp: iso8601Now(),
-            phase: phase,
-            callIndex: callIndex,
-            transport: transport.rawValue,
-            scenario: scenario.name,
-            latencyMs: elapsed * 1000,
-            ok: true,
-            timeout: false,
-            error: nil,
-            counts: counts
-        )
-    } catch {
-        let elapsed = Date().timeIntervalSince(start)
-        let message = error.localizedDescription
-        let isTimeout = isTimeoutError(error)
-        try await enforceInterval(start: start, intervalMS: intervalMS)
-        if cooldownMS > 0 {
-            try? await Task.sleep(nanoseconds: UInt64(cooldownMS) * 1_000_000)
-        }
-        if isTimeout {
-            let diagnostic = captureProjectTimeoutDiagnostic(
-                transport: transport,
-                scenario: scenario,
-                phase: phase,
-                callIndex: callIndex,
-                latencyMs: elapsed * 1000,
-                errorMessage: message
-            )
-            try? appendJSONLine(diagnostic, to: timeoutDiagnosticsURL)
-        }
-        return ProjectBenchEvent(
-            timestamp: iso8601Now(),
-            phase: phase,
-            callIndex: callIndex,
-            transport: transport.rawValue,
-            scenario: scenario.name,
-            latencyMs: elapsed * 1000,
-            ok: false,
-            timeout: isTimeout,
-            error: message,
-            counts: nil
-        )
-    }
-}
-
-private func runTimeoutRecoveryGate() async {
-    let env = ProcessInfo.processInfo.environment
-    let recoveryMs = max(0, env["FOCUS_RELAY_TIMEOUT_RECOVERY_MS"].flatMap(Int.init) ?? 10_000)
-    if recoveryMs > 0 {
-        try? await Task.sleep(nanoseconds: UInt64(recoveryMs) * 1_000_000)
-    }
-    // Lightweight readiness probe before resuming to reduce timeout cascades.
-    _ = try? OmniFocusBridgeService().healthCheck()
-}
-
-private func enforceInterval(start: Date, intervalMS: Int) async throws {
-    guard intervalMS > 0 else { return }
-    let elapsed = Date().timeIntervalSince(start)
-    let target = Double(intervalMS) / 1000.0
-    if elapsed < target {
-        let wait = target - elapsed
-        try await Task.sleep(nanoseconds: UInt64(wait * 1_000_000_000))
-    }
-}
-
-private func accumulate(
-    _ event: ProjectBenchEvent,
-    byTransport: inout [Transport: StatsAccumulator],
-    byScenarioTransport: inout [String: [Transport: StatsAccumulator]]
-) {
-    guard let transport = Transport(rawValue: event.transport) else { return }
-
-    var transportStats = byTransport[transport] ?? StatsAccumulator()
-    transportStats.ingest(event)
-    byTransport[transport] = transportStats
-
-    var scenarioStats = byScenarioTransport[event.scenario] ?? [:]
-    var scopedStats = scenarioStats[transport] ?? StatsAccumulator()
-    scopedStats.ingest(event)
-    scenarioStats[transport] = scopedStats
-    byScenarioTransport[event.scenario] = scenarioStats
-}
-
-private func benchmarkOutputDirectory(customPath: String?) throws -> URL {
-    if let customPath, !customPath.isEmpty {
-        let url = URL(fileURLWithPath: customPath, relativeTo: URL(fileURLWithPath: FileManager.default.currentDirectoryPath))
-            .standardizedFileURL
-        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
-        return url
-    }
-
-    let formatter = DateFormatter()
-    formatter.locale = Locale(identifier: "en_US_POSIX")
-    formatter.dateFormat = "yyyyMMdd-HHmmss"
-    let timestamp = formatter.string(from: Date())
-    let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-        .appendingPathComponent(".build", isDirectory: true)
-        .appendingPathComponent("benchmarks", isDirectory: true)
-        .appendingPathComponent(timestamp, isDirectory: true)
-    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
-    return url
-}
-
-private func initializeBenchmarkArtifacts(rawURL: URL, memoryURL: URL, timeoutDiagnosticsURL: URL) throws {
-    FileManager.default.createFile(atPath: rawURL.path, contents: nil)
-    FileManager.default.createFile(atPath: memoryURL.path, contents: nil)
-    FileManager.default.createFile(atPath: timeoutDiagnosticsURL.path, contents: nil)
-    try appendLine("timestamp,process,pid,rss_kb\n", to: memoryURL)
-}
-
-private func appendJSONLine<T: Encodable>(_ value: T, to url: URL) throws {
-    let encoder = JSONEncoder()
-    encoder.dateEncodingStrategy = .iso8601
-    let data = try encoder.encode(value)
-    guard var line = String(data: data, encoding: .utf8) else {
-        throw ValidationError("Failed to encode benchmark event as UTF-8.")
-    }
-    line.append("\n")
-    try appendLine(line, to: url)
-}
-
-private func appendLine(_ line: String, to url: URL) throws {
-    guard let data = line.data(using: .utf8) else { return }
-    let handle = try FileHandle(forWritingTo: url)
-    defer { try? handle.close() }
-    try handle.seekToEnd()
-    try handle.write(contentsOf: data)
-}
-
-private func isTimeoutError(_ error: Error) -> Bool {
-    let message = error.localizedDescription.lowercased()
-    return message.contains("timed out") || message.contains("timeout")
-}
-
-private func runPreflight() {
-    do {
-        try stopExtraServeProcesses()
-    } catch {
-        print("Preflight warning: failed to inspect/terminate extra servers (\(error.localizedDescription)).")
-    }
-
-    do {
-        try restartOmniFocus()
-    } catch {
-        print("Preflight warning: failed to restart OmniFocus (\(error.localizedDescription)).")
-    }
-}
-
-private func stopExtraServeProcesses() throws {
-    let currentPID = ProcessInfo.processInfo.processIdentifier
-    guard let output = try? runProcess(
-        executable: "/usr/bin/pgrep",
-        arguments: ["-f", "focusrelay"],
-        timeout: 3
-    ) else {
-        print("Preflight: no extra focusrelay server processes detected.")
-        return
-    }
-
-    let candidatePIDs = output
-        .split(separator: "\n")
-        .compactMap { Int32($0) }
-
-    var terminated: [Int32] = []
-    for pid in candidatePIDs {
-        if pid == currentPID { continue }
-        guard let command = try? runProcess(
-            executable: "/bin/ps",
-            arguments: ["-o", "command=", "-p", String(pid)],
-            timeout: 3
-        ) else {
-            continue
-        }
-        let trimmedCommand = command.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmedCommand.contains("focusrelay serve") || trimmedCommand.contains("focusrelay mcp") || trimmedCommand.contains("focusrelay server") {
-            _ = try? runProcess(executable: "/bin/kill", arguments: ["-TERM", String(pid)], timeout: 2)
-            terminated.append(pid)
-        }
-    }
-
-    if !terminated.isEmpty {
-        print("Preflight: terminated focusrelay server processes: \(terminated.map(String.init).joined(separator: ", "))")
-        Thread.sleep(forTimeInterval: 1.0)
-    } else {
-        print("Preflight: no extra focusrelay server processes detected.")
-    }
-}
-
-private func restartOmniFocus() throws {
-    print("Preflight: restarting OmniFocus...")
-    _ = try? runProcess(
-        executable: "/usr/bin/osascript",
-        arguments: ["-e", "tell application \"OmniFocus\" to quit"],
-        timeout: 8
-    )
-    Thread.sleep(forTimeInterval: 2.0)
-    _ = try runProcess(executable: "/usr/bin/open", arguments: ["-a", "OmniFocus"], timeout: 8)
-    Thread.sleep(forTimeInterval: 3.0)
-}
-
-private func currentOmniFocusPID() -> Int32? {
-    guard let output = try? runProcess(executable: "/usr/bin/pgrep", arguments: ["-x", "OmniFocus"], timeout: 3) else {
-        return nil
-    }
-    let firstLine = output.split(separator: "\n").first
-    return firstLine.flatMap { Int32($0) }
-}
-
-private func readRSSKilobytes(pid: Int32) -> Int? {
-    guard let output = try? runProcess(executable: "/bin/ps", arguments: ["-o", "rss=", "-p", String(pid)], timeout: 3) else {
-        return nil
-    }
-    return Int(output.trimmingCharacters(in: .whitespacesAndNewlines))
-}
-
-@discardableResult
-private func runProcess(executable: String, arguments: [String], timeout: TimeInterval = 15) throws -> String {
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: executable)
-    process.arguments = arguments
-    let pipe = Pipe()
-    process.standardOutput = pipe
-    process.standardError = pipe
-    try process.run()
-    let deadline = Date().addingTimeInterval(timeout)
-    while process.isRunning && Date() < deadline {
-        Thread.sleep(forTimeInterval: 0.05)
-    }
-
-    if process.isRunning {
-        process.terminate()
-        throw AutomationError.executionFailed("Process \(executable) timed out after \(Int(timeout))s")
-    }
-
-    process.waitUntilExit()
-    let data = pipe.fileHandleForReading.readDataToEndOfFile()
-    let output = String(decoding: data, as: UTF8.self)
-    if process.terminationStatus != 0 {
-        throw AutomationError.executionFailed("Process \(executable) failed: \(output)")
-    }
-    return output
-}
-
-private func captureProjectTimeoutDiagnostic(
-    transport: Transport,
-    scenario: BenchmarkScenario,
-    phase: String,
-    callIndex: Int,
-    latencyMs: Double,
-    errorMessage: String
-) -> ProjectTimeoutDiagnostic {
-    let requestID = extractRequestID(from: errorMessage)
-    let baseURL = defaultIPCBaseURL()
-    let requestsURL = baseURL.appendingPathComponent("requests", isDirectory: true)
-    let locksURL = baseURL.appendingPathComponent("locks", isDirectory: true)
-    let responsesURL = baseURL.appendingPathComponent("responses", isDirectory: true)
-    let queue = TimeoutQueueSnapshot(
-        basePath: baseURL.path,
-        requestsCount: directoryEntryCount(requestsURL),
-        locksCount: directoryEntryCount(locksURL),
-        responsesCount: directoryEntryCount(responsesURL),
-        requestExists: requestID.map { FileManager.default.fileExists(atPath: requestsURL.appendingPathComponent("\($0).json").path) },
-        lockExists: requestID.map { FileManager.default.fileExists(atPath: locksURL.appendingPathComponent("\($0).lock").path) },
-        responseExists: requestID.map { FileManager.default.fileExists(atPath: responsesURL.appendingPathComponent("\($0).json").path) },
-        sampleRequests: directoryEntrySamples(requestsURL),
-        sampleLocks: directoryEntrySamples(locksURL),
-        sampleResponses: directoryEntrySamples(responsesURL)
-    )
-    let omniPID = currentOmniFocusPID()
-    let benchmarkPID = ProcessInfo.processInfo.processIdentifier
-    let bridgeHealth: TimeoutBridgeHealthSnapshot?
-    if transport == .plugin {
-        if let result = try? OmniFocusBridgeService().healthCheck() {
-            bridgeHealth = TimeoutBridgeHealthSnapshot(
-                ok: result.ok,
-                detail: "plugin=\(result.plugin ?? "unknown") version=\(result.version ?? "unknown")"
-            )
-        } else {
-            bridgeHealth = TimeoutBridgeHealthSnapshot(
-                ok: false,
-                detail: "bridge-health-check failed after timeout"
-            )
-        }
-    } else {
-        bridgeHealth = nil
-    }
-
-    return ProjectTimeoutDiagnostic(
-        timestamp: iso8601Now(),
-        transport: transport.rawValue,
-        scenario: scenario.name,
-        phase: phase,
-        callIndex: callIndex,
-        latencyMs: latencyMs,
-        error: errorMessage,
-        requestId: requestID,
-        queue: queue,
-        omniFocus: TimeoutProcessSnapshot(
-            process: "OmniFocus",
-            pid: omniPID,
-            rssKB: omniPID.flatMap(readRSSKilobytes(pid:))
-        ),
-        focusrelay: TimeoutProcessSnapshot(
-            process: "focusrelay",
-            pid: benchmarkPID,
-            rssKB: readRSSKilobytes(pid: benchmarkPID)
-        ),
-        bridgeHealth: bridgeHealth
-    )
-}
-
-private func extractRequestID(from message: String) -> String? {
-    let pattern = #"requestId=([A-F0-9-]+)"#
-    guard let regex = try? NSRegularExpression(pattern: pattern) else {
-        return nil
-    }
-    let range = NSRange(message.startIndex..<message.endIndex, in: message)
-    guard let match = regex.firstMatch(in: message, range: range),
-          let matchRange = Range(match.range(at: 1), in: message) else {
-        return nil
-    }
-    return String(message[matchRange])
-}
-
-private func directoryEntryCount(_ url: URL) -> Int {
-    guard let contents = try? FileManager.default.contentsOfDirectory(atPath: url.path) else {
-        return 0
-    }
-    return contents.count
-}
-
-private func directoryEntrySamples(_ url: URL, limit: Int = 5) -> [String] {
-    guard let contents = try? FileManager.default.contentsOfDirectory(atPath: url.path) else {
-        return []
-    }
-    return Array(contents.sorted().prefix(limit))
-}
-
-private func defaultIPCBaseURL() -> URL {
-    let home = FileManager.default.homeDirectoryForCurrentUser
-    let container = home
-        .appendingPathComponent("Library", isDirectory: true)
-        .appendingPathComponent("Containers", isDirectory: true)
-        .appendingPathComponent("com.omnigroup.OmniFocus4", isDirectory: true)
-        .appendingPathComponent("Data", isDirectory: true)
-        .appendingPathComponent("Documents", isDirectory: true)
-        .appendingPathComponent("FocusRelayIPC", isDirectory: true)
-
-    if FileManager.default.fileExists(atPath: container.deletingLastPathComponent().path) {
-        return container
-    }
-
-    return home
-        .appendingPathComponent("Library", isDirectory: true)
-        .appendingPathComponent("Caches", isDirectory: true)
-        .appendingPathComponent("focusrelay", isDirectory: true)
-}
-
-private func writeSummary(
-    to url: URL,
-    startedAt: Date,
-    endedAt: Date,
-    memoryURL: URL,
-    durationHours: Double,
-    warmupCalls: Int,
-    intervalMS: Int,
-    cooldownMS: Int,
-    memoryIntervalSeconds: Int,
-    timeoutDiagnosticsURL: URL,
-    scenarios: [BenchmarkScenario],
-    statsByTransport: [Transport: StatsAccumulator],
-    statsByScenarioTransport: [String: [Transport: StatsAccumulator]]
-) async throws {
-    let memorySummary = loadMemorySummary(from: memoryURL)
-    let timeoutDiagnosticCount = countLines(in: timeoutDiagnosticsURL)
-    var lines: [String] = []
-    lines.append("# get_project_counts Benchmark Summary")
-    lines.append("")
-    lines.append("- Started: \(iso8601(startedAt))")
-    lines.append("- Ended: \(iso8601(endedAt))")
-    lines.append(String(format: "- Configured duration (hours): %.2f", durationHours))
-    lines.append("- Warmup calls: \(warmupCalls)")
-    lines.append("- Interval (ms): \(intervalMS)")
-    lines.append("- Cooldown after failure (ms): \(cooldownMS)")
-    lines.append("- Memory sampling interval (seconds): \(memoryIntervalSeconds)")
-    lines.append("- Scenarios: \(scenarios.map(\.name).joined(separator: ", "))")
-    lines.append("")
-    lines.append("## Overall Transport Stats")
-    lines.append("")
-    for transport in Transport.allCases {
-        let stats = statsByTransport[transport] ?? StatsAccumulator()
-        let totalCalls = stats.successCount + stats.errorCount
-        let timeoutRate = percentage(part: stats.timeoutCount, total: totalCalls)
-        let errorRate = percentage(part: stats.errorCount, total: totalCalls)
-        lines.append("### \(transport.rawValue)")
-        lines.append("- Total calls: \(totalCalls)")
-        lines.append("- Success calls: \(stats.successCount)")
-        lines.append("- Error calls: \(stats.errorCount)")
-        lines.append("- Error rate: \(formatPercentage(errorRate))")
-        lines.append("- Timeout calls: \(stats.timeoutCount)")
-        lines.append("- Timeout rate: \(formatPercentage(timeoutRate))")
-        lines.append("- p50 latency (ms): \(formatDouble(percentile(stats.latencies, p: 0.50)))")
-        lines.append("- p95 latency (ms): \(formatDouble(percentile(stats.latencies, p: 0.95)))")
-        lines.append("- p99 latency (ms): \(formatDouble(percentile(stats.latencies, p: 0.99)))")
-        lines.append("")
-    }
-
-    lines.append("## Scenario Stats")
-    lines.append("")
-    for scenario in scenarios {
-        lines.append("### \(scenario.name)")
-        let scoped = statsByScenarioTransport[scenario.name] ?? [:]
-        for transport in Transport.allCases {
-            let stats = scoped[transport] ?? StatsAccumulator()
-            let totalCalls = stats.successCount + stats.errorCount
-            let timeoutRate = percentage(part: stats.timeoutCount, total: totalCalls)
-            let errorRate = percentage(part: stats.errorCount, total: totalCalls)
-            lines.append("- \(transport.rawValue): total=\(totalCalls), success=\(stats.successCount), errors=\(stats.errorCount), error_rate=\(formatPercentage(errorRate)), timeouts=\(stats.timeoutCount), timeout_rate=\(formatPercentage(timeoutRate)), p95_ms=\(formatDouble(percentile(stats.latencies, p: 0.95)))")
-        }
-        lines.append("")
-    }
-
-    lines.append("## Memory Notes")
-    lines.append("")
-    lines.append("- `memory.csv` contains RSS samples for `focusrelay` and `OmniFocus`.")
-    lines.append("- Memory growth slope is estimated in KB/min from sampled RSS values.")
-    lines.append("- `timeout-diagnostics.jsonl` contains timeout queue/process snapshots for this benchmark.")
-    lines.append("")
-    lines.append("### Memory Growth")
-    for process in ["focusrelay", "OmniFocus"] {
-        if let summary = memorySummary[process] {
-            lines.append("- \(process): samples=\(summary.samples), start_kb=\(summary.startKB), end_kb=\(summary.endKB), delta_kb=\(summary.endKB - summary.startKB), slope_kb_per_min=\(formatDouble(summary.slopeKBPerMinute))")
-        } else {
-            lines.append("- \(process): no samples")
-        }
-    }
-    lines.append("")
-    lines.append("## Timeout Diagnostics")
-    lines.append("")
-    lines.append("- Diagnostic entries: \(timeoutDiagnosticCount)")
-
-    try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
-}
-
-private func countLines(in url: URL) -> Int {
-    guard let content = try? String(contentsOf: url, encoding: .utf8) else {
-        return 0
-    }
-    return content.split(separator: "\n", omittingEmptySubsequences: true).count
-}
-
-private func percentile(_ values: [Double], p: Double) -> Double {
-    guard !values.isEmpty else { return .nan }
-    let sorted = values.sorted()
-    let index = Int(Double(sorted.count - 1) * p)
-    return sorted[max(0, min(index, sorted.count - 1))]
-}
-
-private func formatDouble(_ value: Double) -> String {
-    guard value.isFinite else { return "n/a" }
-    return String(format: "%.2f", value)
-}
-
-private func formatPercentage(_ value: Double) -> String {
-    guard value.isFinite else { return "n/a" }
-    return String(format: "%.2f%%", value)
-}
-
-private struct MemorySample {
-    let timestamp: Date
-    let process: String
-    let rssKB: Double
-}
-
-private struct MemoryProcessSummary {
-    let samples: Int
-    let startKB: Int
-    let endKB: Int
-    let slopeKBPerMinute: Double
-}
-
-private func loadMemorySummary(from url: URL) -> [String: MemoryProcessSummary] {
-    guard let content = try? String(contentsOf: url, encoding: .utf8) else {
-        return [:]
-    }
-
-    let parser = ISO8601DateFormatter()
-    parser.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-
-    var byProcess: [String: [MemorySample]] = [:]
-    let lines = content.split(separator: "\n")
-    for (index, line) in lines.enumerated() {
-        if index == 0 { continue } // header
-        let columns = line.split(separator: ",", omittingEmptySubsequences: false)
-        if columns.count < 4 { continue }
-        let timestampRaw = String(columns[0])
-        let process = String(columns[1])
-        let rssRaw = String(columns[3])
-        guard let timestamp = parser.date(from: timestampRaw),
-              let rss = Double(rssRaw) else {
-            continue
-        }
-        let sample = MemorySample(timestamp: timestamp, process: process, rssKB: rss)
-        byProcess[process, default: []].append(sample)
-    }
-
-    var summary: [String: MemoryProcessSummary] = [:]
-    for (process, samples) in byProcess {
-        let sorted = samples.sorted { $0.timestamp < $1.timestamp }
-        guard let first = sorted.first, let last = sorted.last else { continue }
-        let slope = linearSlopeKBPerMinute(samples: sorted)
-        summary[process] = MemoryProcessSummary(
-            samples: sorted.count,
-            startKB: Int(first.rssKB.rounded()),
-            endKB: Int(last.rssKB.rounded()),
-            slopeKBPerMinute: slope
-        )
-    }
-    return summary
-}
-
-private func linearSlopeKBPerMinute(samples: [MemorySample]) -> Double {
-    guard samples.count > 1, let first = samples.first else { return .nan }
-
-    var sumX = 0.0
-    var sumY = 0.0
-    var sumXX = 0.0
-    var sumXY = 0.0
-    let n = Double(samples.count)
-
-    for sample in samples {
-        let x = sample.timestamp.timeIntervalSince(first.timestamp) / 60.0
-        let y = sample.rssKB
-        sumX += x
-        sumY += y
-        sumXX += x * x
-        sumXY += x * y
-    }
-
-    let denominator = (n * sumXX) - (sumX * sumX)
-    if abs(denominator) < 1e-9 { return .nan }
-    return ((n * sumXY) - (sumX * sumY)) / denominator
-}
-
-private func percentage(part: Int, total: Int) -> Double {
-    guard total > 0 else { return .nan }
-    return (Double(part) / Double(total)) * 100.0
-}
-
-private func iso8601Now() -> String {
-    iso8601(Date())
-}
-
-private func iso8601(_ date: Date) -> String {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-    return formatter.string(from: date)
 }
 #endif

--- a/Sources/FocusRelayCLI/BenchmarkSupport.swift
+++ b/Sources/FocusRelayCLI/BenchmarkSupport.swift
@@ -1,0 +1,651 @@
+#if DEBUG
+import ArgumentParser
+import Foundation
+import OmniFocusAutomation
+
+let benchmarkTransport = "plugin"
+
+struct BenchmarkStats {
+    var success: Int = 0
+    var errors: Int = 0
+    var timeouts: Int = 0
+    var latencies: [Double] = []
+
+    mutating func ingest(ok: Bool, timeout: Bool, latencyMs: Double) {
+        if ok {
+            success += 1
+            latencies.append(latencyMs)
+        } else {
+            errors += 1
+            if timeout {
+                timeouts += 1
+            }
+        }
+    }
+}
+
+struct CountBenchmarkEvent<Counts: Codable>: Codable {
+    let timestamp: String
+    let phase: String
+    let callIndex: Int
+    let transport: String
+    let scenario: String
+    let latencyMs: Double
+    let ok: Bool
+    let timeout: Bool
+    let error: String?
+    let counts: Counts?
+}
+
+struct BenchmarkTimeoutQueueSnapshot: Codable {
+    let basePath: String
+    let requestsCount: Int
+    let locksCount: Int
+    let responsesCount: Int
+    let requestExists: Bool?
+    let lockExists: Bool?
+    let responseExists: Bool?
+    let sampleRequests: [String]
+    let sampleLocks: [String]
+    let sampleResponses: [String]
+}
+
+struct BenchmarkTimeoutProcessSnapshot: Codable {
+    let process: String
+    let pid: Int32?
+    let rssKB: Int?
+}
+
+struct BenchmarkTimeoutBridgeHealthSnapshot: Codable {
+    let ok: Bool
+    let detail: String
+}
+
+struct BenchmarkTimeoutDiagnostic: Codable {
+    let timestamp: String
+    let transport: String
+    let scenario: String
+    let phase: String
+    let callIndex: Int
+    let latencyMs: Double
+    let error: String
+    let requestId: String?
+    let queue: BenchmarkTimeoutQueueSnapshot
+    let omniFocus: BenchmarkTimeoutProcessSnapshot
+    let focusrelay: BenchmarkTimeoutProcessSnapshot
+    let bridgeHealth: BenchmarkTimeoutBridgeHealthSnapshot?
+}
+
+func validateBenchmarkArguments(
+    durationHours: Double,
+    warmupCalls: Int,
+    intervalMS: Int,
+    cooldownMS: Int,
+    memoryIntervalSeconds: Int? = nil
+) throws {
+    guard durationHours > 0 else {
+        throw ValidationError("--duration-hours must be > 0.")
+    }
+    guard warmupCalls >= 0 else {
+        throw ValidationError("--warmup-calls must be >= 0.")
+    }
+    guard intervalMS >= 0 else {
+        throw ValidationError("--interval-ms must be >= 0.")
+    }
+    guard cooldownMS >= 0 else {
+        throw ValidationError("--cooldown-ms must be >= 0.")
+    }
+    if let memoryIntervalSeconds, memoryIntervalSeconds <= 0 {
+        throw ValidationError("--memory-interval-seconds must be > 0.")
+    }
+}
+
+func runCountBenchmarkCall<Counts: Codable>(
+    scenario: String,
+    phase: String,
+    timeoutDiagnosticsURL: URL,
+    intervalMS: Int,
+    cooldownMS: Int,
+    callIndex: inout Int,
+    operation: () async throws -> Counts
+) async throws -> CountBenchmarkEvent<Counts> {
+    callIndex += 1
+    let started = Date()
+    do {
+        let counts = try await operation()
+        let latencyMs = Date().timeIntervalSince(started) * 1000
+        try await enforceBenchmarkInterval(started: started, intervalMS: intervalMS)
+        return CountBenchmarkEvent(
+            timestamp: benchmarkISO8601Now(),
+            phase: phase,
+            callIndex: callIndex,
+            transport: benchmarkTransport,
+            scenario: scenario,
+            latencyMs: latencyMs,
+            ok: true,
+            timeout: false,
+            error: nil,
+            counts: counts
+        )
+    } catch {
+        let latencyMs = Date().timeIntervalSince(started) * 1000
+        let timeout = isBenchmarkTimeout(error)
+        try await enforceBenchmarkInterval(started: started, intervalMS: intervalMS)
+        if cooldownMS > 0 {
+            try? await Task.sleep(nanoseconds: UInt64(cooldownMS) * 1_000_000)
+        }
+        if timeout {
+            let diagnostic = captureBenchmarkTimeoutDiagnostic(
+                scenario: scenario,
+                phase: phase,
+                callIndex: callIndex,
+                latencyMs: latencyMs,
+                errorMessage: error.localizedDescription
+            )
+            try? appendBenchmarkJSONLine(diagnostic, to: timeoutDiagnosticsURL)
+        }
+        return CountBenchmarkEvent(
+            timestamp: benchmarkISO8601Now(),
+            phase: phase,
+            callIndex: callIndex,
+            transport: benchmarkTransport,
+            scenario: scenario,
+            latencyMs: latencyMs,
+            ok: false,
+            timeout: timeout,
+            error: error.localizedDescription,
+            counts: nil
+        )
+    }
+}
+
+func ingestBenchmarkEvent(
+    scenario: String,
+    ok: Bool,
+    timeout: Bool,
+    latencyMs: Double,
+    overall: inout BenchmarkStats,
+    scenarios: inout [String: BenchmarkStats]
+) {
+    overall.ingest(ok: ok, timeout: timeout, latencyMs: latencyMs)
+    var scoped = scenarios[scenario] ?? BenchmarkStats()
+    scoped.ingest(ok: ok, timeout: timeout, latencyMs: latencyMs)
+    scenarios[scenario] = scoped
+}
+
+func benchmarkOutputDirectory(customPath: String?, defaultPrefix: String? = nil) throws -> URL {
+    if let customPath, !customPath.isEmpty {
+        let url = URL(
+            fileURLWithPath: customPath,
+            relativeTo: URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        ).standardizedFileURL
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.dateFormat = "yyyyMMdd-HHmmss"
+    let timestamp = formatter.string(from: Date())
+    let directoryName = defaultPrefix.map { "\($0)-\(timestamp)" } ?? timestamp
+    let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        .appendingPathComponent(".build", isDirectory: true)
+        .appendingPathComponent("benchmarks", isDirectory: true)
+        .appendingPathComponent(directoryName, isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+}
+
+func initializeBenchmarkArtifacts(rawURL: URL, memoryURL: URL?, timeoutDiagnosticsURL: URL) throws {
+    FileManager.default.createFile(atPath: rawURL.path, contents: nil)
+    FileManager.default.createFile(atPath: timeoutDiagnosticsURL.path, contents: nil)
+    if let memoryURL {
+        FileManager.default.createFile(atPath: memoryURL.path, contents: nil)
+        try appendBenchmarkLine("timestamp,process,pid,rss_kb\n", to: memoryURL)
+    }
+}
+
+func appendBenchmarkJSONLine<T: Encodable>(_ value: T, to url: URL) throws {
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    let data = try encoder.encode(value)
+    guard var line = String(data: data, encoding: .utf8) else {
+        throw ValidationError("Failed to encode benchmark event as UTF-8.")
+    }
+    line.append("\n")
+    try appendBenchmarkLine(line, to: url)
+}
+
+func appendBenchmarkLine(_ line: String, to url: URL) throws {
+    guard let data = line.data(using: .utf8) else { return }
+    let handle = try FileHandle(forWritingTo: url)
+    defer { try? handle.close() }
+    try handle.seekToEnd()
+    try handle.write(contentsOf: data)
+}
+
+func startBenchmarkMemorySampling(memoryURL: URL, intervalSeconds: Int) -> Task<Void, Never> {
+    let benchmarkPID = ProcessInfo.processInfo.processIdentifier
+    return Task.detached(priority: .utility) {
+        while !Task.isCancelled {
+            let timestamp = benchmarkISO8601Now()
+            if let rss = benchmarkRSSKilobytes(pid: benchmarkPID) {
+                try? appendBenchmarkLine("\(timestamp),focusrelay,\(benchmarkPID),\(rss)\n", to: memoryURL)
+            }
+            if let omniPID = currentOmniFocusPID(), let rss = benchmarkRSSKilobytes(pid: omniPID) {
+                try? appendBenchmarkLine("\(timestamp),OmniFocus,\(omniPID),\(rss)\n", to: memoryURL)
+            }
+            try? await Task.sleep(nanoseconds: UInt64(intervalSeconds) * 1_000_000_000)
+        }
+    }
+}
+
+func runBenchmarkTimeoutRecoveryGate() async {
+    let environment = ProcessInfo.processInfo.environment
+    let recoveryMS = max(0, environment["FOCUS_RELAY_TIMEOUT_RECOVERY_MS"].flatMap(Int.init) ?? 10_000)
+    if recoveryMS > 0 {
+        try? await Task.sleep(nanoseconds: UInt64(recoveryMS) * 1_000_000)
+    }
+    _ = try? OmniFocusBridgeService().healthCheck()
+}
+
+func enforceBenchmarkInterval(started: Date, intervalMS: Int) async throws {
+    guard intervalMS > 0 else { return }
+    let elapsed = Date().timeIntervalSince(started)
+    let target = Double(intervalMS) / 1000.0
+    if elapsed < target {
+        try await Task.sleep(nanoseconds: UInt64((target - elapsed) * 1_000_000_000))
+    }
+}
+
+func isBenchmarkTimeout(_ error: Error) -> Bool {
+    let message = error.localizedDescription.lowercased()
+    return message.contains("timed out") || message.contains("timeout")
+}
+
+func runBenchmarkPreflight() {
+    do {
+        try stopExtraServeProcesses()
+    } catch {
+        print("Preflight warning: failed to inspect/terminate extra servers (\(error.localizedDescription)).")
+    }
+    do {
+        try restartOmniFocus()
+    } catch {
+        print("Preflight warning: failed to restart OmniFocus (\(error.localizedDescription)).")
+    }
+}
+
+private func stopExtraServeProcesses() throws {
+    let currentPID = ProcessInfo.processInfo.processIdentifier
+    guard let output = try? runBenchmarkProcess(
+        executable: "/usr/bin/pgrep",
+        arguments: ["-f", "focusrelay"],
+        timeout: 3
+    ) else {
+        print("Preflight: no extra focusrelay server processes detected.")
+        return
+    }
+
+    let candidatePIDs = output.split(separator: "\n").compactMap { Int32($0) }
+    var terminated: [Int32] = []
+    for pid in candidatePIDs where pid != currentPID {
+        guard let command = try? runBenchmarkProcess(
+            executable: "/bin/ps",
+            arguments: ["-o", "command=", "-p", String(pid)],
+            timeout: 3
+        ) else {
+            continue
+        }
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.contains("focusrelay serve") || trimmed.contains("focusrelay mcp") || trimmed.contains("focusrelay server") {
+            _ = try? runBenchmarkProcess(executable: "/bin/kill", arguments: ["-TERM", String(pid)], timeout: 2)
+            terminated.append(pid)
+        }
+    }
+
+    if terminated.isEmpty {
+        print("Preflight: no extra focusrelay server processes detected.")
+    } else {
+        print("Preflight: terminated focusrelay server processes: \(terminated.map(String.init).joined(separator: ", "))")
+        Thread.sleep(forTimeInterval: 1.0)
+    }
+}
+
+private func restartOmniFocus() throws {
+    print("Preflight: restarting OmniFocus...")
+    _ = try? runBenchmarkProcess(
+        executable: "/usr/bin/osascript",
+        arguments: ["-e", "tell application \"OmniFocus\" to quit"],
+        timeout: 8
+    )
+    Thread.sleep(forTimeInterval: 2.0)
+    _ = try runBenchmarkProcess(executable: "/usr/bin/open", arguments: ["-a", "OmniFocus"], timeout: 8)
+    Thread.sleep(forTimeInterval: 3.0)
+}
+
+func currentOmniFocusPID() -> Int32? {
+    guard let output = try? runBenchmarkProcess(
+        executable: "/usr/bin/pgrep",
+        arguments: ["-x", "OmniFocus"],
+        timeout: 3
+    ) else {
+        return nil
+    }
+    return output.split(separator: "\n").first.flatMap { Int32($0) }
+}
+
+func benchmarkRSSKilobytes(pid: Int32) -> Int? {
+    guard let output = try? runBenchmarkProcess(
+        executable: "/bin/ps",
+        arguments: ["-o", "rss=", "-p", String(pid)],
+        timeout: 3
+    ) else {
+        return nil
+    }
+    return Int(output.trimmingCharacters(in: .whitespacesAndNewlines))
+}
+
+@discardableResult
+func runBenchmarkProcess(executable: String, arguments: [String], timeout: TimeInterval = 15) throws -> String {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: executable)
+    process.arguments = arguments
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = pipe
+    try process.run()
+
+    let deadline = Date().addingTimeInterval(timeout)
+    while process.isRunning && Date() < deadline {
+        Thread.sleep(forTimeInterval: 0.05)
+    }
+    if process.isRunning {
+        process.terminate()
+        throw AutomationError.executionFailed("Process \(executable) timed out after \(Int(timeout))s")
+    }
+
+    process.waitUntilExit()
+    let output = String(decoding: pipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    if process.terminationStatus != 0 {
+        throw AutomationError.executionFailed("Process \(executable) failed: \(output)")
+    }
+    return output
+}
+
+func captureBenchmarkTimeoutDiagnostic(
+    scenario: String,
+    phase: String,
+    callIndex: Int,
+    latencyMs: Double,
+    errorMessage: String
+) -> BenchmarkTimeoutDiagnostic {
+    let requestID = extractBenchmarkRequestID(from: errorMessage)
+    let baseURL = defaultBenchmarkIPCBaseURL()
+    let requestsURL = baseURL.appendingPathComponent("requests", isDirectory: true)
+    let locksURL = baseURL.appendingPathComponent("locks", isDirectory: true)
+    let responsesURL = baseURL.appendingPathComponent("responses", isDirectory: true)
+    let omniPID = currentOmniFocusPID()
+    let benchmarkPID = ProcessInfo.processInfo.processIdentifier
+    let bridgeHealth: BenchmarkTimeoutBridgeHealthSnapshot
+    if let result = try? OmniFocusBridgeService().healthCheck() {
+        bridgeHealth = BenchmarkTimeoutBridgeHealthSnapshot(
+            ok: result.ok,
+            detail: "plugin=\(result.plugin ?? "unknown") version=\(result.version ?? "unknown")"
+        )
+    } else {
+        bridgeHealth = BenchmarkTimeoutBridgeHealthSnapshot(
+            ok: false,
+            detail: "bridge-health-check failed after timeout"
+        )
+    }
+
+    return BenchmarkTimeoutDiagnostic(
+        timestamp: benchmarkISO8601Now(),
+        transport: benchmarkTransport,
+        scenario: scenario,
+        phase: phase,
+        callIndex: callIndex,
+        latencyMs: latencyMs,
+        error: errorMessage,
+        requestId: requestID,
+        queue: BenchmarkTimeoutQueueSnapshot(
+            basePath: baseURL.path,
+            requestsCount: benchmarkDirectoryEntryCount(requestsURL),
+            locksCount: benchmarkDirectoryEntryCount(locksURL),
+            responsesCount: benchmarkDirectoryEntryCount(responsesURL),
+            requestExists: requestID.map { FileManager.default.fileExists(atPath: requestsURL.appendingPathComponent("\($0).json").path) },
+            lockExists: requestID.map { FileManager.default.fileExists(atPath: locksURL.appendingPathComponent("\($0).lock").path) },
+            responseExists: requestID.map { FileManager.default.fileExists(atPath: responsesURL.appendingPathComponent("\($0).json").path) },
+            sampleRequests: benchmarkDirectoryEntrySamples(requestsURL),
+            sampleLocks: benchmarkDirectoryEntrySamples(locksURL),
+            sampleResponses: benchmarkDirectoryEntrySamples(responsesURL)
+        ),
+        omniFocus: BenchmarkTimeoutProcessSnapshot(
+            process: "OmniFocus",
+            pid: omniPID,
+            rssKB: omniPID.flatMap(benchmarkRSSKilobytes(pid:))
+        ),
+        focusrelay: BenchmarkTimeoutProcessSnapshot(
+            process: "focusrelay",
+            pid: benchmarkPID,
+            rssKB: benchmarkRSSKilobytes(pid: benchmarkPID)
+        ),
+        bridgeHealth: bridgeHealth
+    )
+}
+
+private func extractBenchmarkRequestID(from message: String) -> String? {
+    let pattern = #"requestId=([A-F0-9-]+)"#
+    guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+    let range = NSRange(message.startIndex..<message.endIndex, in: message)
+    guard let match = regex.firstMatch(in: message, range: range),
+          let matchRange = Range(match.range(at: 1), in: message) else {
+        return nil
+    }
+    return String(message[matchRange])
+}
+
+private func benchmarkDirectoryEntryCount(_ url: URL) -> Int {
+    (try? FileManager.default.contentsOfDirectory(atPath: url.path).count) ?? 0
+}
+
+private func benchmarkDirectoryEntrySamples(_ url: URL, limit: Int = 5) -> [String] {
+    guard let contents = try? FileManager.default.contentsOfDirectory(atPath: url.path) else { return [] }
+    return Array(contents.sorted().prefix(limit))
+}
+
+private func defaultBenchmarkIPCBaseURL() -> URL {
+    let home = FileManager.default.homeDirectoryForCurrentUser
+    let container = home
+        .appendingPathComponent("Library", isDirectory: true)
+        .appendingPathComponent("Containers", isDirectory: true)
+        .appendingPathComponent("com.omnigroup.OmniFocus4", isDirectory: true)
+        .appendingPathComponent("Data", isDirectory: true)
+        .appendingPathComponent("Documents", isDirectory: true)
+        .appendingPathComponent("FocusRelayIPC", isDirectory: true)
+    if FileManager.default.fileExists(atPath: container.deletingLastPathComponent().path) {
+        return container
+    }
+    return home
+        .appendingPathComponent("Library", isDirectory: true)
+        .appendingPathComponent("Caches", isDirectory: true)
+        .appendingPathComponent("focusrelay", isDirectory: true)
+}
+
+func renderCountBenchmarkSummary(
+    title: String,
+    startedAt: Date,
+    endedAt: Date,
+    durationHours: Double,
+    warmupCalls: Int,
+    intervalMS: Int,
+    cooldownMS: Int,
+    memoryIntervalSeconds: Int,
+    scenarioNames: [String],
+    overall: BenchmarkStats,
+    scenarios: [String: BenchmarkStats],
+    memoryURL: URL,
+    timeoutDiagnosticsURL: URL
+) -> String {
+    let memorySummary = loadBenchmarkMemorySummary(from: memoryURL)
+    var lines = [
+        "# \(title) Benchmark Summary",
+        "",
+        "- Started: \(benchmarkISO8601(startedAt))",
+        "- Ended: \(benchmarkISO8601(endedAt))",
+        String(format: "- Configured duration (hours): %.2f", durationHours),
+        "- Warmup calls: \(warmupCalls)",
+        "- Interval (ms): \(intervalMS)",
+        "- Cooldown after failure (ms): \(cooldownMS)",
+        "- Memory sampling interval (seconds): \(memoryIntervalSeconds)",
+        "- Scenarios: \(scenarioNames.joined(separator: ", "))",
+        "",
+        "## Overall Transport Stats",
+        "",
+        "### \(benchmarkTransport)"
+    ]
+    appendBenchmarkStats(overall, to: &lines, prefix: "")
+    lines.append("")
+    lines.append("## Scenario Stats")
+    lines.append("")
+    for scenario in scenarioNames {
+        lines.append("### \(scenario)")
+        let stats = scenarios[scenario] ?? BenchmarkStats()
+        let total = stats.success + stats.errors
+        lines.append(
+            "- \(benchmarkTransport): total=\(total), success=\(stats.success), errors=\(stats.errors), error_rate=\(benchmarkFormatPercentage(benchmarkPercentage(part: stats.errors, total: total))), timeouts=\(stats.timeouts), timeout_rate=\(benchmarkFormatPercentage(benchmarkPercentage(part: stats.timeouts, total: total))), p95_ms=\(benchmarkFormatDouble(benchmarkPercentile(stats.latencies, p: 0.95)))"
+        )
+        lines.append("")
+    }
+    lines.append("## Memory Notes")
+    lines.append("")
+    lines.append("- `memory.csv` contains RSS samples for `focusrelay` and `OmniFocus`.")
+    lines.append("- Memory growth slope is estimated in KB/min from sampled RSS values.")
+    lines.append("- `timeout-diagnostics.jsonl` contains timeout queue/process snapshots for this benchmark.")
+    lines.append("")
+    lines.append("### Memory Growth")
+    for process in ["focusrelay", "OmniFocus"] {
+        if let summary = memorySummary[process] {
+            lines.append("- \(process): samples=\(summary.samples), start_kb=\(summary.startKB), end_kb=\(summary.endKB), delta_kb=\(summary.endKB - summary.startKB), slope_kb_per_min=\(benchmarkFormatDouble(summary.slopeKBPerMinute))")
+        } else {
+            lines.append("- \(process): no samples")
+        }
+    }
+    lines.append("")
+    lines.append("## Timeout Diagnostics")
+    lines.append("")
+    lines.append("- Diagnostic entries: \(benchmarkCountLines(in: timeoutDiagnosticsURL))")
+    return lines.joined(separator: "\n")
+}
+
+private func appendBenchmarkStats(_ stats: BenchmarkStats, to lines: inout [String], prefix: String) {
+    let total = stats.success + stats.errors
+    lines.append("\(prefix)- Total calls: \(total)")
+    lines.append("\(prefix)- Success calls: \(stats.success)")
+    lines.append("\(prefix)- Error calls: \(stats.errors)")
+    lines.append("\(prefix)- Error rate: \(benchmarkFormatPercentage(benchmarkPercentage(part: stats.errors, total: total)))")
+    lines.append("\(prefix)- Timeout calls: \(stats.timeouts)")
+    lines.append("\(prefix)- Timeout rate: \(benchmarkFormatPercentage(benchmarkPercentage(part: stats.timeouts, total: total)))")
+    lines.append("\(prefix)- p50 latency (ms): \(benchmarkFormatDouble(benchmarkPercentile(stats.latencies, p: 0.50)))")
+    lines.append("\(prefix)- p95 latency (ms): \(benchmarkFormatDouble(benchmarkPercentile(stats.latencies, p: 0.95)))")
+    lines.append("\(prefix)- p99 latency (ms): \(benchmarkFormatDouble(benchmarkPercentile(stats.latencies, p: 0.99)))")
+}
+
+func benchmarkCountLines(in url: URL) -> Int {
+    guard let content = try? String(contentsOf: url, encoding: .utf8), !content.isEmpty else { return 0 }
+    return content.split(separator: "\n", omittingEmptySubsequences: true).count
+}
+
+func benchmarkPercentile(_ values: [Double], p: Double) -> Double {
+    guard !values.isEmpty else { return .nan }
+    let sorted = values.sorted()
+    let index = Int(Double(sorted.count - 1) * p)
+    return sorted[max(0, min(index, sorted.count - 1))]
+}
+
+func benchmarkFormatDouble(_ value: Double) -> String {
+    guard value.isFinite else { return "n/a" }
+    return String(format: "%.2f", value)
+}
+
+func benchmarkFormatPercentage(_ value: Double) -> String {
+    guard value.isFinite else { return "n/a" }
+    return String(format: "%.2f%%", value)
+}
+
+func benchmarkPercentage(part: Int, total: Int) -> Double {
+    guard total > 0 else { return .nan }
+    return (Double(part) / Double(total)) * 100.0
+}
+
+private struct BenchmarkMemorySample {
+    let timestamp: Date
+    let rssKB: Double
+}
+
+private struct BenchmarkMemoryProcessSummary {
+    let samples: Int
+    let startKB: Int
+    let endKB: Int
+    let slopeKBPerMinute: Double
+}
+
+private func loadBenchmarkMemorySummary(from url: URL) -> [String: BenchmarkMemoryProcessSummary] {
+    guard let content = try? String(contentsOf: url, encoding: .utf8) else { return [:] }
+    var grouped: [String: [BenchmarkMemorySample]] = [:]
+    for line in content.split(separator: "\n").dropFirst() {
+        let parts = line.split(separator: ",", omittingEmptySubsequences: false)
+        guard parts.count == 4,
+              let timestamp = benchmarkParseISO8601(String(parts[0])),
+              let rss = Double(parts[3]) else {
+            continue
+        }
+        grouped[String(parts[1]), default: []].append(BenchmarkMemorySample(timestamp: timestamp, rssKB: rss))
+    }
+
+    var summaries: [String: BenchmarkMemoryProcessSummary] = [:]
+    for (process, samples) in grouped {
+        let sorted = samples.sorted { $0.timestamp < $1.timestamp }
+        guard let first = sorted.first, let last = sorted.last else { continue }
+        summaries[process] = BenchmarkMemoryProcessSummary(
+            samples: sorted.count,
+            startKB: Int(first.rssKB),
+            endKB: Int(last.rssKB),
+            slopeKBPerMinute: benchmarkLinearSlope(samples: sorted)
+        )
+    }
+    return summaries
+}
+
+private func benchmarkLinearSlope(samples: [BenchmarkMemorySample]) -> Double {
+    guard samples.count > 1, let first = samples.first else { return .nan }
+    let points = samples.map {
+        (x: $0.timestamp.timeIntervalSince(first.timestamp) / 60.0, y: $0.rssKB)
+    }
+    let meanX = points.map(\.x).reduce(0, +) / Double(points.count)
+    let meanY = points.map(\.y).reduce(0, +) / Double(points.count)
+    let numerator = points.reduce(0.0) { $0 + (($1.x - meanX) * ($1.y - meanY)) }
+    let denominator = points.reduce(0.0) { $0 + (($1.x - meanX) * ($1.x - meanX)) }
+    return denominator == 0 ? .nan : numerator / denominator
+}
+
+func benchmarkISO8601Now() -> String {
+    benchmarkISO8601(Date())
+}
+
+func benchmarkISO8601(_ date: Date) -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter.string(from: date)
+}
+
+private func benchmarkParseISO8601(_ value: String) -> Date? {
+    let fractional = ISO8601DateFormatter()
+    fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    if let date = fractional.date(from: value) { return date }
+    let standard = ISO8601DateFormatter()
+    standard.formatOptions = [.withInternetDateTime]
+    return standard.date(from: value)
+}
+#endif

--- a/Sources/FocusRelayCLI/BenchmarkTaskCountsCommand.swift
+++ b/Sources/FocusRelayCLI/BenchmarkTaskCountsCommand.swift
@@ -4,8 +4,6 @@ import Foundation
 import OmniFocusAutomation
 import OmniFocusCore
 
-private typealias TaskCountsModel = OmniFocusCore.TaskCounts
-
 struct BenchmarkTaskCounts: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "benchmark-task-counts",
@@ -38,25 +36,15 @@ struct BenchmarkTaskCounts: AsyncParsableCommand {
     var performPreflight: Bool = false
 
     func run() async throws {
-        guard durationHours > 0 else {
-            throw ValidationError("--duration-hours must be > 0.")
-        }
-        guard warmupCalls >= 0 else {
-            throw ValidationError("--warmup-calls must be >= 0.")
-        }
-        guard intervalMS >= 0 else {
-            throw ValidationError("--interval-ms must be >= 0.")
-        }
-        guard cooldownMS >= 0 else {
-            throw ValidationError("--cooldown-ms must be >= 0.")
-        }
-        guard memoryIntervalSeconds > 0 else {
-            throw ValidationError("--memory-interval-seconds must be > 0.")
-        }
-
+        try validateBenchmarkArguments(
+            durationHours: durationHours,
+            warmupCalls: warmupCalls,
+            intervalMS: intervalMS,
+            cooldownMS: cooldownMS,
+            memoryIntervalSeconds: memoryIntervalSeconds
+        )
         let completedAfterDate = try ISO8601DateParser.parse(completedAfter, argumentName: "--completed-after")
-        let scenarios = benchmarkScenarios(completedAfter: completedAfterDate)
-
+        let scenarios = taskCountBenchmarkScenarios(completedAfter: completedAfterDate)
         let directoryURL = try benchmarkOutputDirectory(customPath: outputDir)
         let rawURL = directoryURL.appendingPathComponent("raw.jsonl")
         let memoryURL = directoryURL.appendingPathComponent("memory.csv")
@@ -66,94 +54,85 @@ struct BenchmarkTaskCounts: AsyncParsableCommand {
 
         print("Benchmark output directory: \(directoryURL.path)")
         print("Scenarios: \(scenarios.map(\.name).joined(separator: ", "))")
-
         if performPreflight {
-            runPreflight()
+            runBenchmarkPreflight()
         }
 
-        let benchmarkPID = ProcessInfo.processInfo.processIdentifier
-        let memoryTask = Task.detached(priority: .utility) {
-            while !Task.isCancelled {
-                let timestamp = iso8601Now()
-                if let rss = readRSSKilobytes(pid: benchmarkPID) {
-                    let line = "\(timestamp),focusrelay,\(benchmarkPID),\(rss)\n"
-                    try? appendLine(line, to: memoryURL)
-                }
-
-                if let omniPID = currentOmniFocusPID(), let rss = readRSSKilobytes(pid: omniPID) {
-                    let line = "\(timestamp),OmniFocus,\(omniPID),\(rss)\n"
-                    try? appendLine(line, to: memoryURL)
-                }
-
-                let nanos = UInt64(memoryIntervalSeconds) * 1_000_000_000
-                try? await Task.sleep(nanoseconds: nanos)
-            }
-        }
+        let memoryTask = startBenchmarkMemorySampling(memoryURL: memoryURL, intervalSeconds: memoryIntervalSeconds)
         defer { memoryTask.cancel() }
 
-        let pluginService = OmniFocusBridgeService()
-
-        var statsByTransport: [Transport: StatsAccumulator] = [:]
-        var statsByScenarioTransport: [String: [Transport: StatsAccumulator]] = [:]
+        let service = OmniFocusBridgeService()
         var callIndex = 0
-
         if warmupCalls > 0 {
             print("Warmup phase: \(warmupCalls) calls")
-            try await runWarmup(
-                warmupCalls: warmupCalls,
-                scenarios: scenarios,
-                pluginService: pluginService,
-                rawURL: rawURL,
-                timeoutDiagnosticsURL: timeoutDiagnosticsURL,
-                intervalMS: intervalMS,
-                cooldownMS: cooldownMS,
-                callIndex: &callIndex
-            )
+            for index in 0..<warmupCalls {
+                let scenario = scenarios[index % scenarios.count]
+                let event: CountBenchmarkEvent<OmniFocusCore.TaskCounts> = try await runCountBenchmarkCall(
+                    scenario: scenario.name,
+                    phase: "warmup",
+                    timeoutDiagnosticsURL: timeoutDiagnosticsURL,
+                    intervalMS: intervalMS,
+                    cooldownMS: cooldownMS,
+                    callIndex: &callIndex
+                ) {
+                    try await service.getTaskCounts(filter: scenario.filter)
+                }
+                try appendBenchmarkJSONLine(event, to: rawURL)
+                if event.timeout {
+                    await runBenchmarkTimeoutRecoveryGate()
+                }
+            }
         }
 
-        let durationSeconds = durationHours * 3600
         let measuredStart = Date()
-        let measuredEnd = measuredStart.addingTimeInterval(durationSeconds)
-        print("Measured phase started at \(iso8601(measuredStart)); ending at \(iso8601(measuredEnd))")
-
+        let measuredEnd = measuredStart.addingTimeInterval(durationHours * 3600)
+        print("Measured phase started at \(benchmarkISO8601(measuredStart)); ending at \(benchmarkISO8601(measuredEnd))")
+        var overallStats = BenchmarkStats()
+        var scenarioStats: [String: BenchmarkStats] = [:]
         var scenarioIndex = 0
         while Date() < measuredEnd {
             let scenario = scenarios[scenarioIndex % scenarios.count]
             scenarioIndex += 1
-
-            let pluginEvent = try await runBenchCall(
-                transport: .plugin,
-                scenario: scenario,
+            let event: CountBenchmarkEvent<OmniFocusCore.TaskCounts> = try await runCountBenchmarkCall(
+                scenario: scenario.name,
                 phase: "measured",
-                service: pluginService,
                 timeoutDiagnosticsURL: timeoutDiagnosticsURL,
                 intervalMS: intervalMS,
                 cooldownMS: cooldownMS,
                 callIndex: &callIndex
-            )
-            try appendJSONLine(pluginEvent, to: rawURL)
-            accumulate(pluginEvent, byTransport: &statsByTransport, byScenarioTransport: &statsByScenarioTransport)
-            if pluginEvent.timeout {
-                await runTimeoutRecoveryGate()
+            ) {
+                try await service.getTaskCounts(filter: scenario.filter)
             }
-
+            try appendBenchmarkJSONLine(event, to: rawURL)
+            ingestBenchmarkEvent(
+                scenario: event.scenario,
+                ok: event.ok,
+                timeout: event.timeout,
+                latencyMs: event.latencyMs,
+                overall: &overallStats,
+                scenarios: &scenarioStats
+            )
+            if event.timeout {
+                await runBenchmarkTimeoutRecoveryGate()
+            }
         }
 
-        try await writeSummary(
-            to: summaryURL,
+        let summary = renderCountBenchmarkSummary(
+            title: "get_task_counts",
             startedAt: measuredStart,
             endedAt: Date(),
-            memoryURL: memoryURL,
             durationHours: durationHours,
             warmupCalls: warmupCalls,
             intervalMS: intervalMS,
             cooldownMS: cooldownMS,
             memoryIntervalSeconds: memoryIntervalSeconds,
-            timeoutDiagnosticsURL: timeoutDiagnosticsURL,
-            scenarios: scenarios,
-            statsByTransport: statsByTransport,
-            statsByScenarioTransport: statsByScenarioTransport
+            scenarioNames: scenarios.map(\.name),
+            overall: overallStats,
+            scenarios: scenarioStats,
+            memoryURL: memoryURL,
+            timeoutDiagnosticsURL: timeoutDiagnosticsURL
         )
+        try summary.write(to: summaryURL, atomically: true, encoding: .utf8)
 
         print("Benchmark complete.")
         print("Raw data: \(rawURL.path)")
@@ -162,708 +141,27 @@ struct BenchmarkTaskCounts: AsyncParsableCommand {
     }
 }
 
-private struct BenchmarkScenario {
+private struct TaskCountBenchmarkScenario {
     let name: String
     let filter: TaskFilter
 }
 
 private let taskCountsNoMatchSearch = "__focusrelay_benchmark_no_match_7f43d9__"
 
-private func benchmarkScenarios(completedAfter: Date) -> [BenchmarkScenario] {
+private func taskCountBenchmarkScenarios(completedAfter: Date) -> [TaskCountBenchmarkScenario] {
     [
-        BenchmarkScenario(name: "default", filter: TaskFilter()),
-        BenchmarkScenario(name: "inbox_only", filter: TaskFilter(inboxOnly: true)),
-        BenchmarkScenario(name: "available_only", filter: TaskFilter(availableOnly: true)),
-        BenchmarkScenario(
+        TaskCountBenchmarkScenario(name: "default", filter: TaskFilter()),
+        TaskCountBenchmarkScenario(name: "inbox_only", filter: TaskFilter(inboxOnly: true)),
+        TaskCountBenchmarkScenario(name: "available_only", filter: TaskFilter(availableOnly: true)),
+        TaskCountBenchmarkScenario(
             name: "completed_after_anchor",
             filter: TaskFilter(completed: true, completedAfter: completedAfter)
         ),
-        BenchmarkScenario(name: "flagged_only", filter: TaskFilter(flagged: true)),
-        BenchmarkScenario(
+        TaskCountBenchmarkScenario(name: "flagged_only", filter: TaskFilter(flagged: true)),
+        TaskCountBenchmarkScenario(
             name: "search_no_match",
             filter: TaskFilter(availableOnly: false, inboxView: "everything", search: taskCountsNoMatchSearch)
         )
     ]
-}
-
-private enum Transport: String, Codable, CaseIterable {
-    case plugin
-}
-
-private struct BenchEvent: Codable {
-    let timestamp: String
-    let phase: String
-    let callIndex: Int
-    let transport: String
-    let scenario: String
-    let latencyMs: Double
-    let ok: Bool
-    let timeout: Bool
-    let error: String?
-    let counts: TaskCountsModel?
-}
-
-private struct StatsAccumulator {
-    var successCount: Int = 0
-    var errorCount: Int = 0
-    var timeoutCount: Int = 0
-    var latencies: [Double] = []
-
-    mutating func ingest(_ event: BenchEvent) {
-        if event.ok {
-            successCount += 1
-            latencies.append(event.latencyMs)
-        } else {
-            errorCount += 1
-            if event.timeout {
-                timeoutCount += 1
-            }
-        }
-    }
-}
-
-private struct TimeoutQueueSnapshot: Codable {
-    let basePath: String
-    let requestsCount: Int
-    let locksCount: Int
-    let responsesCount: Int
-    let requestExists: Bool?
-    let lockExists: Bool?
-    let responseExists: Bool?
-    let sampleRequests: [String]
-    let sampleLocks: [String]
-    let sampleResponses: [String]
-}
-
-private struct TimeoutProcessSnapshot: Codable {
-    let process: String
-    let pid: Int32?
-    let rssKB: Int?
-}
-
-private struct TimeoutBridgeHealthSnapshot: Codable {
-    let ok: Bool
-    let detail: String
-}
-
-private struct TaskTimeoutDiagnostic: Codable {
-    let timestamp: String
-    let transport: String
-    let scenario: String
-    let phase: String
-    let callIndex: Int
-    let latencyMs: Double
-    let error: String
-    let requestId: String?
-    let queue: TimeoutQueueSnapshot
-    let omniFocus: TimeoutProcessSnapshot
-    let focusrelay: TimeoutProcessSnapshot
-    let bridgeHealth: TimeoutBridgeHealthSnapshot?
-}
-
-private func runWarmup(
-    warmupCalls: Int,
-    scenarios: [BenchmarkScenario],
-    pluginService: OmniFocusBridgeService,
-    rawURL: URL,
-    timeoutDiagnosticsURL: URL,
-    intervalMS: Int,
-    cooldownMS: Int,
-    callIndex: inout Int
-) async throws {
-    var scenarioIndex = 0
-    for _ in 0..<warmupCalls {
-        let scenario = scenarios[scenarioIndex % scenarios.count]
-        scenarioIndex += 1
-        let event = try await runBenchCall(
-            transport: .plugin,
-            scenario: scenario,
-            phase: "warmup",
-            service: pluginService,
-            timeoutDiagnosticsURL: timeoutDiagnosticsURL,
-            intervalMS: intervalMS,
-            cooldownMS: cooldownMS,
-            callIndex: &callIndex
-        )
-        try appendJSONLine(event, to: rawURL)
-    }
-
-}
-
-private func runBenchCall(
-    transport: Transport,
-    scenario: BenchmarkScenario,
-    phase: String,
-    service: any OmniFocusService,
-    timeoutDiagnosticsURL: URL,
-    intervalMS: Int,
-    cooldownMS: Int,
-    callIndex: inout Int
-) async throws -> BenchEvent {
-    callIndex += 1
-    let start = Date()
-    do {
-        let counts = try await service.getTaskCounts(filter: scenario.filter)
-        let elapsed = Date().timeIntervalSince(start)
-        try await enforceInterval(start: start, intervalMS: intervalMS)
-        return BenchEvent(
-            timestamp: iso8601Now(),
-            phase: phase,
-            callIndex: callIndex,
-            transport: transport.rawValue,
-            scenario: scenario.name,
-            latencyMs: elapsed * 1000,
-            ok: true,
-            timeout: false,
-            error: nil,
-            counts: counts
-        )
-    } catch {
-        let elapsed = Date().timeIntervalSince(start)
-        let message = error.localizedDescription
-        let isTimeout = isTimeoutError(error)
-        try await enforceInterval(start: start, intervalMS: intervalMS)
-        if cooldownMS > 0 {
-            try? await Task.sleep(nanoseconds: UInt64(cooldownMS) * 1_000_000)
-        }
-        if isTimeout {
-            let diagnostic = captureTaskTimeoutDiagnostic(
-                transport: transport,
-                scenario: scenario,
-                phase: phase,
-                callIndex: callIndex,
-                latencyMs: elapsed * 1000,
-                errorMessage: message
-            )
-            try? appendJSONLine(diagnostic, to: timeoutDiagnosticsURL)
-        }
-        return BenchEvent(
-            timestamp: iso8601Now(),
-            phase: phase,
-            callIndex: callIndex,
-            transport: transport.rawValue,
-            scenario: scenario.name,
-            latencyMs: elapsed * 1000,
-            ok: false,
-            timeout: isTimeout,
-            error: message,
-            counts: nil
-        )
-    }
-}
-
-private func runTimeoutRecoveryGate() async {
-    let env = ProcessInfo.processInfo.environment
-    let recoveryMs = max(0, env["FOCUS_RELAY_TIMEOUT_RECOVERY_MS"].flatMap(Int.init) ?? 10_000)
-    if recoveryMs > 0 {
-        try? await Task.sleep(nanoseconds: UInt64(recoveryMs) * 1_000_000)
-    }
-    // Lightweight readiness probe before resuming to reduce timeout cascades.
-    _ = try? OmniFocusBridgeService().healthCheck()
-}
-
-private func enforceInterval(start: Date, intervalMS: Int) async throws {
-    guard intervalMS > 0 else { return }
-    let elapsed = Date().timeIntervalSince(start)
-    let target = Double(intervalMS) / 1000.0
-    if elapsed < target {
-        let wait = target - elapsed
-        try await Task.sleep(nanoseconds: UInt64(wait * 1_000_000_000))
-    }
-}
-
-private func accumulate(
-    _ event: BenchEvent,
-    byTransport: inout [Transport: StatsAccumulator],
-    byScenarioTransport: inout [String: [Transport: StatsAccumulator]]
-) {
-    guard let transport = Transport(rawValue: event.transport) else { return }
-
-    var transportStats = byTransport[transport] ?? StatsAccumulator()
-    transportStats.ingest(event)
-    byTransport[transport] = transportStats
-
-    var scenarioStats = byScenarioTransport[event.scenario] ?? [:]
-    var scopedStats = scenarioStats[transport] ?? StatsAccumulator()
-    scopedStats.ingest(event)
-    scenarioStats[transport] = scopedStats
-    byScenarioTransport[event.scenario] = scenarioStats
-}
-
-private func benchmarkOutputDirectory(customPath: String?) throws -> URL {
-    if let customPath, !customPath.isEmpty {
-        let url = URL(fileURLWithPath: customPath, relativeTo: URL(fileURLWithPath: FileManager.default.currentDirectoryPath))
-            .standardizedFileURL
-        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
-        return url
-    }
-
-    let formatter = DateFormatter()
-    formatter.locale = Locale(identifier: "en_US_POSIX")
-    formatter.dateFormat = "yyyyMMdd-HHmmss"
-    let timestamp = formatter.string(from: Date())
-    let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-        .appendingPathComponent(".build", isDirectory: true)
-        .appendingPathComponent("benchmarks", isDirectory: true)
-        .appendingPathComponent(timestamp, isDirectory: true)
-    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
-    return url
-}
-
-private func initializeBenchmarkArtifacts(rawURL: URL, memoryURL: URL, timeoutDiagnosticsURL: URL) throws {
-    FileManager.default.createFile(atPath: rawURL.path, contents: nil)
-    FileManager.default.createFile(atPath: memoryURL.path, contents: nil)
-    FileManager.default.createFile(atPath: timeoutDiagnosticsURL.path, contents: nil)
-    try appendLine("timestamp,process,pid,rss_kb\n", to: memoryURL)
-}
-
-private func appendJSONLine<T: Encodable>(_ value: T, to url: URL) throws {
-    let encoder = JSONEncoder()
-    encoder.dateEncodingStrategy = .iso8601
-    let data = try encoder.encode(value)
-    guard var line = String(data: data, encoding: .utf8) else {
-        throw ValidationError("Failed to encode benchmark event as UTF-8.")
-    }
-    line.append("\n")
-    try appendLine(line, to: url)
-}
-
-private func appendLine(_ line: String, to url: URL) throws {
-    guard let data = line.data(using: .utf8) else { return }
-    let handle = try FileHandle(forWritingTo: url)
-    defer { try? handle.close() }
-    try handle.seekToEnd()
-    try handle.write(contentsOf: data)
-}
-
-private func isTimeoutError(_ error: Error) -> Bool {
-    let message = error.localizedDescription.lowercased()
-    return message.contains("timed out") || message.contains("timeout")
-}
-
-private func runPreflight() {
-    do {
-        try stopExtraServeProcesses()
-    } catch {
-        print("Preflight warning: failed to inspect/terminate extra servers (\(error.localizedDescription)).")
-    }
-
-    do {
-        try restartOmniFocus()
-    } catch {
-        print("Preflight warning: failed to restart OmniFocus (\(error.localizedDescription)).")
-    }
-}
-
-private func stopExtraServeProcesses() throws {
-    let currentPID = ProcessInfo.processInfo.processIdentifier
-    guard let output = try? runProcess(
-        executable: "/usr/bin/pgrep",
-        arguments: ["-f", "focusrelay"],
-        timeout: 3
-    ) else {
-        print("Preflight: no extra focusrelay server processes detected.")
-        return
-    }
-
-    let candidatePIDs = output
-        .split(separator: "\n")
-        .compactMap { Int32($0) }
-
-    var terminated: [Int32] = []
-    for pid in candidatePIDs {
-        if pid == currentPID { continue }
-        guard let command = try? runProcess(
-            executable: "/bin/ps",
-            arguments: ["-o", "command=", "-p", String(pid)],
-            timeout: 3
-        ) else {
-            continue
-        }
-        let trimmedCommand = command.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmedCommand.contains("focusrelay serve") || trimmedCommand.contains("focusrelay mcp") || trimmedCommand.contains("focusrelay server") {
-            _ = try? runProcess(executable: "/bin/kill", arguments: ["-TERM", String(pid)], timeout: 2)
-            terminated.append(pid)
-        }
-    }
-
-    if !terminated.isEmpty {
-        print("Preflight: terminated focusrelay server processes: \(terminated.map(String.init).joined(separator: ", "))")
-        Thread.sleep(forTimeInterval: 1.0)
-    } else {
-        print("Preflight: no extra focusrelay server processes detected.")
-    }
-}
-
-private func restartOmniFocus() throws {
-    print("Preflight: restarting OmniFocus...")
-    _ = try? runProcess(
-        executable: "/usr/bin/osascript",
-        arguments: ["-e", "tell application \"OmniFocus\" to quit"],
-        timeout: 8
-    )
-    Thread.sleep(forTimeInterval: 2.0)
-    _ = try runProcess(executable: "/usr/bin/open", arguments: ["-a", "OmniFocus"], timeout: 8)
-    Thread.sleep(forTimeInterval: 3.0)
-}
-
-private func currentOmniFocusPID() -> Int32? {
-    guard let output = try? runProcess(executable: "/usr/bin/pgrep", arguments: ["-x", "OmniFocus"], timeout: 3) else {
-        return nil
-    }
-    let firstLine = output.split(separator: "\n").first
-    return firstLine.flatMap { Int32($0) }
-}
-
-private func readRSSKilobytes(pid: Int32) -> Int? {
-    guard let output = try? runProcess(executable: "/bin/ps", arguments: ["-o", "rss=", "-p", String(pid)], timeout: 3) else {
-        return nil
-    }
-    return Int(output.trimmingCharacters(in: .whitespacesAndNewlines))
-}
-
-@discardableResult
-private func runProcess(executable: String, arguments: [String], timeout: TimeInterval = 15) throws -> String {
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: executable)
-    process.arguments = arguments
-    let pipe = Pipe()
-    process.standardOutput = pipe
-    process.standardError = pipe
-    try process.run()
-    let deadline = Date().addingTimeInterval(timeout)
-    while process.isRunning && Date() < deadline {
-        Thread.sleep(forTimeInterval: 0.05)
-    }
-
-    if process.isRunning {
-        process.terminate()
-        throw AutomationError.executionFailed("Process \(executable) timed out after \(Int(timeout))s")
-    }
-
-    process.waitUntilExit()
-    let data = pipe.fileHandleForReading.readDataToEndOfFile()
-    let output = String(decoding: data, as: UTF8.self)
-    if process.terminationStatus != 0 {
-        throw AutomationError.executionFailed("Process \(executable) failed: \(output)")
-    }
-    return output
-}
-
-private func captureTaskTimeoutDiagnostic(
-    transport: Transport,
-    scenario: BenchmarkScenario,
-    phase: String,
-    callIndex: Int,
-    latencyMs: Double,
-    errorMessage: String
-) -> TaskTimeoutDiagnostic {
-    let requestID = extractRequestID(from: errorMessage)
-    let baseURL = defaultIPCBaseURL()
-    let requestsURL = baseURL.appendingPathComponent("requests", isDirectory: true)
-    let locksURL = baseURL.appendingPathComponent("locks", isDirectory: true)
-    let responsesURL = baseURL.appendingPathComponent("responses", isDirectory: true)
-    let queue = TimeoutQueueSnapshot(
-        basePath: baseURL.path,
-        requestsCount: directoryEntryCount(requestsURL),
-        locksCount: directoryEntryCount(locksURL),
-        responsesCount: directoryEntryCount(responsesURL),
-        requestExists: requestID.map { FileManager.default.fileExists(atPath: requestsURL.appendingPathComponent("\($0).json").path) },
-        lockExists: requestID.map { FileManager.default.fileExists(atPath: locksURL.appendingPathComponent("\($0).lock").path) },
-        responseExists: requestID.map { FileManager.default.fileExists(atPath: responsesURL.appendingPathComponent("\($0).json").path) },
-        sampleRequests: directoryEntrySamples(requestsURL),
-        sampleLocks: directoryEntrySamples(locksURL),
-        sampleResponses: directoryEntrySamples(responsesURL)
-    )
-    let omniPID = currentOmniFocusPID()
-    let benchmarkPID = ProcessInfo.processInfo.processIdentifier
-    let bridgeHealth: TimeoutBridgeHealthSnapshot?
-    if transport == .plugin {
-        if let result = try? OmniFocusBridgeService().healthCheck() {
-            bridgeHealth = TimeoutBridgeHealthSnapshot(
-                ok: result.ok,
-                detail: "plugin=\(result.plugin ?? "unknown") version=\(result.version ?? "unknown")"
-            )
-        } else {
-            bridgeHealth = TimeoutBridgeHealthSnapshot(
-                ok: false,
-                detail: "bridge-health-check failed after timeout"
-            )
-        }
-    } else {
-        bridgeHealth = nil
-    }
-
-    return TaskTimeoutDiagnostic(
-        timestamp: iso8601Now(),
-        transport: transport.rawValue,
-        scenario: scenario.name,
-        phase: phase,
-        callIndex: callIndex,
-        latencyMs: latencyMs,
-        error: errorMessage,
-        requestId: requestID,
-        queue: queue,
-        omniFocus: TimeoutProcessSnapshot(
-            process: "OmniFocus",
-            pid: omniPID,
-            rssKB: omniPID.flatMap(readRSSKilobytes(pid:))
-        ),
-        focusrelay: TimeoutProcessSnapshot(
-            process: "focusrelay",
-            pid: benchmarkPID,
-            rssKB: readRSSKilobytes(pid: benchmarkPID)
-        ),
-        bridgeHealth: bridgeHealth
-    )
-}
-
-private func extractRequestID(from message: String) -> String? {
-    let pattern = #"requestId=([A-F0-9-]+)"#
-    guard let regex = try? NSRegularExpression(pattern: pattern) else {
-        return nil
-    }
-    let range = NSRange(message.startIndex..<message.endIndex, in: message)
-    guard let match = regex.firstMatch(in: message, range: range),
-          let matchRange = Range(match.range(at: 1), in: message) else {
-        return nil
-    }
-    return String(message[matchRange])
-}
-
-private func directoryEntryCount(_ url: URL) -> Int {
-    guard let contents = try? FileManager.default.contentsOfDirectory(atPath: url.path) else {
-        return 0
-    }
-    return contents.count
-}
-
-private func directoryEntrySamples(_ url: URL, limit: Int = 5) -> [String] {
-    guard let contents = try? FileManager.default.contentsOfDirectory(atPath: url.path) else {
-        return []
-    }
-    return Array(contents.sorted().prefix(limit))
-}
-
-private func defaultIPCBaseURL() -> URL {
-    let home = FileManager.default.homeDirectoryForCurrentUser
-    let container = home
-        .appendingPathComponent("Library", isDirectory: true)
-        .appendingPathComponent("Containers", isDirectory: true)
-        .appendingPathComponent("com.omnigroup.OmniFocus4", isDirectory: true)
-        .appendingPathComponent("Data", isDirectory: true)
-        .appendingPathComponent("Documents", isDirectory: true)
-        .appendingPathComponent("FocusRelayIPC", isDirectory: true)
-
-    if FileManager.default.fileExists(atPath: container.deletingLastPathComponent().path) {
-        return container
-    }
-
-    return home
-        .appendingPathComponent("Library", isDirectory: true)
-        .appendingPathComponent("Caches", isDirectory: true)
-        .appendingPathComponent("focusrelay", isDirectory: true)
-}
-
-private func writeSummary(
-    to url: URL,
-    startedAt: Date,
-    endedAt: Date,
-    memoryURL: URL,
-    durationHours: Double,
-    warmupCalls: Int,
-    intervalMS: Int,
-    cooldownMS: Int,
-    memoryIntervalSeconds: Int,
-    timeoutDiagnosticsURL: URL,
-    scenarios: [BenchmarkScenario],
-    statsByTransport: [Transport: StatsAccumulator],
-    statsByScenarioTransport: [String: [Transport: StatsAccumulator]]
-) async throws {
-    let memorySummary = loadMemorySummary(from: memoryURL)
-    let timeoutDiagnosticCount = countLines(in: timeoutDiagnosticsURL)
-    var lines: [String] = []
-    lines.append("# get_task_counts Benchmark Summary")
-    lines.append("")
-    lines.append("- Started: \(iso8601(startedAt))")
-    lines.append("- Ended: \(iso8601(endedAt))")
-    lines.append(String(format: "- Configured duration (hours): %.2f", durationHours))
-    lines.append("- Warmup calls: \(warmupCalls)")
-    lines.append("- Interval (ms): \(intervalMS)")
-    lines.append("- Cooldown after failure (ms): \(cooldownMS)")
-    lines.append("- Memory sampling interval (seconds): \(memoryIntervalSeconds)")
-    lines.append("- Scenarios: \(scenarios.map(\.name).joined(separator: ", "))")
-    lines.append("")
-    lines.append("## Overall Transport Stats")
-    lines.append("")
-    for transport in Transport.allCases {
-        let stats = statsByTransport[transport] ?? StatsAccumulator()
-        let totalCalls = stats.successCount + stats.errorCount
-        let timeoutRate = percentage(part: stats.timeoutCount, total: totalCalls)
-        let errorRate = percentage(part: stats.errorCount, total: totalCalls)
-        lines.append("### \(transport.rawValue)")
-        lines.append("- Total calls: \(totalCalls)")
-        lines.append("- Success calls: \(stats.successCount)")
-        lines.append("- Error calls: \(stats.errorCount)")
-        lines.append("- Error rate: \(formatPercentage(errorRate))")
-        lines.append("- Timeout calls: \(stats.timeoutCount)")
-        lines.append("- Timeout rate: \(formatPercentage(timeoutRate))")
-        lines.append("- p50 latency (ms): \(formatDouble(percentile(stats.latencies, p: 0.50)))")
-        lines.append("- p95 latency (ms): \(formatDouble(percentile(stats.latencies, p: 0.95)))")
-        lines.append("- p99 latency (ms): \(formatDouble(percentile(stats.latencies, p: 0.99)))")
-        lines.append("")
-    }
-
-    lines.append("## Scenario Stats")
-    lines.append("")
-    for scenario in scenarios {
-        lines.append("### \(scenario.name)")
-        let scoped = statsByScenarioTransport[scenario.name] ?? [:]
-        for transport in Transport.allCases {
-            let stats = scoped[transport] ?? StatsAccumulator()
-            let totalCalls = stats.successCount + stats.errorCount
-            let timeoutRate = percentage(part: stats.timeoutCount, total: totalCalls)
-            let errorRate = percentage(part: stats.errorCount, total: totalCalls)
-            lines.append("- \(transport.rawValue): total=\(totalCalls), success=\(stats.successCount), errors=\(stats.errorCount), error_rate=\(formatPercentage(errorRate)), timeouts=\(stats.timeoutCount), timeout_rate=\(formatPercentage(timeoutRate)), p95_ms=\(formatDouble(percentile(stats.latencies, p: 0.95)))")
-        }
-        lines.append("")
-    }
-
-    lines.append("## Memory Notes")
-    lines.append("")
-    lines.append("- `memory.csv` contains RSS samples for `focusrelay` and `OmniFocus`.")
-    lines.append("- Memory growth slope is estimated in KB/min from sampled RSS values.")
-    lines.append("- `timeout-diagnostics.jsonl` contains timeout queue/process snapshots for this benchmark.")
-    lines.append("")
-    lines.append("### Memory Growth")
-    for process in ["focusrelay", "OmniFocus"] {
-        if let summary = memorySummary[process] {
-            lines.append("- \(process): samples=\(summary.samples), start_kb=\(summary.startKB), end_kb=\(summary.endKB), delta_kb=\(summary.endKB - summary.startKB), slope_kb_per_min=\(formatDouble(summary.slopeKBPerMinute))")
-        } else {
-            lines.append("- \(process): no samples")
-        }
-    }
-
-    lines.append("")
-    lines.append("## Timeout Diagnostics")
-    lines.append("")
-    lines.append("- Diagnostic entries: \(timeoutDiagnosticCount)")
-
-    try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
-}
-
-private func percentile(_ values: [Double], p: Double) -> Double {
-    guard !values.isEmpty else { return .nan }
-    let sorted = values.sorted()
-    let index = Int(Double(sorted.count - 1) * p)
-    return sorted[max(0, min(index, sorted.count - 1))]
-}
-
-private func formatDouble(_ value: Double) -> String {
-    guard value.isFinite else { return "n/a" }
-    return String(format: "%.2f", value)
-}
-
-private func formatPercentage(_ value: Double) -> String {
-    guard value.isFinite else { return "n/a" }
-    return String(format: "%.2f%%", value)
-}
-
-private struct MemorySample {
-    let timestamp: Date
-    let process: String
-    let rssKB: Double
-}
-
-private struct MemoryProcessSummary {
-    let samples: Int
-    let startKB: Int
-    let endKB: Int
-    let slopeKBPerMinute: Double
-}
-
-private func loadMemorySummary(from url: URL) -> [String: MemoryProcessSummary] {
-    guard let content = try? String(contentsOf: url, encoding: .utf8) else {
-        return [:]
-    }
-
-    let parser = ISO8601DateFormatter()
-    parser.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-
-    var byProcess: [String: [MemorySample]] = [:]
-    let lines = content.split(separator: "\n")
-    for (index, line) in lines.enumerated() {
-        if index == 0 { continue } // header
-        let columns = line.split(separator: ",", omittingEmptySubsequences: false)
-        if columns.count < 4 { continue }
-        let timestampRaw = String(columns[0])
-        let process = String(columns[1])
-        let rssRaw = String(columns[3])
-        guard let timestamp = parser.date(from: timestampRaw),
-              let rss = Double(rssRaw) else {
-            continue
-        }
-        let sample = MemorySample(timestamp: timestamp, process: process, rssKB: rss)
-        byProcess[process, default: []].append(sample)
-    }
-
-    var summary: [String: MemoryProcessSummary] = [:]
-    for (process, samples) in byProcess {
-        let sorted = samples.sorted { $0.timestamp < $1.timestamp }
-        guard let first = sorted.first, let last = sorted.last else { continue }
-        let slope = linearSlopeKBPerMinute(samples: sorted)
-        summary[process] = MemoryProcessSummary(
-            samples: sorted.count,
-            startKB: Int(first.rssKB.rounded()),
-            endKB: Int(last.rssKB.rounded()),
-            slopeKBPerMinute: slope
-        )
-    }
-    return summary
-}
-
-private func linearSlopeKBPerMinute(samples: [MemorySample]) -> Double {
-    guard samples.count > 1, let first = samples.first else { return .nan }
-
-    var sumX = 0.0
-    var sumY = 0.0
-    var sumXX = 0.0
-    var sumXY = 0.0
-    let n = Double(samples.count)
-
-    for sample in samples {
-        let x = sample.timestamp.timeIntervalSince(first.timestamp) / 60.0
-        let y = sample.rssKB
-        sumX += x
-        sumY += y
-        sumXX += x * x
-        sumXY += x * y
-    }
-
-    let denominator = (n * sumXX) - (sumX * sumX)
-    if abs(denominator) < 1e-9 { return .nan }
-    return ((n * sumXY) - (sumX * sumY)) / denominator
-}
-
-private func percentage(part: Int, total: Int) -> Double {
-    guard total > 0 else { return .nan }
-    return (Double(part) / Double(total)) * 100.0
-}
-
-private func countLines(in url: URL) -> Int {
-    guard let content = try? String(contentsOf: url, encoding: .utf8), !content.isEmpty else {
-        return 0
-    }
-    return max(0, content.split(separator: "\n").count)
-}
-
-private func iso8601Now() -> String {
-    iso8601(Date())
-}
-
-private func iso8601(_ date: Date) -> String {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-    return formatter.string(from: date)
 }
 #endif

--- a/Tests/FocusRelayCLITests/FocusRelayCLITests.swift
+++ b/Tests/FocusRelayCLITests/FocusRelayCLITests.swift
@@ -238,25 +238,88 @@ func benchmarkGateParsesToolScope() throws {
 
 @Test
 func listTaskBenchmarkRotatesEveryScenario() {
-    #expect((0..<8).map { listTaskScenarioIndex(pairIndex: $0, scenarioCount: 4) } == [0, 1, 2, 3, 0, 1, 2, 3])
-    #expect((0..<7).map { listTaskScenarioIndex(pairIndex: $0, scenarioCount: 3) } == [0, 1, 2, 0, 1, 2, 0])
+    #expect((0..<8).map { benchmarkScenarioIndex(callIndex: $0, scenarioCount: 4) } == [0, 1, 2, 3, 0, 1, 2, 3])
+    #expect((0..<7).map { benchmarkScenarioIndex(callIndex: $0, scenarioCount: 3) } == [0, 1, 2, 0, 1, 2, 0])
 }
 
 @Test
 func listTaskBenchmarkReportsMissingMeasuredCoverage() {
-    var success = ListTaskStats()
+    var success = BenchmarkStats()
     success.success = 1
-    var failure = ListTaskStats()
+    var failure = BenchmarkStats()
     failure.errors = 1
     let complete = [
-        "first": ["plugin": success],
-        "second": ["plugin": failure]
+        "first": success,
+        "second": failure
     ]
 
     #expect(listTaskMissingMeasuredCoverage(scenarios: ["first", "second"], stats: complete).isEmpty)
 
-    let incomplete = ["first": ["plugin": success]]
+    let incomplete = ["first": success]
     #expect(listTaskMissingMeasuredCoverage(scenarios: ["first", "second"], stats: incomplete) == [
         "second:plugin"
     ])
+}
+
+@Test
+func benchmarkArgumentsUseOneValidationContract() {
+    #expect(throws: (any Error).self) {
+        try validateBenchmarkArguments(durationHours: 0, warmupCalls: 0, intervalMS: 0, cooldownMS: 0)
+    }
+    #expect(throws: (any Error).self) {
+        try validateBenchmarkArguments(durationHours: 1, warmupCalls: -1, intervalMS: 0, cooldownMS: 0)
+    }
+    #expect(throws: (any Error).self) {
+        try validateBenchmarkArguments(durationHours: 1, warmupCalls: 0, intervalMS: 0, cooldownMS: 0, memoryIntervalSeconds: 0)
+    }
+}
+
+@Test
+func countBenchmarkArtifactKeepsHistoricalKeys() throws {
+    let event = CountBenchmarkEvent(
+        timestamp: "2026-07-18T00:00:00.000Z",
+        phase: "measured",
+        callIndex: 1,
+        transport: benchmarkTransport,
+        scenario: "default",
+        latencyMs: 12.5,
+        ok: true,
+        timeout: false,
+        error: nil,
+        counts: TaskCounts(total: 1, completed: 0, available: 1, flagged: 0)
+    )
+    let object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(event)) as? [String: Any])
+
+    #expect(Set(object.keys) == [
+        "timestamp", "phase", "callIndex", "transport", "scenario", "latencyMs",
+        "ok", "timeout", "counts"
+    ])
+    #expect(object["transport"] as? String == "plugin")
+}
+
+@Test
+func listBenchmarkArtifactKeepsHistoricalKeys() throws {
+    let event = ListTaskEvent(
+        timestamp: "2026-07-18T00:00:00.000Z",
+        phase: "measured",
+        callIndex: 1,
+        transport: benchmarkTransport,
+        scenario: "default",
+        latencyMs: 12.5,
+        ok: true,
+        timeout: false,
+        error: nil,
+        returnedCount: 1,
+        totalCount: 1,
+        nextCursor: nil,
+        firstItemID: "first",
+        lastItemID: "first"
+    )
+    let object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(event)) as? [String: Any])
+
+    #expect(Set(object.keys) == [
+        "timestamp", "phase", "callIndex", "transport", "scenario", "latencyMs",
+        "ok", "timeout", "returnedCount", "totalCount", "firstItemID", "lastItemID"
+    ])
+    #expect(object["transport"] as? String == "plugin")
 }

--- a/scripts/benchmark-suite-overnight.sh
+++ b/scripts/benchmark-suite-overnight.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-exec "${ROOT_DIR}/scripts/benchmark-suite.sh" "$@"


### PR DESCRIPTION
## What changed

- Extracted shared debug-only support for benchmark artifacts, statistics, timeout diagnostics, process/RSS inspection, preflight, timing, and summaries.
- Removed one-case transport enums, transport-keyed maps, unreachable alternate-transport branches, and JXA-era pair terminology.
- Preserved `transport: "plugin"` and all established successful JSONL keys for historical artifact comparison.
- Applied one argument-validation contract to all three benchmark commands.
- Removed the undocumented `benchmark-suite-overnight.sh` pass-through; the profile-based suite remains the supported entry point.

The three benchmark implementations shrink from 2,340 to 1,266 lines, with 1,015 net lines removed overall.

## Why

After #80 made the Bridge plugin the only architecture, the benchmark tools still carried structure designed for plugin/JXA comparisons. Keeping that structure added unreachable code and caused the three commands to drift even though they exercise the same runtime path.

## User and developer impact

There is no production server, query, mutation, cache, or IPC behavior change. Developers keep the same benchmark command names, scenarios, timing behavior, profiles, and artifact fields, with one smaller implementation to maintain.

## Validation

- `swift run focusrelay-dev validate --impact performance` — 137 tests and all eight live Bridge semantic contracts passed.
- Release build passed.
- Bridge-only architecture guard passed for debug and release binaries.
- Live canaries: 40/40 calls succeeded, zero errors, zero timeouts, with every task-count, list-task, and project-count scenario exercised.
- Successful pre- and post-refactor JSONL key sets match for all three tools.
- Shell syntax and `git diff --check` passed.

The production Bridge fingerprint is unchanged, so the existing long release evidence remains valid.

Closes #123
