### PR TITLE
Upgrade Swift MCP SDK to 0.12.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9e053ea11d4638f5325fb74ab75cb8d4565532193f9d490492a10647719af98a",
+  "originHash" : "b16027b0442936e903e66b3fabf6b145774dc5e75eb3e78ec562f728419e2b40",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
-        "revision" : "6132fd4b5b4217ce4717c4775e4607f5c3120129",
-        "version" : "0.12.0"
+        "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
+        "version" : "0.12.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .executable(name: "focusrelay-dev", targets: ["FocusRelayDevCLI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.10.0"),
+        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
         .package(url: "https://github.com/swiftlang/swift-markdown.git", from: "0.8.0")

--- a/Sources/FocusRelayServer/FocusRelayServer.swift
+++ b/Sources/FocusRelayServer/FocusRelayServer.swift
@@ -719,7 +719,7 @@ public enum FocusRelayServer {
                         filter = try decodeArgument(TaskFilter.self, from: params.arguments, key: "filter") ?? TaskFilter()
                     } catch {
                         logger.error("Failed to decode filter: \(String(describing: error))")
-                        return .init(content: [.text("Error decoding filter: \(error)")], isError: true)
+                        return .init(content: [.text(text: "Error decoding filter: \(error)", annotations: nil, _meta: nil)], isError: true)
                     }
                     let page = try decodePageRequest(from: params)
                     let requestedFields = decodeStringArray(params.arguments?["fields"]) ?? []
@@ -728,18 +728,18 @@ public enum FocusRelayServer {
                     let fieldSet = Set(fields)
                     let items = result.items.map { makeTaskOutput(from: $0, fields: fieldSet) }
                     let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount, warnings: result.warnings)
-                    return .init(content: [.text(try encodeJSON(output))])
+                    return .init(content: [.text(text: try encodeJSON(output), annotations: nil, _meta: nil)])
                 case "get_task":
                     let id = try decodeArgument(String.self, from: params.arguments, key: "id") ?? ""
                     if id.isEmpty {
-                        return .init(content: [.text("Missing id")], isError: true)
+                        return .init(content: [.text(text: "Missing id", annotations: nil, _meta: nil)], isError: true)
                     }
                     let requestedFields = decodeStringArray(params.arguments?["fields"]) ?? []
                     let fields = requestedFields.isEmpty ? ["id", "name"] : requestedFields
                     let result = try await service.getTask(id: id, fields: fields)
                     let fieldSet = Set(fields)
                     let output = makeTaskOutput(from: result, fields: fieldSet)
-                    return .init(content: [.text(try encodeJSON(output))])
+                    return .init(content: [.text(text: try encodeJSON(output), annotations: nil, _meta: nil)])
                 case "list_projects":
                     let page = try decodePageRequest(from: params)
                     let statusFilter = try decodeArgument(String.self, from: params.arguments, key: "statusFilter") ?? "active"
@@ -771,7 +771,7 @@ public enum FocusRelayServer {
                     let fieldSet = Set(fields)
                     let items = result.items.map { makeProjectOutput(from: $0, fields: fieldSet, includeTaskCounts: includeTaskCounts) }
                     let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount, warnings: result.warnings)
-                    return .init(content: [.text(try encodeJSON(output))])
+                    return .init(content: [.text(text: try encodeJSON(output), annotations: nil, _meta: nil)])
                 case "list_tags":
                     let page = try decodePageRequest(from: params)
                     let statusFilter = try decodeArgument(String.self, from: params.arguments, key: "statusFilter") ?? "active"
@@ -780,7 +780,7 @@ public enum FocusRelayServer {
                     let fieldSet = Set(["id", "name", "status", "availableTasks", "remainingTasks", "totalTasks"])
                     let items = result.items.map { makeTagOutput(from: $0, fields: fieldSet, includeTaskCounts: includeTaskCounts) }
                     let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount, warnings: result.warnings)
-                    return .init(content: [.text(try encodeJSON(output))])
+                    return .init(content: [.text(text: try encodeJSON(output), annotations: nil, _meta: nil)])
                 case "list_folders":
                     let page = try decodePageRequest(from: params)
                     let requestedFields = decodeStringArray(params.arguments?["fields"]) ?? []
@@ -789,7 +789,7 @@ public enum FocusRelayServer {
                     let fieldSet = Set(fields)
                     let items = result.items.map { makeFolderOutput(from: $0, fields: fieldSet) }
                     let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount, warnings: result.warnings)
-                    return .init(content: [.text(try encodeJSON(output))])
+                    return .init(content: [.text(text: try encodeJSON(output), annotations: nil, _meta: nil)])
                 case "update_tasks":
                     let targetIDs = try decodeArgument([String].self, from: params.arguments, key: "targetIDs") ?? []
                     let taskPatch = try decodeArgument(TaskPatchMutation.self, from: params.arguments, key: "taskPatch")
@@ -808,7 +808,7 @@ public enum FocusRelayServer {
                         returnFields: returnFields
                     )
                     let result = try await service.performMutation(request)
-                    return .init(content: [.text(try encodeJSON(result))])
+                    return .init(content: [.text(text: try encodeJSON(result), annotations: nil, _meta: nil)])
                 case "set_tasks_completion":
                     let targetIDs = try decodeArgument([String].self, from: params.arguments, key: "targetIDs") ?? []
                     let completion = try decodeArgument(CompletionMutation.self, from: params.arguments, key: "completion")
