### PR TITLE
Prepare v0.10.1-beta maintenance release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1-beta] - 2026-07-19
+
+### Added
+
+- Bridge response warnings now appear in server logs and list responses instead
+  of being silently discarded.
+- Impact-based development and release validation commands, explicit benchmark
+  profiles, production fingerprint reports, and Markdown link validation.
+- MCP Registry metadata, contribution guidance, and an MIT license.
+
+### Changed
+
+- FocusRelay now has one OmniFocus architecture: the installed Bridge plugin
+  invoked through plugin URL dispatch. Retired direct-JXA and OSAKit runtime,
+  diagnostic, and benchmark paths were removed from debug and release builds.
+- Blocking Bridge response waits run outside Swift's cooperative thread pool so
+  concurrent MCP requests do not monopolize executor threads.
+- Bridge-only benchmark commands share one implementation while preserving
+  established scenarios and artifact fields.
+- Default tag listing avoids calculating per-tag task counts unless
+  `includeTaskCounts=true`.
+
+### Fixed
+
+- Completed-project date-window queries no longer disappear under the default
+  active-project status filter.
+- `completed=false` now means remaining work and excludes dropped tasks and
+  children of completed or dropped parents.
+- `get_project_counts` uses the documented inclusive `completedBefore` bound for
+  task counts.
+- MCP arguments accept ISO8601 timestamps with fractional seconds.
+- List tools reject non-positive page limits instead of producing empty or
+  backwards pagination, and cursor-only page objects use each tool's documented
+  default limit.
+- Unsupported project patch fields fail clearly instead of appearing to succeed
+  as no-ops.
+
+## [0.10.0-beta] - 2026-07-14
+
 ### Added
 
 - A preview-first write surface for homogeneous bulk task and project updates,

--- a/docs/release-notes-v0.10.1-beta.md
+++ b/docs/release-notes-v0.10.1-beta.md
@@ -1,0 +1,69 @@
+# FocusRelay 0.10.1-beta
+
+FocusRelay 0.10.1-beta is a maintenance release focused on truthful queries,
+reliable MCP pagination, concurrent Bridge requests, and one supported
+OmniFocus automation architecture.
+
+## Highlights
+
+- Follow list pagination cursors without repeating the page limit. FocusRelay
+  now applies the documented default for each list tool.
+- Retrieve completed projects in date windows without the default active status
+  filter hiding them.
+- Treat `completed=false` consistently as remaining work, excluding dropped
+  tasks and work beneath completed or dropped parents.
+- Send fractional-second ISO8601 timestamps from MCP clients.
+- Receive Bridge warnings in list responses and server logs.
+- Handle concurrent requests without blocking Swift's cooperative executor on
+  file-response polling.
+
+## One Bridge Architecture
+
+FocusRelay now develops, validates, benchmarks, and ships one OmniFocus path:
+the installed FocusRelay Bridge plugin invoked through Omni Automation URL
+dispatch. The incomplete direct-JXA engine, OSAKit linkage, alternate dispatch,
+and dual-transport benchmark code have been removed.
+
+This does not change the MCP configuration or supported tool names. It removes
+unused internal paths that duplicated query semantics and complicated release
+validation.
+
+## Query And Safety Corrections
+
+- Completed-project filters imply completed projects and compose with inclusive
+  date bounds.
+- Project completion-window task counts include actions exactly on the
+  `completedBefore` boundary.
+- Non-positive page limits fail at the MCP argument boundary and are also
+  defensively clamped in the Bridge.
+- Project fields that are not implemented no longer produce successful-looking
+  no-op updates.
+- Default tag catalog reads skip expensive task-count properties unless counts
+  are explicitly requested.
+
+## Upgrade Notes
+
+The plugin JavaScript and binary must stay in sync. After upgrading:
+
+1. Reinstall `FocusRelayBridge.omnijs` using the packaged installer.
+2. Quit OmniFocus completely and reopen it.
+3. Run `focusrelay --version` and `focusrelay bridge-health-check`.
+4. Run a small query and approve the Omni Automation script if OmniFocus asks.
+
+No MCP tool names or configuration paths changed in this release.
+
+## Validation
+
+The release candidate is certified through Swift tests, direct MCP wire probes,
+Bridge semantic contracts, release builds, Bridge-only architecture checks, a
+real MCP cursor-pagination journey, and the frozen 1.5-hour realistic benchmark
+profile. Final measured counts and artifact verification are recorded in the
+GitHub release and release tracker [#131](https://github.com/deverman/FocusRelayMCP/issues/131).
+
+## Contributors
+
+The release includes the ISO8601 bridge-decoding foundation previously
+contributed by [@Lumenbeing](https://github.com/Lumenbeing), now reused at the
+MCP argument boundary. Thanks also to
+[@osamu2001](https://github.com/osamu2001) for earlier status and cache work that
+continues to underpin the corrected query contracts.


### PR DESCRIPTION
## Release target

Prepare `v0.10.1-beta`, the maintenance release after `v0.10.0-beta`.

## What changed

- separate the published `0.10.0-beta` changelog from the new maintenance delta
- document corrected query semantics, cursor pagination, Bridge warnings, and concurrent request handling
- document the completed Bridge-only architecture and removal of retired JXA/OSAKit paths
- provide upgrade guidance and the exact final validation contract

## Validation impact

`docs` for this PR. The release as a whole is tracked as
`transport-reliability` in #131 and will be certified only after this PR merges.

## Acceptance journey

A user can read the release notes, understand the behavior that changed since
`v0.10.0-beta`, upgrade the binary and plugin together, and verify version,
Bridge health, cursor pagination, and a real query.

## Validation

- `swift run focusrelay-dev validate --impact docs`
- whitespace and local Markdown links pass

Closes #131 only after the tag, GitHub artifacts, Homebrew package, and installed
journey are verified; merging this PR does not close the release tracker.
