### PR TITLE
Queue attention, search, and edit roadmap work

### DIFF
--- a/NEXT-STEPS.md
+++ b/NEXT-STEPS.md
@@ -1,6 +1,6 @@
 # FocusRelay Next Steps
 
-Last updated: 2026-07-18
+Last updated: 2026-07-19
 
 GitHub issues are the source of truth for deliverables and validation evidence.
 The concise dependency order lives in
@@ -12,14 +12,13 @@ The concise dependency order lives in
    Swift MCP SDK and remove deprecated response construction.
 2. [#91](https://github.com/deverman/FocusRelayMCP/issues/91) — consolidate task
    and project editing without reducing model correctness.
-3. [#94](https://github.com/deverman/FocusRelayMCP/issues/94) — research
+3. [#129](https://github.com/deverman/FocusRelayMCP/issues/129) — support true
+   task dropping and restoration without recording false completion history.
+4. [#94](https://github.com/deverman/FocusRelayMCP/issues/94) — research
    discoverable MCP workflow prompts and slash-command compatibility.
-4. [#82](https://github.com/deverman/FocusRelayMCP/issues/82) and
+5. [#82](https://github.com/deverman/FocusRelayMCP/issues/82) and
    [#83](https://github.com/deverman/FocusRelayMCP/issues/83) — create tasks,
    subtasks, and projects safely.
-5. [#88](https://github.com/deverman/FocusRelayMCP/issues/88) and
-   [#87](https://github.com/deverman/FocusRelayMCP/issues/87) — expose project
-   folder membership and reduce project-review context server-side.
 
 The `v0.10.0-beta` release and its evidence are recorded in the GitHub release,
 closed release tracker #63, and the repository history rather than duplicated

--- a/NEXT-STEPS.md
+++ b/NEXT-STEPS.md
@@ -1,6 +1,6 @@
 # FocusRelay Next Steps
 
-Last updated: 2026-07-15
+Last updated: 2026-07-18
 
 GitHub issues are the source of truth for deliverables and validation evidence.
 The concise dependency order lives in
@@ -8,17 +8,18 @@ The concise dependency order lives in
 
 ## Current Priority
 
-1. [#95](https://github.com/deverman/FocusRelayMCP/issues/95) — reduce
-   development and release lead time without weakening quality.
-2. [#75](https://github.com/deverman/FocusRelayMCP/issues/75) — upgrade the
+1. [#75](https://github.com/deverman/FocusRelayMCP/issues/75) — upgrade the
    Swift MCP SDK and remove deprecated response construction.
-3. [#91](https://github.com/deverman/FocusRelayMCP/issues/91) — consolidate task
+2. [#91](https://github.com/deverman/FocusRelayMCP/issues/91) — consolidate task
    and project editing without reducing model correctness.
-4. [#94](https://github.com/deverman/FocusRelayMCP/issues/94) — research
+3. [#94](https://github.com/deverman/FocusRelayMCP/issues/94) — research
    discoverable MCP workflow prompts and slash-command compatibility.
-5. [#82](https://github.com/deverman/FocusRelayMCP/issues/82) and
+4. [#82](https://github.com/deverman/FocusRelayMCP/issues/82) and
    [#83](https://github.com/deverman/FocusRelayMCP/issues/83) — create tasks,
    subtasks, and projects safely.
+5. [#88](https://github.com/deverman/FocusRelayMCP/issues/88) and
+   [#87](https://github.com/deverman/FocusRelayMCP/issues/87) — expose project
+   folder membership and reduce project-review context server-side.
 
 The `v0.10.0-beta` release and its evidence are recorded in the GitHub release,
 closed release tracker #63, and the repository history rather than duplicated

--- a/docs/roadmap-execution-plan.md
+++ b/docs/roadmap-execution-plan.md
@@ -11,25 +11,34 @@ records only current sequencing and cross-issue dependencies.
    - Upgrade to `0.12.1` and remove deprecated response construction before
      adding prompt responses.
 2. [#91 — Smaller edit interface](https://github.com/deverman/FocusRelayMCP/issues/91)
-   - Preserve or improve Kimi and comparison-model tool selection.
-3. [#94 — Discoverable MCP workflows](https://github.com/deverman/FocusRelayMCP/issues/94)
+   - Preserve or improve model tool selection, correctness, call count,
+     retries, latency, and user experience. Catalog size is supporting evidence,
+     not a hard limit.
+3. [#129 — task dropping and restoration](https://github.com/deverman/FocusRelayMCP/issues/129)
+   - Keep dropping distinct from completing so cleanup does not create false
+     completion history.
+4. [#94 — Discoverable MCP workflows](https://github.com/deverman/FocusRelayMCP/issues/94)
    - Research daily focus, weekly review, inbox processing, and project
      planning before fixing the public prompt set.
-4. [#82 — Task/subtask creation](https://github.com/deverman/FocusRelayMCP/issues/82), then
+5. [#82 — Task/subtask creation](https://github.com/deverman/FocusRelayMCP/issues/82), then
    [#83 — project creation/conversion](https://github.com/deverman/FocusRelayMCP/issues/83)
-   - Build on the consolidated edit surface and retain duplicate/write safety.
-5. [#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88), then
+   - Build on the consolidated edit surface, support safe project folder
+     destinations, and retain duplicate/write safety.
+6. [#70 — parent-aware tag discovery](https://github.com/deverman/FocusRelayMCP/issues/70), then
+   [#128 — create and assign missing tags](https://github.com/deverman/FocusRelayMCP/issues/128)
+   - Resolve root and nested tags safely before creating them during assignment.
+7. [#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88), then
    [#87 — project-health filters](https://github.com/deverman/FocusRelayMCP/issues/87)
    - Reduce context before expanding project-review workflows.
-6. [#85 — safe Forecast contract](https://github.com/deverman/FocusRelayMCP/issues/85), then
+8. [#85 — safe Forecast contract](https://github.com/deverman/FocusRelayMCP/issues/85), then
    [#125 — Forecast-based attention](https://github.com/deverman/FocusRelayMCP/issues/125), then
    [#126 — broader ranked task search](https://github.com/deverman/FocusRelayMCP/issues/126)
    - Reuse one documented task-only Forecast classifier for attention ranking.
    - Keep search independent, broad, relevance-ranked, and lightweight.
-7. Small independent query improvements: #11, #22, #18, #59, and #62.
-8. [#93 — repetition support](https://github.com/deverman/FocusRelayMCP/issues/93)
+9. Small independent query improvements: #11, #22, #18, #59, and #62.
+10. [#93 — repetition support](https://github.com/deverman/FocusRelayMCP/issues/93)
    after creation and editing stabilize.
-9. Feasibility work for #10 custom perspectives and #16 planned-date writes.
+11. Feasibility work for #10 custom perspectives and #16 planned-date writes.
 
 ## Standing Decisions
 
@@ -42,6 +51,9 @@ records only current sequencing and cross-issue dependencies.
 - Run the realistic 1.5-hour suite once per frozen production fingerprint.
 - Performance work must show a user-relevant latency/reliability win after
   semantic correctness passes.
+- Public tool count and serialized catalog size are directional optimization
+  evidence; they must not override correctness, routing reliability, or real
+  and perceived performance.
 - #95 established the current development and release flow; #90 owns the
   remaining command/session latency investigation.
 - Raw benchmark artifacts are not roadmap content and belong under `.build`.

--- a/docs/roadmap-execution-plan.md
+++ b/docs/roadmap-execution-plan.md
@@ -1,6 +1,6 @@
 # FocusRelay Roadmap Execution Plan
 
-Last updated: 2026-07-18
+Last updated: 2026-07-19
 
 GitHub issues own requirements, discussion, and validation evidence. This file
 records only current sequencing and cross-issue dependencies.
@@ -24,20 +24,23 @@ records only current sequencing and cross-issue dependencies.
    [#83 — project creation/conversion](https://github.com/deverman/FocusRelayMCP/issues/83)
    - Build on the consolidated edit surface, support safe project folder
      destinations, and retain duplicate/write safety.
-6. [#70 — parent-aware tag discovery](https://github.com/deverman/FocusRelayMCP/issues/70), then
+6. [#93 — repetition support](https://github.com/deverman/FocusRelayMCP/issues/93)
+   - After task creation and truthful drop behavior stabilize, establish complete
+     schedule readback before adding create, edit, and lifecycle mutation slices.
+7. [#70 — parent-aware tag discovery](https://github.com/deverman/FocusRelayMCP/issues/70), then
+   [#130 — project tag membership and filtering](https://github.com/deverman/FocusRelayMCP/issues/130), then
    [#128 — create and assign missing tags](https://github.com/deverman/FocusRelayMCP/issues/128)
-   - Resolve root and nested tags safely before creating them during assignment.
-7. [#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88), then
+   - Resolve root and nested tags safely, query direct project membership by
+     stable ID, then create missing tags during assignment.
+8. [#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88), then
    [#87 — project-health filters](https://github.com/deverman/FocusRelayMCP/issues/87)
    - Reduce context before expanding project-review workflows.
-8. [#85 — safe Forecast contract](https://github.com/deverman/FocusRelayMCP/issues/85), then
+9. [#85 — safe Forecast contract](https://github.com/deverman/FocusRelayMCP/issues/85), then
    [#125 — Forecast-based attention](https://github.com/deverman/FocusRelayMCP/issues/125), then
    [#126 — broader ranked task search](https://github.com/deverman/FocusRelayMCP/issues/126)
    - Reuse one documented task-only Forecast classifier for attention ranking.
    - Keep search independent, broad, relevance-ranked, and lightweight.
-9. Small independent query improvements: #11, #22, #18, #59, and #62.
-10. [#93 — repetition support](https://github.com/deverman/FocusRelayMCP/issues/93)
-   after creation and editing stabilize.
+10. Small independent query improvements: #11, #22, #18, #59, and #62.
 11. Feasibility work for #10 custom perspectives and #16 planned-date writes.
 
 ## Standing Decisions

--- a/docs/roadmap-execution-plan.md
+++ b/docs/roadmap-execution-plan.md
@@ -1,35 +1,35 @@
 # FocusRelay Roadmap Execution Plan
 
-Last updated: 2026-07-15
+Last updated: 2026-07-18
 
 GitHub issues own requirements, discussion, and validation evidence. This file
 records only current sequencing and cross-issue dependencies.
 
 ## Delivery Order
 
-1. [#95 — Kaizen development and release flow](https://github.com/deverman/FocusRelayMCP/issues/95)
-   - Establish impact-based validation, truthful live-test reporting,
-     developer workflow tooling, lean CI, and one frozen-RC reliability run.
-   - Keep #90 as the focused command/session latency investigation.
-2. [#75 — Swift MCP SDK maintenance](https://github.com/deverman/FocusRelayMCP/issues/75)
+1. [#75 — Swift MCP SDK maintenance](https://github.com/deverman/FocusRelayMCP/issues/75)
    - Upgrade to `0.12.1` and remove deprecated response construction before
      adding prompt responses.
-3. [#91 — Smaller edit interface](https://github.com/deverman/FocusRelayMCP/issues/91)
+2. [#91 — Smaller edit interface](https://github.com/deverman/FocusRelayMCP/issues/91)
    - Preserve or improve Kimi and comparison-model tool selection.
-4. [#94 — Discoverable MCP workflows](https://github.com/deverman/FocusRelayMCP/issues/94)
+3. [#94 — Discoverable MCP workflows](https://github.com/deverman/FocusRelayMCP/issues/94)
    - Research daily focus, weekly review, inbox processing, and project
      planning before fixing the public prompt set.
-5. [#82 — Task/subtask creation](https://github.com/deverman/FocusRelayMCP/issues/82), then
+4. [#82 — Task/subtask creation](https://github.com/deverman/FocusRelayMCP/issues/82), then
    [#83 — project creation/conversion](https://github.com/deverman/FocusRelayMCP/issues/83)
    - Build on the consolidated edit surface and retain duplicate/write safety.
-6. [#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88), then
+5. [#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88), then
    [#87 — project-health filters](https://github.com/deverman/FocusRelayMCP/issues/87)
    - Reduce context before expanding project-review workflows.
-7. [#85 — safe Forecast contract](https://github.com/deverman/FocusRelayMCP/issues/85)
-8. Small independent query improvements: #11, #22, #18, #59, and #62.
-9. [#93 — repetition support](https://github.com/deverman/FocusRelayMCP/issues/93)
+6. [#85 — safe Forecast contract](https://github.com/deverman/FocusRelayMCP/issues/85), then
+   [#125 — Forecast-based attention](https://github.com/deverman/FocusRelayMCP/issues/125), then
+   [#126 — broader ranked task search](https://github.com/deverman/FocusRelayMCP/issues/126)
+   - Reuse one documented task-only Forecast classifier for attention ranking.
+   - Keep search independent, broad, relevance-ranked, and lightweight.
+7. Small independent query improvements: #11, #22, #18, #59, and #62.
+8. [#93 — repetition support](https://github.com/deverman/FocusRelayMCP/issues/93)
    after creation and editing stabilize.
-10. Feasibility work for #10 custom perspectives and #16 planned-date writes.
+9. Feasibility work for #10 custom perspectives and #16 planned-date writes.
 
 ## Standing Decisions
 
@@ -42,6 +42,8 @@ records only current sequencing and cross-issue dependencies.
 - Run the realistic 1.5-hour suite once per frozen production fingerprint.
 - Performance work must show a user-relevant latency/reliability win after
   semantic correctness passes.
+- #95 established the current development and release flow; #90 owns the
+  remaining command/session latency investigation.
 - Raw benchmark artifacts are not roadmap content and belong under `.build`.
 
 ## Release Reference


### PR DESCRIPTION
## What changed

- queue #125 and #126 for Forecast-based attention and broader ranked task search
- queue #129 for true task dropping/restoration without false completion history
- queue #70, #130, and #128 so hierarchical tags are resolved, direct project membership can be queried by stable ID, and missing tags are created only after those read contracts are stable
- move #93 immediately after creation prerequisites and require complete schedule readback before repetition mutations
- expand #82 and #83 with task, subtask, project, conversion, and safe project-folder destination contracts
- expand #91 with negative routing and model-evaluation criteria for the consolidated edit interface
- align `NEXT-STEPS.md` with the roadmap's immediate #75, #91, #129, #94, #82/#83 order
- record the dependency order in the concise roadmap

## Why

The issue bodies now define bounded user journeys, wire shapes, edge cases,
failure semantics, documented OmniFocus API constraints, and validation
requirements in enough detail for a less-capable implementation model to follow.

The roadmap also incorporates the product intent learned from the
`Lumenbeing/FocusRelayMCP` fork without importing its stale implementation:
project folder context remains in #88, repetition awareness remains in #93, and
project tag membership/filtering is isolated in #130.

Catalog byte counts and public tool count remain useful optimization evidence,
but they are not hard limits. Correctness, tool routing, retries, latency, and
real and perceived user performance drive the decisions.

## Impact

Documentation and backlog sequencing only. No production code, MCP schema,
plugin, CLI behavior, tests, or package configuration changed.

## Validation

```text
swift run focusrelay-dev validate --impact docs
```

Whitespace and local Markdown link checks pass.

The longer invocation documented in `AGENTS.md` currently rejects
`--base origin/master`; validation used the helper's supported docs-tier
interface without escalating to a larger test tier.