@@ -827,7 +827,7 @@ public enum FocusRelayServer {
                         returnFields: returnFields
                     )
                     let result = try await service.performMutation(request)
-                    return .init(content: [.text(try encodeJSON(result))])
+                    return .init(content: [.text(text: try encodeJSON(result), annotations: nil, _meta: nil)])
                 case "move_tasks":
                     let targetIDs = try decodeArgument([String].self, from: params.arguments, key: "targetIDs") ?? []
                     let move = try decodeArgument(MoveMutation.self, from: params.arguments, key: "move")
@@ -846,7 +846,7 @@ public enum FocusRelayServer {
                         returnFields: returnFields
                     )
                     let result = try await service.performMutation(request)
-                    return .init(content: [.text(try encodeJSON(result))])
+                    return .init(content: [.text(text: try encodeJSON(result), annotations: nil, _meta: nil)])
                 case "update_projects":
                     let targetIDs = try decodeArgument([String].self, from: params.arguments, key: "targetIDs") ?? []
                     let projectPatch = try decodeArgument(ProjectPatchMutation.self, from: params.arguments, key: "projectPatch")
@@ -865,7 +865,7 @@ public enum FocusRelayServer {
                         returnFields: returnFields
                     )
                     let result = try await service.performMutation(request)
-                    return .init(content: [.text(try encodeJSON(result))])
+                    return .init(content: [.text(text: try encodeJSON(result), annotations: nil, _meta: nil)])
                 case "set_projects_status":
                     let targetIDs = try decodeArgument([String].self, from: params.arguments, key: "targetIDs") ?? []
                     let projectStatus = try decodeArgument(ProjectStatusMutation.self, from: params.arguments, key: "projectStatus")
@@ -884,7 +884,7 @@ public enum FocusRelayServer {
                         returnFields: returnFields
                     )
                     let result = try await service.performMutation(request)
-                    return .init(content: [.text(try encodeJSON(result))])
+                    return .init(content: [.text(text: try encodeJSON(result), annotations: nil, _meta: nil)])
                 case "set_projects_completion":
                     let targetIDs = try decodeArgument([String].self, from: params.arguments, key: "targetIDs") ?? []
                     let completion = try decodeArgument(CompletionMutation.self, from: params.arguments, key: "completion")
@@ -903,7 +903,7 @@ public enum FocusRelayServer {
                         returnFields: returnFields
                     )
                     let result = try await service.performMutation(request)
-                    return .init(content: [.text(try encodeJSON(result))])
+                    return .init(content: [.text(text: try encodeJSON(result), annotations: nil, _meta: nil)])
                 case "move_projects":
                     let targetIDs = try decodeArgument([String].self, from: params.arguments, key: "targetIDs") ?? []
                     let move = try decodeArgument(MoveMutation.self, from: params.arguments, key: "move")
@@ -922,21 +922,21 @@ public enum FocusRelayServer {
                         returnFields: returnFields
                     )
                     let result = try await service.performMutation(request)
-                    return .init(content: [.text(try encodeJSON(result))])
+                    return .init(content: [.text(text: try encodeJSON(result), annotations: nil, _meta: nil)])
                 case "get_task_counts":
                     let filter = try decodeArgument(TaskFilter.self, from: params.arguments, key: "filter") ?? TaskFilter()
                     let counts = try await service.getTaskCounts(filter: filter)
-                    return .init(content: [.text(try encodeJSON(counts))])
+                    return .init(content: [.text(text: try encodeJSON(counts), annotations: nil, _meta: nil)])
                 case "get_project_counts":
                     let filter = try decodeArgument(TaskFilter.self, from: params.arguments, key: "filter") ?? TaskFilter()
                     let counts = try await service.getProjectCounts(filter: filter)
-                    return .init(content: [.text(try encodeJSON(counts))])
+                    return .init(content: [.text(text: try encodeJSON(counts), annotations: nil, _meta: nil)])
                 default:
-                    return .init(content: [.text("Unknown tool: \(params.name)")], isError: true)
+                    return .init(content: [.text(text: "Unknown tool: \(params.name)", annotations: nil, _meta: nil)], isError: true)
                 }
             } catch {
                 logger.error("Tool call failed: \(error.localizedDescription)")
-                return .init(content: [.text("Error: \(error.localizedDescription)")], isError: true)
+                return .init(content: [.text(text: "Error: \(error.localizedDescription)", annotations: nil, _meta: nil)], isError: true)
             }
         }
 


### PR DESCRIPTION
Closes #75

## Summary
- raise the official Swift MCP SDK dependency floor to 0.12.1
- pin `Package.resolved` to the official 0.12.1 revision
- migrate all production tool responses from deprecated `Content.text(_:)` construction
- preserve response text, JSON payloads, ordering, and error flags

## Validation
- `swift package resolve`
- `swift run focusrelay-dev validate --impact server-wire` (139 tests and clean release build)
- direct stdio MCP initialize and `tools/list` (14 tools)
- direct successful `list_tasks`, validation-error `get_task`, and unknown-tool calls with expected wire shapes
- rebuilt release binary Bridge health and compact `list_tasks` smoke
- `git diff --check`

## SDK Review
The 0.12.0...0.12.1 shared `Server` change adds optional HTTP handler context. `StdioTransport` is unchanged and does not provide HTTP context, so FocusRelay stdio dispatch semantics are unaffected.