### PR TITLE
Record v0.10.1-beta release completion

### DIFF
--- a/NEXT-STEPS.md
+++ b/NEXT-STEPS.md
@@ -20,6 +20,6 @@ The concise dependency order lives in
    [#83](https://github.com/deverman/FocusRelayMCP/issues/83) — create tasks,
    subtasks, and projects safely.
 
-The `v0.10.0-beta` release and its evidence are recorded in the GitHub release,
-closed release tracker #63, and the repository history rather than duplicated
+The `v0.10.1-beta` release and its evidence are recorded in the GitHub release,
+release tracker #131, and the repository history rather than duplicated
 here.

--- a/docs/roadmap-execution-plan.md
+++ b/docs/roadmap-execution-plan.md
@@ -63,7 +63,7 @@ records only current sequencing and cross-issue dependencies.
 
 ## Release Reference
 
-- Current release: [`v0.10.0-beta`](https://github.com/deverman/FocusRelayMCP/releases/tag/v0.10.0-beta)
+- Current release: [`v0.10.1-beta`](https://github.com/deverman/FocusRelayMCP/releases/tag/v0.10.1-beta)
 - Release engineering: [`release-engineering-checklist.md`](release-engineering-checklist.md)
 - Development validation: [`development-workflow.md`](development-workflow.md)
 - User-facing changes: [`../CHANGELOG.md`](../CHANGELOG.md)


### PR DESCRIPTION
## Summary
- point the concise roadmap at the published v0.10.1-beta release
- point NEXT-STEPS at release tracker #131

## Impact
Docs only; the certified production fingerprint is unchanged.

## Validation
- swift run focusrelay-dev validate --impact docs

Refs #131