### PR TITLE
Consolidate task and project edit commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,8 @@ focusrelay list-tasks \
   --fields name
 
 # Preview a change without touching OmniFocus
-focusrelay update-tasks <task-id> \
+focusrelay edit-tasks <task-id> \
+  --operation update \
   --flagged true \
   --preview-only \
   --return-fields id,name,flagged
@@ -234,7 +235,7 @@ and applies changes through documented OmniFocus APIs.
 | --- | --- | --- | --- | --- | --- |
 | Runtime | **Native Swift · Homebrew** | TypeScript · npx | TypeScript · npx | Native Rust · Homebrew; Python and TypeScript available | Python · uvx |
 | OmniFocus access | **Bridge plug-in inside Omni Automation; documented APIs** | JXA and Omni Automation through `osascript` | Omni Automation through `osascript` | Omni Automation through `osascript` | Internal SQLite read cache; OmniJS fallback |
-| Public MCP tools | **14 → 11 after [#91](https://github.com/deverman/FocusRelayMCP/issues/91), [#82](https://github.com/deverman/FocusRelayMCP/issues/82), and [#83](https://github.com/deverman/FocusRelayMCP/issues/83)** | 12 | 18 | 45 | 11 |
+| Public MCP tools | **9 after [#91](https://github.com/deverman/FocusRelayMCP/issues/91); 11 after planned creation tools [#82](https://github.com/deverman/FocusRelayMCP/issues/82) and [#83](https://github.com/deverman/FocusRelayMCP/issues/83)** | 12 | 18 | 45 | 11 |
 | Find, filter, and count tasks | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Update existing tasks | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Update existing projects | ✅ | ✅ | ✅ | ✅ | ◇ v1.5 roadmap |

--- a/Sources/FocusRelayCLI/CLIHelpers.swift
+++ b/Sources/FocusRelayCLI/CLIHelpers.swift
@@ -5,6 +5,8 @@ import OmniFocusCore
 extension MutationCompletionState: ExpressibleByArgument {}
 extension MutationMoveDestinationKind: ExpressibleByArgument {}
 extension MutationProjectStatus: ExpressibleByArgument {}
+extension TaskEditOperation: ExpressibleByArgument {}
+extension ProjectEditOperation: ExpressibleByArgument {}
 
 enum FieldList {
     static func parse(_ raw: String?) -> [String] {

--- a/Sources/FocusRelayCLI/FocusRelayCLI.swift
+++ b/Sources/FocusRelayCLI/FocusRelayCLI.swift
@@ -16,13 +16,8 @@ struct FocusRelayCLI: AsyncParsableCommand {
             ListProjects.self,
             ListTags.self,
             ListFolders.self,
-            UpdateTasks.self,
-            SetTasksCompletion.self,
-            MoveTasks.self,
-            UpdateProjects.self,
-            SetProjectsStatus.self,
-            SetProjectsCompletion.self,
-            MoveProjects.self,
+            EditTasks.self,
+            EditProjects.self,
             TaskCounts.self,
             ProjectCounts.self,
             BridgeHealthCheck.self
@@ -234,105 +229,32 @@ struct ListFolders: AsyncParsableCommand {
     }
 }
 
-struct UpdateTasks: AsyncParsableCommand {
+struct EditTasks: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
-        commandName: "update-tasks",
-        abstract: "Apply one shared task patch to multiple task IDs.",
-        aliases: ["update_tasks"]
+        commandName: "edit-tasks",
+        abstract: "Update, complete/reopen, or move existing tasks by ID.",
+        aliases: ["edit_tasks"]
     )
 
-    @Argument(help: "Task IDs to update.")
+    @Argument(help: "Task IDs to edit.")
     var ids: [String] = []
+
+    @Option(help: "Operation: update, set_completion, or move.")
+    var operation: TaskEditOperation
 
     @OptionGroup var patch: TaskPatchOptions
 
-    @Flag(name: .customLong("preview-only"), help: "Validate and resolve targets without mutating.")
-    var previewOnly: Bool = false
+    @Option(help: "Completion state for set_completion: active or completed.")
+    var state: MutationCompletionState?
 
-    @Flag(help: "Verify the final state after mutation.")
-    var verify: Bool = false
-
-    @Option(name: .customLong("return-fields"), help: "Comma-separated task fields to include in per-item results.")
-    var returnFields: String?
-
-    func run() async throws {
-        let service = OmniFocusBridgeService()
-        let request = MutationRequest(
-            targetType: .task,
-            targetIDs: ids,
-            operation: MutationOperation(
-                kind: .updateTasks,
-                taskPatch: try patch.makeTaskPatchMutation()
-            ),
-            previewOnly: previewOnly,
-            verify: verify,
-            returnFields: FieldList.parse(returnFields)
-        )
-
-        let result = try await service.performMutation(request)
-        print(try encodeJSON(result))
-    }
-}
-
-struct SetTasksCompletion: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "set-tasks-completion",
-        abstract: "Apply one shared task completion state to multiple task IDs.",
-        aliases: ["set_tasks_completion"]
-    )
-
-    @Argument(help: "Task IDs to update.")
-    var ids: [String] = []
-
-    @Option(help: "Lifecycle state to apply: active or completed.")
-    var state: MutationCompletionState
-
-    @Flag(name: .customLong("preview-only"), help: "Validate and resolve targets without mutating.")
-    var previewOnly: Bool = false
-
-    @Flag(help: "Verify the final state after mutation.")
-    var verify: Bool = false
-
-    @Option(name: .customLong("return-fields"), help: "Comma-separated task fields to include in per-item results.")
-    var returnFields: String?
-
-    func run() async throws {
-        let service = OmniFocusBridgeService()
-        let request = MutationRequest(
-            targetType: .task,
-            targetIDs: ids,
-            operation: MutationOperation(
-                kind: .setTasksCompletion,
-                completion: CompletionMutation(state: state)
-            ),
-            previewOnly: previewOnly,
-            verify: verify,
-            returnFields: FieldList.parse(returnFields)
-        )
-
-        let result = try await service.performMutation(request)
-        print(try encodeJSON(result))
-    }
-}
-
-struct MoveTasks: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "move-tasks",
-        abstract: "Move or reparent multiple tasks to one shared destination.",
-        aliases: ["move_tasks"]
-    )
-
-    @Argument(help: "Task IDs to move.")
-    var ids: [String] = []
-
-    @Option(help: "Destination kind: inbox, project, or parent_task.")
-    var destinationKind: MutationMoveDestinationKind
+    @Option(help: "Destination kind for move: inbox, project, or parent_task.")
+    var destinationKind: MutationMoveDestinationKind?
 
     @Option(help: "Destination ID for project or parent_task moves.")
     var destinationID: String?
 
-    @Option(help: "Placement within the destination: beginning or ending.")
-    var position: String = "ending"
+    @Option(help: "Move placement: beginning or ending.")
+    var position: String?
 
     @Flag(name: .customLong("preview-only"), help: "Validate and resolve targets without mutating.")
     var previewOnly: Bool = false
@@ -343,169 +265,68 @@ struct MoveTasks: AsyncParsableCommand {
     @Option(name: .customLong("return-fields"), help: "Comma-separated task fields to include in per-item results.")
     var returnFields: String?
 
-    func run() async throws {
-        let service = OmniFocusBridgeService()
-        let request = MutationRequest(
-            targetType: .task,
+    func makeRequest() throws -> MutationRequest {
+        let taskPatch = try patch.makeTaskPatchMutation()
+        let hasMovePayload = destinationKind != nil || destinationID != nil || position != nil
+        let move: MoveMutation?
+        if hasMovePayload {
+            guard let destinationKind else {
+                throw ValidationError("Task moves require --destination-kind.")
+            }
+            move = MoveMutation(destinationKind: destinationKind, destinationID: destinationID, position: position)
+        } else {
+            move = nil
+        }
+
+        return try MutationRequest.editTasks(
             targetIDs: ids,
-            operation: MutationOperation(
-                kind: .moveTasks,
-                move: MoveMutation(
-                    destinationKind: destinationKind,
-                    destinationID: destinationID,
-                    position: position
-                )
-            ),
+            operation: operation,
+            taskPatch: taskPatch.isEmpty ? nil : taskPatch,
+            completion: state.map(CompletionMutation.init(state:)),
+            move: move,
             previewOnly: previewOnly,
             verify: verify,
             returnFields: FieldList.parse(returnFields)
         )
+    }
 
+    func run() async throws {
+        let service = OmniFocusBridgeService()
+        let request = try makeRequest()
         let result = try await service.performMutation(request)
         print(try encodeJSON(result))
     }
 }
 
-struct UpdateProjects: AsyncParsableCommand {
+struct EditProjects: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
-        commandName: "update-projects",
-        abstract: "Apply one shared project patch to multiple project IDs.",
-        aliases: ["update_projects"]
+        commandName: "edit-projects",
+        abstract: "Update, change status/completion, or move existing projects by ID.",
+        aliases: ["edit_projects"]
     )
 
-    @Argument(help: "Project IDs to update.")
+    @Argument(help: "Project IDs to edit.")
     var ids: [String] = []
+
+    @Option(help: "Operation: update, set_status, set_completion, or move.")
+    var operation: ProjectEditOperation
 
     @OptionGroup var patch: ProjectPatchOptions
 
-    @Flag(name: .customLong("preview-only"), help: "Validate and resolve targets without mutating.")
-    var previewOnly: Bool = false
+    @Option(help: "Project status for set_status: active, on_hold, or dropped.")
+    var status: MutationProjectStatus?
 
-    @Flag(help: "Verify the final state after mutation.")
-    var verify: Bool = false
+    @Option(help: "Completion state for set_completion: active or completed.")
+    var state: MutationCompletionState?
 
-    @Option(name: .customLong("return-fields"), help: "Comma-separated project fields to include in per-item results.")
-    var returnFields: String?
+    @Option(help: "Destination kind for move: folder.")
+    var destinationKind: MutationMoveDestinationKind?
 
-    func run() async throws {
-        let service = OmniFocusBridgeService()
-        let request = MutationRequest(
-            targetType: .project,
-            targetIDs: ids,
-            operation: MutationOperation(
-                kind: .updateProjects,
-                projectPatch: try patch.makeProjectPatchMutation()
-            ),
-            previewOnly: previewOnly,
-            verify: verify,
-            returnFields: FieldList.parse(returnFields)
-        )
-
-        let result = try await service.performMutation(request)
-        print(try encodeJSON(result))
-    }
-}
-
-struct SetProjectsStatus: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "set-projects-status",
-        abstract: "Apply one shared project status to multiple project IDs.",
-        aliases: ["set_projects_status"]
-    )
-
-    @Argument(help: "Project IDs to update.")
-    var ids: [String] = []
-
-    @Option(help: "Project status to apply: active, on_hold, or dropped.")
-    var status: MutationProjectStatus
-
-    @Flag(name: .customLong("preview-only"), help: "Validate and resolve targets without mutating.")
-    var previewOnly: Bool = false
-
-    @Flag(help: "Verify the final state after mutation.")
-    var verify: Bool = false
-
-    @Option(name: .customLong("return-fields"), help: "Comma-separated project fields to include in per-item results.")
-    var returnFields: String?
-
-    func run() async throws {
-        let service = OmniFocusBridgeService()
-        let request = MutationRequest(
-            targetType: .project,
-            targetIDs: ids,
-            operation: MutationOperation(
-                kind: .setProjectsStatus,
-                projectStatus: ProjectStatusMutation(status: status)
-            ),
-            previewOnly: previewOnly,
-            verify: verify,
-            returnFields: FieldList.parse(returnFields)
-        )
-
-        let result = try await service.performMutation(request)
-        print(try encodeJSON(result))
-    }
-}
-
-struct SetProjectsCompletion: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "set-projects-completion",
-        abstract: "Apply one shared project completion state to multiple project IDs.",
-        aliases: ["set_projects_completion"]
-    )
-
-    @Argument(help: "Project IDs to update.")
-    var ids: [String] = []
-
-    @Option(help: "Lifecycle state to apply: active or completed.")
-    var state: MutationCompletionState
-
-    @Flag(name: .customLong("preview-only"), help: "Validate and resolve targets without mutating.")
-    var previewOnly: Bool = false
-
-    @Flag(help: "Verify the final state after mutation.")
-    var verify: Bool = false
-
-    @Option(name: .customLong("return-fields"), help: "Comma-separated project fields to include in per-item results.")
-    var returnFields: String?
-
-    func run() async throws {
-        let service = OmniFocusBridgeService()
-        let request = MutationRequest(
-            targetType: .project,
-            targetIDs: ids,
-            operation: MutationOperation(
-                kind: .setProjectsCompletion,
-                completion: CompletionMutation(state: state)
-            ),
-            previewOnly: previewOnly,
-            verify: verify,
-            returnFields: FieldList.parse(returnFields)
-        )
-
-        let result = try await service.performMutation(request)
-        print(try encodeJSON(result))
-    }
-}
-
-struct MoveProjects: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "move-projects",
-        abstract: "Move multiple projects to one shared folder or the root library.",
-        aliases: ["move_projects"]
-    )
-
-    @Argument(help: "Project IDs to move.")
-    var ids: [String] = []
-
-    @Option(help: "Destination kind: folder. Omit destination-id to move to the root library.")
-    var destinationKind: MutationMoveDestinationKind = .folder
-
-    @Option(help: "Destination folder ID from list-folders. Omit to move to the root library.")
+    @Option(help: "Destination folder ID. Omit for a root-library move.")
     var destinationID: String?
 
-    @Option(help: "Placement within the destination: beginning or ending.")
-    var position: String = "ending"
+    @Option(help: "Move placement: beginning or ending.")
+    var position: String?
 
     @Flag(name: .customLong("preview-only"), help: "Validate and resolve targets without mutating.")
     var previewOnly: Bool = false
@@ -516,24 +337,35 @@ struct MoveProjects: AsyncParsableCommand {
     @Option(name: .customLong("return-fields"), help: "Comma-separated project fields to include in per-item results.")
     var returnFields: String?
 
-    func run() async throws {
-        let service = OmniFocusBridgeService()
-        let request = MutationRequest(
-            targetType: .project,
+    func makeRequest() throws -> MutationRequest {
+        let projectPatch = try patch.makeProjectPatchMutation()
+        let hasMovePayload = destinationKind != nil || destinationID != nil || position != nil
+        let move: MoveMutation?
+        if hasMovePayload {
+            guard let destinationKind else {
+                throw ValidationError("Project moves require --destination-kind folder.")
+            }
+            move = MoveMutation(destinationKind: destinationKind, destinationID: destinationID, position: position)
+        } else {
+            move = nil
+        }
+
+        return try MutationRequest.editProjects(
             targetIDs: ids,
-            operation: MutationOperation(
-                kind: .moveProjects,
-                move: MoveMutation(
-                    destinationKind: destinationKind,
-                    destinationID: destinationID,
-                    position: position
-                )
-            ),
+            operation: operation,
+            projectPatch: projectPatch.isEmpty ? nil : projectPatch,
+            projectStatus: status.map(ProjectStatusMutation.init(status:)),
+            completion: state.map(CompletionMutation.init(state:)),
+            move: move,
             previewOnly: previewOnly,
             verify: verify,
             returnFields: FieldList.parse(returnFields)
         )
+    }
 
+    func run() async throws {
+        let service = OmniFocusBridgeService()
+        let request = try makeRequest()
         let result = try await service.performMutation(request)
         print(try encodeJSON(result))
     }

--- a/Sources/FocusRelayServer/FocusRelayServer.swift
+++ b/Sources/FocusRelayServer/FocusRelayServer.swift
@@ -26,26 +26,46 @@ public enum FocusRelayServer {
         "list_projects",
         "list_tags",
         "list_folders",
-        "update_tasks",
-        "set_tasks_completion",
-        "move_tasks",
-        "update_projects",
-        "set_projects_status",
-        "set_projects_completion",
-        "move_projects",
+        "edit_tasks",
+        "edit_projects",
         "get_task_counts",
         "get_project_counts"
     ]
 
     static let mutationToolNames: Set<String> = [
-        "update_tasks",
-        "set_tasks_completion",
-        "move_tasks",
-        "update_projects",
-        "set_projects_status",
-        "set_projects_completion",
-        "move_projects"
+        "edit_tasks",
+        "edit_projects"
     ]
+
+    static let mutationToolAnnotations = Tool.Annotations(
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false
+    )
+
+    static func makeTaskEditSchema(properties: [String: Value]) -> Value {
+        discriminatedToolSchema(
+            properties: properties,
+            operationPayloads: [
+                "update": "taskPatch",
+                "set_completion": "completion",
+                "move": "move"
+            ]
+        )
+    }
+
+    static func makeProjectEditSchema(properties: [String: Value]) -> Value {
+        discriminatedToolSchema(
+            properties: properties,
+            operationPayloads: [
+                "update": "projectPatch",
+                "set_status": "projectStatus",
+                "set_completion": "completion",
+                "move": "move"
+            ]
+        )
+    }
 
     static let listProjectsToolDescription = """
     List OmniFocus projects with pagination and filtering. Projects have a status (active, onHold, dropped, done) and can optionally include child-task counts.
@@ -352,7 +372,7 @@ public enum FocusRelayServer {
                 ),
                 Tool(
                     name: "list_folders",
-                    description: "List OmniFocus folders with pagination for project move destination discovery. Use this before move_projects when moving projects into a folder. Compact default fields are id and name; request parentID, parentName, projectCount, or childFolderCount when needed.",
+                    description: "List OmniFocus folders with pagination for project move destination discovery. Use this before edit_projects with operation=move when moving projects into a folder. Compact default fields are id and name; request parentID, parentName, projectCount, or childFolderCount when needed.",
                     inputSchema: toolSchema(
                         properties: [
                             "page": .object([
@@ -372,10 +392,15 @@ public enum FocusRelayServer {
                     annotations: .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false)
                 ),
                 Tool(
-                    name: "update_tasks",
-                    description: "Apply one shared task field patch to multiple task IDs. Supports name, note replace, note append, flagged, estimated minutes, due date set/clear, defer date set/clear, and deterministic tag add/remove/set/clear operations.\n\nV1 constraints:\n- task IDs only\n- one shared patch for all targets\n- no completion changes\n- no moves/reparenting\n- no plannedDate writes\n\nSet previewOnly=true to validate without mutating. When false or omitted, this tool writes immediately. Use verify=true to confirm the final state. Use returnFields to request compact post-write task fields in the per-item results.",
-                    inputSchema: toolSchema(
+                    name: "edit_tasks",
+                    description: "Edit existing OmniFocus tasks by ID. Choose exactly one operation and include only its matching payload: update with taskPatch, set_completion with completion, or move with move. One call applies the same operation and payload to every target.\n\nUse update for fields and tags, set_completion only for complete/reopen, and move for inbox/project/parent changes. Dropping, discarding, abandoning, or cancelling tasks is not supported and must not be treated as completion. No plannedDate writes.\n\nSet previewOnly=true to validate without writing. Use verify=true for post-write readback. Repeating completion may advance the original task.",
+                    inputSchema: makeTaskEditSchema(
                         properties: [
+                            "operation": .object([
+                                "type": .string("string"),
+                                "enum": .array([.string("update"), .string("set_completion"), .string("move")]),
+                                "description": .string("Required edit operation. Include exactly one matching payload.")
+                            ]),
                             "targetIDs": .object([
                                 "type": .string("array"),
                                 "description": .string("Task IDs to update."),
@@ -406,78 +431,33 @@ public enum FocusRelayServer {
                                     ])
                                 ])
                             ]),
-                            "previewOnly": propertySchema(type: "boolean", description: "When true, validate and resolve targets without mutating. False or omitted performs the write.", defaultValue: .bool(false)),
-                            "verify": propertySchema(type: "boolean", description: "When true, read back and verify the final state after a write. Defaults to false.", defaultValue: .bool(false)),
-                            "returnFields": .object([
-                                "type": .string("array"),
-                                "description": .string("Optional task fields to return in per-item results after mutation."),
-                                "items": .object(["type": .string("string")])
-                            ])
-                        ],
-                        required: ["targetIDs", "taskPatch"]
-                    ),
-                    annotations: .init(readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false)
-                ),
-                Tool(
-                    name: "set_tasks_completion",
-                    description: "Apply one shared lifecycle state to multiple task IDs. This tool owns task complete and uncomplete behavior and keeps lifecycle semantics out of update_tasks.\n\nV1 constraints:\n- task IDs only\n- one shared state for all targets\n- supported states: active, completed\n- no field edits\n- no moves/reparenting\n\nSet previewOnly=true to validate without mutating. When false or omitted, this tool writes immediately. Use verify=true to confirm the final state. For repeating tasks, OmniFocus completes a generated occurrence and advances the original task, so result messages may describe that special case.",
-                    inputSchema: toolSchema(
-                        properties: [
-                            "targetIDs": .object([
-                                "type": .string("array"),
-                                "description": .string("Task IDs to change."),
-                                "items": .object(["type": .string("string")])
-                            ]),
                             "completion": .object([
                                 "type": .string("object"),
-                                "description": .string("Shared completion payload applied to every task ID in targetIDs."),
+                                "description": .string("Required only for operation=set_completion. Never use completion to drop a task."),
                                 "properties": .object([
                                     "state": .object([
                                         "type": .string("string"),
-                                        "enum": .array([.string("active"), .string("completed")]),
-                                        "description": .string("Lifecycle state to apply.")
+                                        "enum": .array([.string("active"), .string("completed")])
                                     ])
-                                ])
-                            ]),
-                            "previewOnly": propertySchema(type: "boolean", description: "When true, validate and resolve targets without mutating. False or omitted performs the write.", defaultValue: .bool(false)),
-                            "verify": propertySchema(type: "boolean", description: "When true, read back and verify the final state after a write. Defaults to false.", defaultValue: .bool(false)),
-                            "returnFields": .object([
-                                "type": .string("array"),
-                                "description": .string("Optional task fields to return in per-item results after mutation."),
-                                "items": .object(["type": .string("string")])
-                            ])
-                        ],
-                        required: ["targetIDs", "completion"]
-                    ),
-                    annotations: .init(readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false)
-                ),
-                Tool(
-                    name: "move_tasks",
-                    description: "Move or reparent multiple task IDs to one shared destination. This tool owns structural task relocation and keeps move semantics out of update_tasks.\n\nV1 constraints:\n- task IDs only\n- one shared destination for all targets\n- supported destination kinds: inbox, project, parent_task\n- supported placement values: beginning, ending\n- no field edits\n- no completion changes\n\nSet previewOnly=true to validate without mutating. When false or omitted, this tool writes immediately. Use verify=true to confirm the final state after the move.",
-                    inputSchema: toolSchema(
-                        properties: [
-                            "targetIDs": .object([
-                                "type": .string("array"),
-                                "description": .string("Task IDs to move."),
-                                "items": .object(["type": .string("string")])
+                                ]),
+                                "required": .array([.string("state")])
                             ]),
                             "move": .object([
                                 "type": .string("object"),
-                                "description": .string("Shared move payload applied to every task ID in targetIDs."),
+                                "description": .string("Required only for operation=move. Shared task destination."),
                                 "properties": .object([
                                     "destinationKind": .object([
                                         "type": .string("string"),
-                                        "enum": .array([.string("inbox"), .string("project"), .string("parent_task")]),
-                                        "description": .string("Destination kind.")
+                                        "enum": .array([.string("inbox"), .string("project"), .string("parent_task")])
                                     ]),
-                                    "destinationID": propertySchema(type: "string", description: "Destination project ID or parent task ID. Omit for inbox moves."),
+                                    "destinationID": propertySchema(type: "string", description: "Project or parent task ID. Omit for inbox moves."),
                                     "position": .object([
                                         "type": .string("string"),
                                         "enum": .array([.string("beginning"), .string("ending")]),
-                                        "description": .string("Placement inside the destination."),
                                         "default": .string("ending")
                                     ])
-                                ])
+                                ]),
+                                "required": .array([.string("destinationKind")])
                             ]),
                             "previewOnly": propertySchema(type: "boolean", description: "When true, validate and resolve targets without mutating. False or omitted performs the write.", defaultValue: .bool(false)),
                             "verify": propertySchema(type: "boolean", description: "When true, read back and verify the final state after a write. Defaults to false.", defaultValue: .bool(false)),
@@ -486,16 +466,20 @@ public enum FocusRelayServer {
                                 "description": .string("Optional task fields to return in per-item results after mutation."),
                                 "items": .object(["type": .string("string")])
                             ])
-                        ],
-                        required: ["targetIDs", "move"]
+                        ]
                     ),
-                    annotations: .init(readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false)
+                    annotations: mutationToolAnnotations
                 ),
                 Tool(
-                    name: "update_projects",
-                    description: "Apply one shared project field patch to multiple project IDs. Supports name, note replace, note append, flagged, due date set/clear, defer date set/clear, sequential state, and review interval updates.\n\nV1 constraints:\n- project IDs only\n- one shared patch for all targets\n- no status changes\n- no completion changes\n- no folder moves\n- no tag or containsSingletonActions writes\n\nSet previewOnly=true to validate without mutating. When false or omitted, this tool writes immediately. Use verify=true to confirm the final state. Use returnFields to request compact post-write project fields in the per-item results.",
-                    inputSchema: toolSchema(
+                    name: "edit_projects",
+                    description: "Edit existing OmniFocus projects by ID. Choose exactly one operation and include only its matching payload: update with projectPatch, set_status with projectStatus, set_completion with completion, or move with move. One call applies the same operation and payload to every target.\n\nUse set_status for active/on-hold/dropped and set_completion for complete/reopen. Use list_folders before a folder move when its ID is unknown; omit destinationID for the root library. Project tags and containsSingletonActions writes are not supported.\n\nSet previewOnly=true to validate without writing. Use verify=true for post-write readback. Repeating completion may advance the original project.",
+                    inputSchema: makeProjectEditSchema(
                         properties: [
+                            "operation": .object([
+                                "type": .string("string"),
+                                "enum": .array([.string("update"), .string("set_status"), .string("set_completion"), .string("move")]),
+                                "description": .string("Required edit operation. Include exactly one matching payload.")
+                            ]),
                             "targetIDs": .object([
                                 "type": .string("array"),
                                 "description": .string("Project IDs to update."),
@@ -524,111 +508,44 @@ public enum FocusRelayServer {
                                     ])
                                 ])
                             ]),
-                            "previewOnly": propertySchema(type: "boolean", description: "When true, validate and resolve targets without mutating. False or omitted performs the write.", defaultValue: .bool(false)),
-                            "verify": propertySchema(type: "boolean", description: "When true, read back and verify the final state after a write. Defaults to false.", defaultValue: .bool(false)),
-                            "returnFields": .object([
-                                "type": .string("array"),
-                                "description": .string("Optional project fields to return in per-item results after mutation."),
-                                "items": .object(["type": .string("string")])
-                            ])
-                        ],
-                        required: ["targetIDs", "projectPatch"]
-                    ),
-                    annotations: .init(readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false)
-                ),
-                Tool(
-                    name: "set_projects_status",
-                    description: "Apply one shared project status to multiple project IDs. This tool owns project status transitions and keeps lifecycle/status semantics out of update_projects.\n\nV1 constraints:\n- project IDs only\n- one shared status for all targets\n- supported statuses: active, on_hold, dropped\n- no field edits\n- no completion changes\n- no folder moves\n\nSet previewOnly=true to validate without mutating. When false or omitted, this tool writes immediately. Use verify=true to confirm the final state.",
-                    inputSchema: toolSchema(
-                        properties: [
-                            "targetIDs": .object([
-                                "type": .string("array"),
-                                "description": .string("Project IDs to change."),
-                                "items": .object(["type": .string("string")])
-                            ]),
                             "projectStatus": .object([
                                 "type": .string("object"),
-                                "description": .string("Shared project status payload applied to every project ID in targetIDs."),
+                                "description": .string("Required only for operation=set_status."),
                                 "properties": .object([
                                     "status": .object([
                                         "type": .string("string"),
-                                        "enum": .array([.string("active"), .string("on_hold"), .string("dropped")]),
-                                        "description": .string("Project status to apply.")
+                                        "enum": .array([.string("active"), .string("on_hold"), .string("dropped")])
                                     ])
-                                ])
-                            ]),
-                            "previewOnly": propertySchema(type: "boolean", description: "When true, validate and resolve targets without mutating. False or omitted performs the write.", defaultValue: .bool(false)),
-                            "verify": propertySchema(type: "boolean", description: "When true, read back and verify the final state after a write. Defaults to false.", defaultValue: .bool(false)),
-                            "returnFields": .object([
-                                "type": .string("array"),
-                                "description": .string("Optional project fields to return in per-item results after mutation."),
-                                "items": .object(["type": .string("string")])
-                            ])
-                        ],
-                        required: ["targetIDs", "projectStatus"]
-                    ),
-                    annotations: .init(readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false)
-                ),
-                Tool(
-                    name: "set_projects_completion",
-                    description: "Apply one shared lifecycle state to multiple project IDs. This tool owns project complete and uncomplete behavior and keeps lifecycle semantics out of update_projects and set_projects_status.\n\nV1 constraints:\n- project IDs only\n- one shared state for all targets\n- supported states: active, completed\n- no field edits\n- no status-only transitions\n- no folder moves\n\nSet previewOnly=true to validate without mutating. When false or omitted, this tool writes immediately. Use verify=true to confirm the final state. For repeating projects, OmniFocus completes a generated project occurrence and advances the original project, so result messages may describe that special case.",
-                    inputSchema: toolSchema(
-                        properties: [
-                            "targetIDs": .object([
-                                "type": .string("array"),
-                                "description": .string("Project IDs to change."),
-                                "items": .object(["type": .string("string")])
+                                ]),
+                                "required": .array([.string("status")])
                             ]),
                             "completion": .object([
                                 "type": .string("object"),
-                                "description": .string("Shared completion payload applied to every project ID in targetIDs."),
+                                "description": .string("Required only for operation=set_completion."),
                                 "properties": .object([
                                     "state": .object([
                                         "type": .string("string"),
-                                        "enum": .array([.string("active"), .string("completed")]),
-                                        "description": .string("Lifecycle state to apply.")
+                                        "enum": .array([.string("active"), .string("completed")])
                                     ])
-                                ])
-                            ]),
-                            "previewOnly": propertySchema(type: "boolean", description: "When true, validate and resolve targets without mutating. False or omitted performs the write.", defaultValue: .bool(false)),
-                            "verify": propertySchema(type: "boolean", description: "When true, read back and verify the final state after a write. Defaults to false.", defaultValue: .bool(false)),
-                            "returnFields": .object([
-                                "type": .string("array"),
-                                "description": .string("Optional project fields to return in per-item results after mutation."),
-                                "items": .object(["type": .string("string")])
-                            ])
-                        ],
-                        required: ["targetIDs", "completion"]
-                    ),
-                    annotations: .init(readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false)
-                ),
-                Tool(
-                    name: "move_projects",
-                    description: "Move multiple project IDs to one shared folder or the root library. Use list_folders first when the destination folder ID is not already known. This tool owns structural project relocation and keeps folder moves out of update_projects.\n\nV1 constraints:\n- project IDs only\n- one shared destination for all targets\n- supported destination kind: folder\n- omit destinationID to move to the root library\n- supported placement values: beginning, ending\n- no field edits\n- no status changes\n- no completion changes\n\nSet previewOnly=true to validate without mutating. When false or omitted, this tool writes immediately. Use verify=true to confirm the final state after the move.",
-                    inputSchema: toolSchema(
-                        properties: [
-                            "targetIDs": .object([
-                                "type": .string("array"),
-                                "description": .string("Project IDs to move."),
-                                "items": .object(["type": .string("string")])
+                                ]),
+                                "required": .array([.string("state")])
                             ]),
                             "move": .object([
                                 "type": .string("object"),
-                                "description": .string("Shared move payload applied to every project ID in targetIDs."),
+                                "description": .string("Required only for operation=move. Omit destinationID for the root library."),
                                 "properties": .object([
                                     "destinationKind": .object([
                                         "type": .string("string"),
-                                        "enum": .array([.string("folder")]),
-                                        "description": .string("Destination kind. Use folder for both folder and root-library project moves.")
+                                        "enum": .array([.string("folder")])
                                     ]),
-                                    "destinationID": propertySchema(type: "string", description: "Destination folder ID from list_folders. Omit to move projects to the root library."),
+                                    "destinationID": propertySchema(type: "string", description: "Destination folder ID from list_folders."),
                                     "position": .object([
                                         "type": .string("string"),
                                         "enum": .array([.string("beginning"), .string("ending")]),
-                                        "description": .string("Placement inside the folder or root library."),
                                         "default": .string("ending")
                                     ])
-                                ])
+                                ]),
+                                "required": .array([.string("destinationKind")])
                             ]),
                             "previewOnly": propertySchema(type: "boolean", description: "When true, validate and resolve targets without mutating. False or omitted performs the write.", defaultValue: .bool(false)),
                             "verify": propertySchema(type: "boolean", description: "When true, read back and verify the final state after a write. Defaults to false.", defaultValue: .bool(false)),
@@ -637,10 +554,9 @@ public enum FocusRelayServer {
                                 "description": .string("Optional project fields to return in per-item results after mutation."),
                                 "items": .object(["type": .string("string")])
                             ])
-                        ],
-                        required: ["targetIDs", "move"]
+                        ]
                     ),
-                    annotations: .init(readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false)
+                    annotations: mutationToolAnnotations
                 ),
                 Tool(
                     name: "get_task_counts",
@@ -708,6 +624,10 @@ public enum FocusRelayServer {
                 defer {
                     let elapsed = Date().timeIntervalSince(toolStart)
                     logger.info("Tool \(params.name) completed in \(String(format: "%.3f", elapsed))s")
+                }
+
+                guard publicToolNames.contains(params.name) else {
+                    return .init(content: [.text(text: "Unknown tool: \(params.name)", annotations: nil, _meta: nil)], isError: true)
                 }
 
                 switch params.name {
@@ -790,137 +710,12 @@ public enum FocusRelayServer {
                     let items = result.items.map { makeFolderOutput(from: $0, fields: fieldSet) }
                     let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount, warnings: result.warnings)
                     return .init(content: [.text(text: try encodeJSON(output), annotations: nil, _meta: nil)])
-                case "update_tasks":
-                    let targetIDs = try decodeArgument([String].self, from: params.arguments, key: "targetIDs") ?? []
-                    let taskPatch = try decodeArgument(TaskPatchMutation.self, from: params.arguments, key: "taskPatch")
-                    let previewOnly = try decodeArgument(Bool.self, from: params.arguments, key: "previewOnly") ?? false
-                    let verify = try decodeArgument(Bool.self, from: params.arguments, key: "verify") ?? false
-                    let returnFields = decodeStringArray(params.arguments?["returnFields"])
-                    let request = MutationRequest(
-                        targetType: .task,
-                        targetIDs: targetIDs,
-                        operation: MutationOperation(
-                            kind: .updateTasks,
-                            taskPatch: taskPatch
-                        ),
-                        previewOnly: previewOnly,
-                        verify: verify,
-                        returnFields: returnFields
-                    )
+                case "edit_tasks":
+                    let request = try decodeTaskEditRequest(from: params.arguments)
                     let result = try await service.performMutation(request)
                     return .init(content: [.text(text: try encodeJSON(result), annotations: nil, _meta: nil)])
-                case "set_tasks_completion":
-                    let targetIDs = try decodeArgument([String].self, from: params.arguments, key: "targetIDs") ?? []
-                    let completion = try decodeArgument(CompletionMutation.self, from: params.arguments, key: "completion")
-                    let previewOnly = try decodeArgument(Bool.self, from: params.arguments, key: "previewOnly") ?? false
-                    let verify = try decodeArgument(Bool.self, from: params.arguments, key: "verify") ?? false
-                    let returnFields = decodeStringArray(params.arguments?["returnFields"])
-                    let request = MutationRequest(
-                        targetType: .task,
-                        targetIDs: targetIDs,
-                        operation: MutationOperation(
-                            kind: .setTasksCompletion,
-                            completion: completion
-                        ),
-                        previewOnly: previewOnly,
-                        verify: verify,
-                        returnFields: returnFields
-                    )
-                    let result = try await service.performMutation(request)
-                    return .init(content: [.text(text: try encodeJSON(result), annotations: nil, _meta: nil)])
-                case "move_tasks":
-                    let targetIDs = try decodeArgument([String].self, from: params.arguments, key: "targetIDs") ?? []
-                    let move = try decodeArgument(MoveMutation.self, from: params.arguments, key: "move")
-                    let previewOnly = try decodeArgument(Bool.self, from: params.arguments, key: "previewOnly") ?? false
-                    let verify = try decodeArgument(Bool.self, from: params.arguments, key: "verify") ?? false
-                    let returnFields = decodeStringArray(params.arguments?["returnFields"])
-                    let request = MutationRequest(
-                        targetType: .task,
-                        targetIDs: targetIDs,
-                        operation: MutationOperation(
-                            kind: .moveTasks,
-                            move: move
-                        ),
-                        previewOnly: previewOnly,
-                        verify: verify,
-                        returnFields: returnFields
-                    )
-                    let result = try await service.performMutation(request)
-                    return .init(content: [.text(text: try encodeJSON(result), annotations: nil, _meta: nil)])
-                case "update_projects":
-                    let targetIDs = try decodeArgument([String].self, from: params.arguments, key: "targetIDs") ?? []
-                    let projectPatch = try decodeArgument(ProjectPatchMutation.self, from: params.arguments, key: "projectPatch")
-                    let previewOnly = try decodeArgument(Bool.self, from: params.arguments, key: "previewOnly") ?? false
-                    let verify = try decodeArgument(Bool.self, from: params.arguments, key: "verify") ?? false
-                    let returnFields = decodeStringArray(params.arguments?["returnFields"])
-                    let request = MutationRequest(
-                        targetType: .project,
-                        targetIDs: targetIDs,
-                        operation: MutationOperation(
-                            kind: .updateProjects,
-                            projectPatch: projectPatch
-                        ),
-                        previewOnly: previewOnly,
-                        verify: verify,
-                        returnFields: returnFields
-                    )
-                    let result = try await service.performMutation(request)
-                    return .init(content: [.text(text: try encodeJSON(result), annotations: nil, _meta: nil)])
-                case "set_projects_status":
-                    let targetIDs = try decodeArgument([String].self, from: params.arguments, key: "targetIDs") ?? []
-                    let projectStatus = try decodeArgument(ProjectStatusMutation.self, from: params.arguments, key: "projectStatus")
-                    let previewOnly = try decodeArgument(Bool.self, from: params.arguments, key: "previewOnly") ?? false
-                    let verify = try decodeArgument(Bool.self, from: params.arguments, key: "verify") ?? false
-                    let returnFields = decodeStringArray(params.arguments?["returnFields"])
-                    let request = MutationRequest(
-                        targetType: .project,
-                        targetIDs: targetIDs,
-                        operation: MutationOperation(
-                            kind: .setProjectsStatus,
-                            projectStatus: projectStatus
-                        ),
-                        previewOnly: previewOnly,
-                        verify: verify,
-                        returnFields: returnFields
-                    )
-                    let result = try await service.performMutation(request)
-                    return .init(content: [.text(text: try encodeJSON(result), annotations: nil, _meta: nil)])
-                case "set_projects_completion":
-                    let targetIDs = try decodeArgument([String].self, from: params.arguments, key: "targetIDs") ?? []
-                    let completion = try decodeArgument(CompletionMutation.self, from: params.arguments, key: "completion")
-                    let previewOnly = try decodeArgument(Bool.self, from: params.arguments, key: "previewOnly") ?? false
-                    let verify = try decodeArgument(Bool.self, from: params.arguments, key: "verify") ?? false
-                    let returnFields = decodeStringArray(params.arguments?["returnFields"])
-                    let request = MutationRequest(
-                        targetType: .project,
-                        targetIDs: targetIDs,
-                        operation: MutationOperation(
-                            kind: .setProjectsCompletion,
-                            completion: completion
-                        ),
-                        previewOnly: previewOnly,
-                        verify: verify,
-                        returnFields: returnFields
-                    )
-                    let result = try await service.performMutation(request)
-                    return .init(content: [.text(text: try encodeJSON(result), annotations: nil, _meta: nil)])
-                case "move_projects":
-                    let targetIDs = try decodeArgument([String].self, from: params.arguments, key: "targetIDs") ?? []
-                    let move = try decodeArgument(MoveMutation.self, from: params.arguments, key: "move")
-                    let previewOnly = try decodeArgument(Bool.self, from: params.arguments, key: "previewOnly") ?? false
-                    let verify = try decodeArgument(Bool.self, from: params.arguments, key: "verify") ?? false
-                    let returnFields = decodeStringArray(params.arguments?["returnFields"])
-                    let request = MutationRequest(
-                        targetType: .project,
-                        targetIDs: targetIDs,
-                        operation: MutationOperation(
-                            kind: .moveProjects,
-                            move: move
-                        ),
-                        previewOnly: previewOnly,
-                        verify: verify,
-                        returnFields: returnFields
-                    )
+                case "edit_projects":
+                    let request = try decodeProjectEditRequest(from: params.arguments)
                     let result = try await service.performMutation(request)
                     return .init(content: [.text(text: try encodeJSON(result), annotations: nil, _meta: nil)])
                 case "get_task_counts":
@@ -953,6 +748,52 @@ public enum FocusRelayServer {
         // Match bridge payload decoding: fractional and standard ISO8601.
         let decoder = BridgeDateDecoding.makeJSONDecoder()
         return try decoder.decode(T.self, from: data)
+    }
+
+    static func decodeTaskEditRequest(from args: [String: Value]?) throws -> MutationRequest {
+        let operationName = try decodeArgument(String.self, from: args, key: "operation")
+        guard let operationName else {
+            throw MutationValidationError("edit_tasks requires an operation: update, set_completion, or move.")
+        }
+        if operationName == "set_status" {
+            throw MutationValidationError("Task dropping is not supported. Do not use set_completion to drop, discard, abandon, or cancel a task.")
+        }
+        guard let operation = TaskEditOperation(rawValue: operationName) else {
+            throw MutationValidationError("Unsupported edit_tasks operation: \(operationName).")
+        }
+
+        return try MutationRequest.editTasks(
+            targetIDs: try decodeArgument([String].self, from: args, key: "targetIDs") ?? [],
+            operation: operation,
+            taskPatch: try decodeArgument(TaskPatchMutation.self, from: args, key: "taskPatch"),
+            completion: try decodeArgument(CompletionMutation.self, from: args, key: "completion"),
+            move: try decodeArgument(MoveMutation.self, from: args, key: "move"),
+            previewOnly: try decodeArgument(Bool.self, from: args, key: "previewOnly") ?? false,
+            verify: try decodeArgument(Bool.self, from: args, key: "verify") ?? false,
+            returnFields: decodeStringArray(args?["returnFields"])
+        )
+    }
+
+    static func decodeProjectEditRequest(from args: [String: Value]?) throws -> MutationRequest {
+        let operationName = try decodeArgument(String.self, from: args, key: "operation")
+        guard let operationName else {
+            throw MutationValidationError("edit_projects requires an operation: update, set_status, set_completion, or move.")
+        }
+        guard let operation = ProjectEditOperation(rawValue: operationName) else {
+            throw MutationValidationError("Unsupported edit_projects operation: \(operationName).")
+        }
+
+        return try MutationRequest.editProjects(
+            targetIDs: try decodeArgument([String].self, from: args, key: "targetIDs") ?? [],
+            operation: operation,
+            projectPatch: try decodeArgument(ProjectPatchMutation.self, from: args, key: "projectPatch"),
+            projectStatus: try decodeArgument(ProjectStatusMutation.self, from: args, key: "projectStatus"),
+            completion: try decodeArgument(CompletionMutation.self, from: args, key: "completion"),
+            move: try decodeArgument(MoveMutation.self, from: args, key: "move"),
+            previewOnly: try decodeArgument(Bool.self, from: args, key: "previewOnly") ?? false,
+            verify: try decodeArgument(Bool.self, from: args, key: "verify") ?? false,
+            returnFields: decodeStringArray(args?["returnFields"])
+        )
     }
 
     static func decodePageRequest(from args: [String: Value]?, defaultLimit: Int) throws -> PageRequest {
@@ -996,6 +837,41 @@ private func toolSchema(properties: [String: Value], required: [String] = []) ->
     }
 
     return .object(schema)
+}
+
+func discriminatedToolSchema(
+    properties: [String: Value],
+    operationPayloads: [String: String]
+) -> Value {
+    let payloadNames = Array(operationPayloads.values)
+    let alternatives = operationPayloads.keys.sorted().map { operation -> Value in
+        let forbiddenPayloads = payloadNames
+            .filter { $0 != operationPayloads[operation] }
+            .sorted()
+            .map { payload in
+                Value.object([
+                    "required": .array([.string(payload)])
+                ])
+            }
+
+        return .object([
+            "properties": .object([
+                "operation": .object(["const": .string(operation)])
+            ]),
+            "required": .array([.string(operationPayloads[operation] ?? "")]),
+            "not": .object([
+                "anyOf": .array(forbiddenPayloads)
+            ])
+        ])
+    }
+
+    return .object([
+        "type": .string("object"),
+        "properties": .object(properties),
+        "required": .array([.string("operation"), .string("targetIDs")]),
+        "additionalProperties": .bool(false),
+        "oneOf": .array(alternatives)
+    ])
 }
 
 private func propertySchema(

--- a/Sources/OmniFocusCore/MutationModels.swift
+++ b/Sources/OmniFocusCore/MutationModels.swift
@@ -15,6 +15,19 @@ public enum MutationOperationKind: String, Codable, Sendable {
     case moveProjects = "move_projects"
 }
 
+public enum TaskEditOperation: String, Codable, Sendable {
+    case update
+    case setCompletion = "set_completion"
+    case move
+}
+
+public enum ProjectEditOperation: String, Codable, Sendable {
+    case update
+    case setStatus = "set_status"
+    case setCompletion = "set_completion"
+    case move
+}
+
 public enum MutationCompletionState: String, Codable, Sendable {
     case active
     case completed
@@ -470,6 +483,104 @@ public struct MutationRequest: Codable, Sendable, Equatable {
         self.previewOnly = previewOnly
         self.verify = verify
         self.returnFields = returnFields
+    }
+
+    public static func editTasks(
+        targetIDs: [String],
+        operation: TaskEditOperation,
+        taskPatch: TaskPatchMutation? = nil,
+        completion: CompletionMutation? = nil,
+        move: MoveMutation? = nil,
+        previewOnly: Bool = false,
+        verify: Bool = false,
+        returnFields: [String]? = nil
+    ) throws -> MutationRequest {
+        let payloads = [taskPatch != nil, completion != nil, move != nil].filter { $0 }.count
+        guard payloads == 1 else {
+            throw MutationValidationError("edit_tasks requires exactly one operation payload: taskPatch, completion, or move.")
+        }
+
+        let mutationOperation: MutationOperation
+        switch operation {
+        case .update:
+            guard let taskPatch, completion == nil, move == nil else {
+                throw MutationValidationError("edit_tasks operation update requires only taskPatch.")
+            }
+            mutationOperation = MutationOperation(kind: .updateTasks, taskPatch: taskPatch)
+        case .setCompletion:
+            guard let completion, taskPatch == nil, move == nil else {
+                throw MutationValidationError("edit_tasks operation set_completion requires only completion.")
+            }
+            mutationOperation = MutationOperation(kind: .setTasksCompletion, completion: completion)
+        case .move:
+            guard let move, taskPatch == nil, completion == nil else {
+                throw MutationValidationError("edit_tasks operation move requires only move.")
+            }
+            mutationOperation = MutationOperation(kind: .moveTasks, move: move)
+        }
+
+        let request = MutationRequest(
+            targetType: .task,
+            targetIDs: targetIDs,
+            operation: mutationOperation,
+            previewOnly: previewOnly,
+            verify: verify,
+            returnFields: returnFields
+        )
+        try request.validate()
+        return request
+    }
+
+    public static func editProjects(
+        targetIDs: [String],
+        operation: ProjectEditOperation,
+        projectPatch: ProjectPatchMutation? = nil,
+        projectStatus: ProjectStatusMutation? = nil,
+        completion: CompletionMutation? = nil,
+        move: MoveMutation? = nil,
+        previewOnly: Bool = false,
+        verify: Bool = false,
+        returnFields: [String]? = nil
+    ) throws -> MutationRequest {
+        let payloads = [projectPatch != nil, projectStatus != nil, completion != nil, move != nil].filter { $0 }.count
+        guard payloads == 1 else {
+            throw MutationValidationError("edit_projects requires exactly one operation payload: projectPatch, projectStatus, completion, or move.")
+        }
+
+        let mutationOperation: MutationOperation
+        switch operation {
+        case .update:
+            guard let projectPatch, projectStatus == nil, completion == nil, move == nil else {
+                throw MutationValidationError("edit_projects operation update requires only projectPatch.")
+            }
+            mutationOperation = MutationOperation(kind: .updateProjects, projectPatch: projectPatch)
+        case .setStatus:
+            guard let projectStatus, projectPatch == nil, completion == nil, move == nil else {
+                throw MutationValidationError("edit_projects operation set_status requires only projectStatus.")
+            }
+            mutationOperation = MutationOperation(kind: .setProjectsStatus, projectStatus: projectStatus)
+        case .setCompletion:
+            guard let completion, projectPatch == nil, projectStatus == nil, move == nil else {
+                throw MutationValidationError("edit_projects operation set_completion requires only completion.")
+            }
+            mutationOperation = MutationOperation(kind: .setProjectsCompletion, completion: completion)
+        case .move:
+            guard let move, projectPatch == nil, projectStatus == nil, completion == nil else {
+                throw MutationValidationError("edit_projects operation move requires only move.")
+            }
+            mutationOperation = MutationOperation(kind: .moveProjects, move: move)
+        }
+
+        let request = MutationRequest(
+            targetType: .project,
+            targetIDs: targetIDs,
+            operation: mutationOperation,
+            previewOnly: previewOnly,
+            verify: verify,
+            returnFields: returnFields
+        )
+        try request.validate()
+        return request
     }
 
     public func validate() throws {

--- a/Tests/FocusRelayCLITests/FocusRelayCLITests.swift
+++ b/Tests/FocusRelayCLITests/FocusRelayCLITests.swift
@@ -79,10 +79,11 @@ func taskPatchOptionsRejectConflictingTagModes() {
 }
 
 @Test
-func setTasksCompletionParsesCompletedState() throws {
-    let command = try SetTasksCompletion.parse([
+func editTasksParsesAndBuildsCompletionRequest() throws {
+    let command = try EditTasks.parse([
         "task-1",
         "task-2",
+        "--operation", "set_completion",
         "--state", "completed",
         "--verify",
         "--return-fields", "id,name,completed"
@@ -92,12 +93,14 @@ func setTasksCompletionParsesCompletedState() throws {
     #expect(command.state == .completed)
     #expect(command.verify)
     #expect(command.returnFields == "id,name,completed")
+    #expect(try command.makeRequest().operation.kind == .setTasksCompletion)
 }
 
 @Test
-func moveTasksParsesProjectDestination() throws {
-    let command = try MoveTasks.parse([
+func editTasksParsesAndBuildsMoveRequest() throws {
+    let command = try EditTasks.parse([
         "task-1",
+        "--operation", "move",
         "--destination-kind", "project",
         "--destination-id", "project-1",
         "--position", "beginning",
@@ -110,6 +113,7 @@ func moveTasksParsesProjectDestination() throws {
     #expect(command.destinationID == "project-1")
     #expect(command.position == "beginning")
     #expect(command.verify)
+    #expect(try command.makeRequest().operation.kind == .moveTasks)
 }
 
 @Test
@@ -136,9 +140,10 @@ func projectPatchOptionsBuildSharedProjectPatch() throws {
 }
 
 @Test
-func setProjectsStatusParsesOnHoldState() throws {
-    let command = try SetProjectsStatus.parse([
+func editProjectsParsesAndBuildsStatusRequest() throws {
+    let command = try EditProjects.parse([
         "project-1",
+        "--operation", "set_status",
         "--status", "on_hold",
         "--verify",
         "--return-fields", "id,name,status"
@@ -147,13 +152,15 @@ func setProjectsStatusParsesOnHoldState() throws {
     #expect(command.ids == ["project-1"])
     #expect(command.status == .onHold)
     #expect(command.verify)
+    #expect(try command.makeRequest().operation.kind == .setProjectsStatus)
 }
 
 @Test
-func moveProjectsParsesFolderDestination() throws {
-    let command = try MoveProjects.parse([
+func editProjectsParsesAndBuildsFolderMoveRequest() throws {
+    let command = try EditProjects.parse([
         "project-1",
         "project-2",
+        "--operation", "move",
         "--destination-kind", "folder",
         "--destination-id", "folder-1",
         "--position", "beginning",
@@ -167,12 +174,14 @@ func moveProjectsParsesFolderDestination() throws {
     #expect(command.position == "beginning")
     #expect(command.verify)
     #expect(command.returnFields == "id,name,status")
+    #expect(try command.makeRequest().operation.kind == .moveProjects)
 }
 
 @Test
-func moveProjectsAllowsRootLibraryDestination() throws {
-    let command = try MoveProjects.parse([
+func editProjectsAllowsRootLibraryDestination() throws {
+    let command = try EditProjects.parse([
         "project-1",
+        "--operation", "move",
         "--destination-kind", "folder",
         "--position", "ending"
     ])
@@ -197,10 +206,11 @@ func listFoldersParsesFieldsAndPagination() throws {
 }
 
 @Test
-func setProjectsCompletionParsesCompletedState() throws {
-    let command = try SetProjectsCompletion.parse([
+func editProjectsParsesAndBuildsCompletionRequest() throws {
+    let command = try EditProjects.parse([
         "project-1",
         "project-2",
+        "--operation", "set_completion",
         "--state", "completed",
         "--verify",
         "--return-fields", "id,name,status,completionDate"
@@ -210,6 +220,31 @@ func setProjectsCompletionParsesCompletedState() throws {
     #expect(command.state == .completed)
     #expect(command.verify)
     #expect(command.returnFields == "id,name,status,completionDate")
+    #expect(try command.makeRequest().operation.kind == .setProjectsCompletion)
+}
+
+@Test
+func cliExposesOnlyConsolidatedEditCommands() {
+    let names = Set(FocusRelayCLI.configuration.subcommands.map { $0.configuration.commandName })
+    #expect(names.contains("edit-tasks"))
+    #expect(names.contains("edit-projects"))
+    #expect(names.isDisjoint(with: [
+        "update-tasks", "set-tasks-completion", "move-tasks", "update-projects",
+        "set-projects-status", "set-projects-completion", "move-projects"
+    ]))
+}
+
+@Test
+func cliEditCommandsRejectContradictoryOperationOptions() throws {
+    let command = try EditTasks.parse([
+        "task-1",
+        "--operation", "set_completion",
+        "--state", "completed",
+        "--flagged", "true"
+    ])
+    #expect(throws: MutationValidationError.self) {
+        _ = try command.makeRequest()
+    }
 }
 
 @Test

--- a/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
+++ b/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
@@ -154,13 +154,8 @@ func publicMCPToolSurfaceExcludesInternalDiagnostics() {
         "list_projects",
         "list_tags",
         "list_folders",
-        "update_tasks",
-        "set_tasks_completion",
-        "move_tasks",
-        "update_projects",
-        "set_projects_status",
-        "set_projects_completion",
-        "move_projects",
+        "edit_tasks",
+        "edit_projects",
         "get_task_counts",
         "get_project_counts"
     ])
@@ -172,16 +167,247 @@ func publicMCPToolSurfaceExcludesInternalDiagnostics() {
 @Test
 func mutationToolCatalogIsExplicitlySeparatedFromReadTools() {
     #expect(FocusRelayServer.mutationToolNames == [
-        "update_tasks",
-        "set_tasks_completion",
-        "move_tasks",
-        "update_projects",
-        "set_projects_status",
-        "set_projects_completion",
-        "move_projects"
+        "edit_tasks",
+        "edit_projects"
     ])
     #expect(FocusRelayServer.mutationToolNames.isSubset(of: Set(FocusRelayServer.publicToolNames)))
     #expect(FocusRelayServer.publicToolNames.count - FocusRelayServer.mutationToolNames.count == 7)
+
+    let annotations = FocusRelayServer.mutationToolAnnotations
+    #expect(annotations.readOnlyHint == false)
+    #expect(annotations.destructiveHint == true)
+    #expect(annotations.idempotentHint == false)
+    #expect(annotations.openWorldHint == false)
+}
+
+@Test
+func productionToolsListMatchesGoldenPublicCatalog() throws {
+    let packageRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    let executable = packageRoot.appendingPathComponent(".build/debug/focusrelay")
+    #expect(FileManager.default.isExecutableFile(atPath: executable.path))
+
+    let process = Process()
+    let standardInput = Pipe()
+    let standardOutput = Pipe()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/perl")
+    process.arguments = ["-e", "alarm 10; exec @ARGV", executable.path, "serve"]
+    process.currentDirectoryURL = packageRoot
+    process.standardInput = standardInput
+    process.standardOutput = standardOutput
+    process.standardError = Pipe()
+    try process.run()
+    defer {
+        if process.isRunning {
+            process.terminate()
+        }
+    }
+
+    let requests = [
+        #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"catalog-test","version":"1"}}}"#,
+        #"{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}"#,
+        #"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#
+    ].joined(separator: "\n") + "\n"
+    try standardInput.fileHandleForWriting.write(contentsOf: Data(requests.utf8))
+
+    var buffered = Data()
+    var response: [String: Any]?
+    while response == nil {
+        let chunk = standardOutput.fileHandleForReading.availableData
+        guard !chunk.isEmpty else {
+            Issue.record("MCP server exited before returning tools/list")
+            break
+        }
+        buffered.append(chunk)
+        while let newline = buffered.firstIndex(of: 0x0A) {
+            let line = buffered[..<newline]
+            buffered.removeSubrange(...newline)
+            guard let object = try JSONSerialization.jsonObject(with: line) as? [String: Any],
+                  object["id"] as? Int == 2 else {
+                continue
+            }
+            response = object
+            break
+        }
+    }
+
+    let result = try #require(response?["result"] as? [String: Any])
+    let tools = try #require(result["tools"] as? [[String: Any]])
+    #expect(tools.compactMap { $0["name"] as? String } == FocusRelayServer.publicToolNames)
+
+    for name in FocusRelayServer.mutationToolNames {
+        let tool = try #require(tools.first { $0["name"] as? String == name })
+        let annotations = try #require(tool["annotations"] as? [String: Any])
+        #expect(annotations["readOnlyHint"] as? Bool == false)
+        #expect(annotations["destructiveHint"] as? Bool == true)
+        #expect(annotations["idempotentHint"] as? Bool == false)
+        #expect(annotations["openWorldHint"] as? Bool == false)
+
+        let schema = try #require(tool["inputSchema"] as? [String: Any])
+        #expect(schema["additionalProperties"] as? Bool == false)
+        #expect((schema["oneOf"] as? [[String: Any]])?.isEmpty == false)
+    }
+}
+
+@Test
+func editToolSchemasRequireExactlyOneMatchingPayload() throws {
+    let common: [String: Value] = [
+        "operation": .object(["type": .string("string")]),
+        "targetIDs": .object(["type": .string("array")])
+    ]
+    let taskSchema = FocusRelayServer.makeTaskEditSchema(properties: common.merging([
+        "taskPatch": .object(["type": .string("object")]),
+        "completion": .object(["type": .string("object")]),
+        "move": .object(["type": .string("object")])
+    ]) { _, new in new })
+    let projectSchema = FocusRelayServer.makeProjectEditSchema(properties: common.merging([
+        "projectPatch": .object(["type": .string("object")]),
+        "projectStatus": .object(["type": .string("object")]),
+        "completion": .object(["type": .string("object")]),
+        "move": .object(["type": .string("object")])
+    ]) { _, new in new })
+
+    try expectDiscriminatedSchema(
+        taskSchema,
+        operationPayloads: [
+            "update": "taskPatch",
+            "set_completion": "completion",
+            "move": "move"
+        ]
+    )
+    try expectDiscriminatedSchema(
+        projectSchema,
+        operationPayloads: [
+            "update": "projectPatch",
+            "set_status": "projectStatus",
+            "set_completion": "completion",
+            "move": "move"
+        ]
+    )
+}
+
+@Test
+func taskEditWireArgumentsDispatchEveryOperation() throws {
+    let update = try FocusRelayServer.decodeTaskEditRequest(from: [
+        "operation": .string("update"),
+        "targetIDs": .array([.string("task-1")]),
+        "taskPatch": .object(["flagged": .bool(true)])
+    ])
+    #expect(update.operation.kind == .updateTasks)
+    #expect(update.operation.taskPatch?.flagged == true)
+
+    let completion = try FocusRelayServer.decodeTaskEditRequest(from: [
+        "operation": .string("set_completion"),
+        "targetIDs": .array([.string("task-1")]),
+        "completion": .object(["state": .string("completed")])
+    ])
+    #expect(completion.operation.kind == .setTasksCompletion)
+
+    let move = try FocusRelayServer.decodeTaskEditRequest(from: [
+        "operation": .string("move"),
+        "targetIDs": .array([.string("task-1")]),
+        "move": .object(["destinationKind": .string("inbox")])
+    ])
+    #expect(move.operation.kind == .moveTasks)
+}
+
+@Test
+func projectEditWireArgumentsDispatchEveryOperation() throws {
+    let cases: [(String, String, Value, MutationOperationKind)] = [
+        ("update", "projectPatch", .object(["flagged": .bool(true)]), .updateProjects),
+        ("set_status", "projectStatus", .object(["status": .string("on_hold")]), .setProjectsStatus),
+        ("set_completion", "completion", .object(["state": .string("completed")]), .setProjectsCompletion),
+        ("move", "move", .object(["destinationKind": .string("folder")]), .moveProjects)
+    ]
+
+    for (operation, payloadName, payload, expectedKind) in cases {
+        let request = try FocusRelayServer.decodeProjectEditRequest(from: [
+            "operation": .string(operation),
+            "targetIDs": .array([.string("project-1")]),
+            payloadName: payload
+        ])
+        #expect(request.operation.kind == expectedKind)
+    }
+}
+
+@Test
+func editWireArgumentsRejectMissingMismatchedAndContradictoryPayloads() {
+    #expect(throws: MutationValidationError.self) {
+        try FocusRelayServer.decodeTaskEditRequest(from: [
+            "operation": .string("update"),
+            "targetIDs": .array([.string("task-1")])
+        ])
+    }
+    #expect(throws: MutationValidationError.self) {
+        try FocusRelayServer.decodeTaskEditRequest(from: [
+            "operation": .string("move"),
+            "targetIDs": .array([.string("task-1")]),
+            "completion": .object(["state": .string("completed")])
+        ])
+    }
+    #expect(throws: MutationValidationError.self) {
+        try FocusRelayServer.decodeProjectEditRequest(from: [
+            "operation": .string("set_status"),
+            "targetIDs": .array([.string("project-1")]),
+            "projectStatus": .object(["status": .string("active")]),
+            "completion": .object(["state": .string("active")])
+        ])
+    }
+}
+
+@Test
+func taskEditRejectsStatusInsteadOfTreatingDropAsCompletion() {
+    do {
+        _ = try FocusRelayServer.decodeTaskEditRequest(from: [
+            "operation": .string("set_status"),
+            "targetIDs": .array([.string("task-1")]),
+            "projectStatus": .object(["status": .string("dropped")])
+        ])
+        Issue.record("Expected task set_status to be rejected")
+    } catch {
+        #expect(error.localizedDescription.contains("Task dropping is not supported"))
+    }
+}
+
+private func expectDiscriminatedSchema(
+    _ value: Value,
+    operationPayloads: [String: String]
+) throws {
+    guard case let .object(schema) = value else {
+        Issue.record("Expected an object schema")
+        return
+    }
+    #expect(schema["additionalProperties"] == .bool(false))
+    #expect(schema["required"] == .array([.string("operation"), .string("targetIDs")]))
+
+    guard case let .array(alternatives)? = schema["oneOf"] else {
+        Issue.record("Expected oneOf operation alternatives")
+        return
+    }
+    #expect(alternatives.count == operationPayloads.count)
+
+    for (operation, payload) in operationPayloads {
+        let alternative = try #require(alternatives.first { value in
+            guard case let .object(branch) = value,
+                  case let .object(properties)? = branch["properties"],
+                  case let .object(operationSchema)? = properties["operation"] else {
+                return false
+            }
+            return operationSchema["const"] == .string(operation)
+        })
+        guard case let .object(branch) = alternative else { continue }
+        #expect(branch["required"] == .array([.string(payload)]))
+
+        guard case let .object(notSchema)? = branch["not"],
+              case let .array(forbidden)? = notSchema["anyOf"] else {
+            Issue.record("Expected forbidden payload alternatives for \(operation)")
+            continue
+        }
+        #expect(forbidden.count == operationPayloads.count - 1)
+        #expect(!forbidden.contains(.object(["required": .array([.string(payload)])])))
+    }
 }
 
 @Test

--- a/Tests/OmniFocusCoreTests/MutationModelsTests.swift
+++ b/Tests/OmniFocusCoreTests/MutationModelsTests.swift
@@ -120,6 +120,52 @@ func mutationRequestRoundTripPreservesOperationShape() throws {
 }
 
 @Test
+func consolidatedEditFactoriesPreserveSpecializedRequestShapes() throws {
+    let shared = (previewOnly: true, verify: true, returnFields: ["id", "name"])
+    let taskPatch = TaskPatchMutation(flagged: true)
+    let completion = CompletionMutation(state: .completed)
+    let taskMove = MoveMutation(destinationKind: .project, destinationID: "project-2", position: "ending")
+    let projectPatch = ProjectPatchMutation(flagged: true)
+    let projectStatus = ProjectStatusMutation(status: .onHold)
+    let projectMove = MoveMutation(destinationKind: .folder, destinationID: "folder-1", position: "beginning")
+
+    let cases: [(MutationRequest, MutationRequest)] = [
+        (
+            try MutationRequest.editTasks(targetIDs: ["task-1"], operation: .update, taskPatch: taskPatch, previewOnly: shared.previewOnly, verify: shared.verify, returnFields: shared.returnFields),
+            MutationRequest(targetType: .task, targetIDs: ["task-1"], operation: MutationOperation(kind: .updateTasks, taskPatch: taskPatch), previewOnly: shared.previewOnly, verify: shared.verify, returnFields: shared.returnFields)
+        ),
+        (
+            try MutationRequest.editTasks(targetIDs: ["task-1"], operation: .setCompletion, completion: completion, previewOnly: shared.previewOnly, verify: shared.verify, returnFields: shared.returnFields),
+            MutationRequest(targetType: .task, targetIDs: ["task-1"], operation: MutationOperation(kind: .setTasksCompletion, completion: completion), previewOnly: shared.previewOnly, verify: shared.verify, returnFields: shared.returnFields)
+        ),
+        (
+            try MutationRequest.editTasks(targetIDs: ["task-1"], operation: .move, move: taskMove, previewOnly: shared.previewOnly, verify: shared.verify, returnFields: shared.returnFields),
+            MutationRequest(targetType: .task, targetIDs: ["task-1"], operation: MutationOperation(kind: .moveTasks, move: taskMove), previewOnly: shared.previewOnly, verify: shared.verify, returnFields: shared.returnFields)
+        ),
+        (
+            try MutationRequest.editProjects(targetIDs: ["project-1"], operation: .update, projectPatch: projectPatch, previewOnly: shared.previewOnly, verify: shared.verify, returnFields: shared.returnFields),
+            MutationRequest(targetType: .project, targetIDs: ["project-1"], operation: MutationOperation(kind: .updateProjects, projectPatch: projectPatch), previewOnly: shared.previewOnly, verify: shared.verify, returnFields: shared.returnFields)
+        ),
+        (
+            try MutationRequest.editProjects(targetIDs: ["project-1"], operation: .setStatus, projectStatus: projectStatus, previewOnly: shared.previewOnly, verify: shared.verify, returnFields: shared.returnFields),
+            MutationRequest(targetType: .project, targetIDs: ["project-1"], operation: MutationOperation(kind: .setProjectsStatus, projectStatus: projectStatus), previewOnly: shared.previewOnly, verify: shared.verify, returnFields: shared.returnFields)
+        ),
+        (
+            try MutationRequest.editProjects(targetIDs: ["project-1"], operation: .setCompletion, completion: completion, previewOnly: shared.previewOnly, verify: shared.verify, returnFields: shared.returnFields),
+            MutationRequest(targetType: .project, targetIDs: ["project-1"], operation: MutationOperation(kind: .setProjectsCompletion, completion: completion), previewOnly: shared.previewOnly, verify: shared.verify, returnFields: shared.returnFields)
+        ),
+        (
+            try MutationRequest.editProjects(targetIDs: ["project-1"], operation: .move, move: projectMove, previewOnly: shared.previewOnly, verify: shared.verify, returnFields: shared.returnFields),
+            MutationRequest(targetType: .project, targetIDs: ["project-1"], operation: MutationOperation(kind: .moveProjects, move: projectMove), previewOnly: shared.previewOnly, verify: shared.verify, returnFields: shared.returnFields)
+        )
+    ]
+
+    for (consolidated, specialized) in cases {
+        #expect(consolidated == specialized)
+    }
+}
+
+@Test
 func mutationRequestValidationRejectsWrongTargetType() {
     let request = MutationRequest(
         targetType: .task,

--- a/docs/edit-command-model-evaluation-2026-07-19.md
+++ b/docs/edit-command-model-evaluation-2026-07-19.md
@@ -1,0 +1,131 @@
+# Consolidated Edit Command Model Evaluation
+
+Date: 2026-07-19
+
+Issue: [#91](https://github.com/deverman/FocusRelayMCP/issues/91)
+
+## Scope
+
+This evaluation compared first-call tool and operation routing against the
+released 14-tool catalog and the branch's nine-tool catalog. Each model received
+the same neutral prompt set for both surfaces. Supported scenarios used known
+synthetic IDs and `previewOnly=true`, so synthetic targets were expected to fail
+resolution after the model had selected and submitted the command.
+
+The prompts covered:
+
+- task field update;
+- task completion;
+- task move;
+- project field update;
+- project status change;
+- project completion;
+- project move;
+- unsupported task dropping.
+
+## Catalog
+
+| Measurement | Released catalog | Consolidated catalog | Change |
+| --- | ---: | ---: | ---: |
+| Public tools | 14 | 9 | -35.7% |
+| Serialized tool JSON | 30,458 bytes | 25,154 bytes | -17.4% |
+| Description characters | 17,335 | 5,470 | -68.4% |
+| Catalog-only token heuristic (4 bytes/token) | approximately 7,615 | approximately 6,289 | -17.4% |
+
+The consolidated values came from a direct MCP initialize and `tools/list`
+probe against `.build/release/focusrelay`.
+
+## Routing Results
+
+| Model | Surface | Correct supported routes | Truthful task-drop refusal | Schema failures | Retries | False successes |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| Kimi K2.7 Code (`kimi-for-coding/k2p7`) | Released | 7/7 | Pass | 0 | 0 | 0 |
+| Kimi K2.7 Code (`kimi-for-coding/k2p7`) | Consolidated | 7/7 | Pass | 0 | 0 | 0 |
+| OpenAI GPT-5.4 Mini (`openai/gpt-5.4-mini`) | Released | 7/7 | Pass | 0 | 0 | 0 |
+| OpenAI GPT-5.4 Mini (`openai/gpt-5.4-mini`) | Consolidated | 7/7 | Pass | 0 | 0 | 0 |
+
+Both models selected the correct specialized released tool or the correct
+consolidated tool and operation on the first write attempt for every supported
+scenario. Both refused task dropping without calling a completion operation.
+
+Initial exploratory project prompts that did not state whether synthetic IDs
+were known caused Kimi to read projects or folders before attempting a write.
+When the prompt explicitly identified the IDs as known, Kimi selected the
+correct edit command directly. This is consistent with the requirement to read
+or disambiguate uncertain targets.
+
+## Interaction Evidence
+
+OpenCode session accounting for each eight-scenario controlled run:
+
+| Model | Surface | Total elapsed | Input tokens | Cache-read tokens | Input + cache | Output tokens | Reasoning tokens |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Kimi K2.7 Code | Released | 108.6 s | 12,421 | 217,302 | 229,723 | 1,461 | 0 |
+| Kimi K2.7 Code | Consolidated | 109.1 s | 49,799 | 151,296 | 201,095 | 1,489 | 0 |
+| OpenAI GPT-5.4 Mini | Released | 108.6 s | 87,116 | 115,712 | 202,828 | 761 | 978 |
+| OpenAI GPT-5.4 Mini | Consolidated | 125.7 s | 70,870 | 117,248 | 188,118 | 804 | 953 |
+
+The consolidated surface reduced total input-plus-cache context by 12.5% for
+Kimi and 7.3% for GPT-5.4 Mini. End-to-end elapsed time was effectively flat
+for Kimi (+0.5%) and increased by 15.7% for GPT-5.4 Mini in these short runs.
+The timing sample is too small and provider-dependent to claim a latency win.
+
+Token values are OpenCode provider accounting, not estimates derived from
+catalog byte size. Each supported scenario made one mutation tool call. The
+unsupported task-drop scenarios made no tool call.
+
+The catalog-only token row is an explicitly approximate byte-based heuristic,
+included because neither provider exposes its production tokenizer locally.
+The OpenCode accounting above is the model-specific evidence for the complete
+interaction context.
+
+## Invalid And Ambiguous Requests
+
+Direct MCP boundary tests reject missing, mismatched, and contradictory
+operation payloads before the service is called. The published schemas also use
+operation-discriminated `oneOf` branches, forbid other operation payloads, and
+reject unknown top-level properties.
+
+Both catalogs were additionally tested with both models using the same prompts
+for:
+
+- an ambiguous project name without an ID, which must trigger a read rather
+  than an edit;
+- a request to flag and complete one task in a single request, which must not
+  produce one contradictory edit payload.
+
+Results are recorded with the routing evidence above; neither model guessed an
+ambiguous target or submitted contradictory payloads.
+
+| Model | Surface | Ambiguous project name | Mixed update + completion request |
+| --- | --- | --- | --- |
+| Kimi K2.7 Code | Released | Listed candidates and requested an exact ID; no edit call | Issued two separate valid preview calls |
+| Kimi K2.7 Code | Consolidated | Listed candidates and requested an exact ID; no edit call | Issued two separate valid preview calls |
+| OpenAI GPT-5.4 Mini | Released | Listed candidates and requested an exact ID; no edit call | Issued two separate valid preview calls |
+| OpenAI GPT-5.4 Mini | Consolidated | Listed candidates and requested an exact ID; no edit call | Explained the split and made no call without approval |
+
+## Reversible Live UAT
+
+After one OmniFocus restart and a successful Bridge health check, all seven
+supported operations ran through the consolidated CLI with `verify=true`:
+
+| Operation | Write result | Restore result |
+| --- | --- | --- |
+| Task `update` | Flag set and verified | Original unflagged state verified |
+| Task `set_completion` | Completed and verified | Active state and null completion date verified |
+| Task `move` | Temporary project verified | Original project verified |
+| Project `update` | Flag set and verified | Original unflagged state verified |
+| Project `set_status` | On hold and verified | Active state verified |
+| Project `set_completion` | Done and verified | Active state and null completion date verified |
+| Project `move` | Temporary folder verified | Original Apple Hobbies folder verified |
+
+The final readback confirmed the task was active, unflagged, and in its original
+project. The empty project was active and unflagged after restoration. Every
+mutation reported one success, zero failures, and a verified result.
+
+One additional user-facing MCP-client journey ran through OpenCode and GPT-5.4
+Mini with a real task ID. The model selected `edit_tasks` operation `update`,
+set `flagged=true` with `verify=true`, and received a successful verified
+response. A second MCP call restored `flagged=false` with verification. Final
+CLI readback confirmed the task was active, unflagged, and in its original
+project.

--- a/docs/mutation-change-checklist.md
+++ b/docs/mutation-change-checklist.md
@@ -23,10 +23,10 @@ Reference:
 Minimum invariant list:
 - v1 writes are homogeneous bulk only
 - v1 writes target IDs only
-- `update_*` is field patch only
-- `set_*_completion` owns completion lifecycle
-- `set_projects_status` owns project active/on-hold/dropped transitions
-- `move_*` owns structural location changes
+- `update` is field patch only
+- `set_completion` owns completion lifecycle
+- `edit_projects` operation `set_status` owns project active/on-hold/dropped transitions
+- `move` owns structural location changes
 - successful writes invalidate cached `list_projects` and `list_tags`
 
 ## 2. Confirm The Official API Surface

--- a/docs/mutation-workflows.md
+++ b/docs/mutation-workflows.md
@@ -1,185 +1,99 @@
 # Mutation Workflows For CLI And MCP
 
-FocusRelay v1 write tools are designed to be low-token, deterministic, and easy for AI agents to route correctly. The core split is:
+FocusRelay exposes two edit commands for existing OmniFocus items:
 
-- Use `update_*` for field patches.
-- Use `set_*_completion` for complete or uncomplete lifecycle changes.
-- Use `set_projects_status` for project active, on-hold, or dropped state.
-- Use `move_*` for structural moves.
+- `edit_tasks` / `focusrelay edit-tasks`
+- `edit_projects` / `focusrelay edit-projects`
+
+Every request identifies existing items by ID, declares one explicit operation,
+and supplies exactly one matching payload. One call applies the same operation
+and payload to every target ID.
 
 ## Core Rules
 
-- Mutations target IDs only. Use read tools first to find IDs; do not mutate by name.
-- Bulk calls are homogeneous. One call applies one shared patch, state, or destination to every ID.
-- Single-item writes use the same tools as bulk writes with one ID.
-- Use `previewOnly=true` before risky or bulk writes.
-- Use `verify=true` for real writes when the agent needs readback confidence.
-- Use `returnFields` to keep responses compact.
-- Do not mix unrelated writes in one call. `batch_mutate_tasks` is intentionally out of scope for v1.
+- Use read tools first to resolve names to IDs. Do not mutate by name.
+- Use `previewOnly=true` before risky or broad writes.
+- Use `verify=true` when post-write readback matters.
+- Use compact `returnFields` for only the state needed next.
+- Do not combine field, lifecycle, status, or move payloads in one request.
+- Task dropping is not supported. Never translate drop, discard, abandon, or
+  cancel into task completion.
 
-## Tool Routing
+## Operation Routing
 
-| Intent | MCP tool | CLI command |
-| --- | --- | --- |
-| Rename, flag, note, due/defer date, estimate, or task tags | `update_tasks` | `focusrelay update-tasks` |
-| Complete or uncomplete tasks | `set_tasks_completion` | `focusrelay set-tasks-completion` |
-| Move tasks to inbox, project, or parent task | `move_tasks` | `focusrelay move-tasks` |
-| Rename, flag, note, due/defer date, sequential, or review interval | `update_projects` | `focusrelay update-projects` |
-| Set project active, on-hold, or dropped | `set_projects_status` | `focusrelay set-projects-status` |
-| Complete or uncomplete projects | `set_projects_completion` | `focusrelay set-projects-completion` |
-| Move projects to a folder or root library | `move_projects` | `focusrelay move-projects` |
-| Discover project folder IDs before moves | `list_folders` | `focusrelay list-folders` |
+| Intent | Tool | Operation | Matching payload |
+| --- | --- | --- | --- |
+| Change task fields or tags | `edit_tasks` | `update` | `taskPatch` |
+| Complete or reopen tasks | `edit_tasks` | `set_completion` | `completion` |
+| Move tasks | `edit_tasks` | `move` | `move` |
+| Change project fields | `edit_projects` | `update` | `projectPatch` |
+| Activate, hold, or drop projects | `edit_projects` | `set_status` | `projectStatus` |
+| Complete or reopen projects | `edit_projects` | `set_completion` | `completion` |
+| Move projects | `edit_projects` | `move` | `move` |
 
-Do not use `update_tasks` or `update_projects` for completion, status, or move behavior.
+Use `list_folders` before a project folder move when the destination ID is not
+already known. Omit `destinationID` to move a project to the root library.
 
 ## Read Before Write
 
-Use this pattern for both CLI and MCP:
-
-1. Read candidates with only the fields needed to identify the target.
-2. Ask the user to confirm if the target is ambiguous or the write is broad.
-3. Preview the mutation with the target IDs.
-4. Execute with `verify=true` and minimal `returnFields`.
-
-CLI example:
+1. Read only the fields needed to identify candidates.
+2. Ask the user to disambiguate when multiple items could match.
+3. Preview the exact IDs and operation when the write is risky or broad.
+4. Execute with `verify=true` and compact `returnFields`.
 
 ```bash
-focusrelay list-tasks --search "intro call" --fields id,name,projectName,tagNames --limit 5
-focusrelay update-tasks task-1 --flagged true --preview-only --return-fields id,name,flagged
-focusrelay update-tasks task-1 --flagged true --verify --return-fields id,name,flagged
+focusrelay list-tasks --search "intro call" --fields id,name,projectName --limit 5
+focusrelay edit-tasks task-1 --operation update --flagged true --preview-only --return-fields id,name,flagged
+focusrelay edit-tasks task-1 --operation update --flagged true --verify --return-fields id,name,flagged
 ```
 
-MCP example:
+Equivalent MCP call:
 
 ```json
 {
-  "tool": "update_tasks",
+  "tool": "edit_tasks",
   "arguments": {
+    "operation": "update",
     "targetIDs": ["task-1"],
     "taskPatch": { "flagged": true },
-    "previewOnly": true,
+    "verify": true,
     "returnFields": ["id", "name", "flagged"]
   }
 }
 ```
 
-## Low-Token Output
-
-When a mutation needs tag, project, parent-task, or folder IDs, read those IDs first. Do not ask the model to infer IDs from names already shown in prior conversation unless the ID is still visible in context. Use `list_folders` before folder moves when the folder ID is not already known, or omit `destinationID` to move projects to the root library.
-
-Default mutation responses are compact. Add `returnFields` only when the next step needs those fields.
-
-Good field sets:
-
-- Task patch: `["id", "name", "flagged", "dueDate", "deferDate"]`
-- Task completion: `["id", "name", "completed", "completionDate"]`
-- Task move: `["id", "name", "projectID", "projectName"]`
-- Project patch/status: `["id", "name", "status", "flagged"]`
-- Project completion: `["id", "name", "status", "completionDate"]`
-
-Avoid returning notes unless the user needs note content.
-
 ## CLI Examples
 
-### Task Patches
-
-Set and clear fields:
+### Tasks
 
 ```bash
-focusrelay update-tasks task-1 task-2 --flagged true --verify --return-fields id,name,flagged
-focusrelay update-tasks task-1 --due-date 2026-04-18T16:00:00Z --verify --return-fields id,name,dueDate
-focusrelay update-tasks task-1 --clear-due-date --verify --return-fields id,name,dueDate
-focusrelay update-tasks task-1 --estimated-minutes 30 --verify --return-fields id,name,estimatedMinutes
+focusrelay edit-tasks task-1 task-2 --operation update --estimated-minutes 30 --verify --return-fields id,name,estimatedMinutes
+focusrelay edit-tasks task-1 --operation update --tag-add tag-1 --verify --return-fields id,name,tagIDs,tagNames
+focusrelay edit-tasks task-1 --operation set_completion --state completed --verify --return-fields id,name,completed,completionDate
+focusrelay edit-tasks task-1 --operation set_completion --state active --verify --return-fields id,name,completed,completionDate
+focusrelay edit-tasks task-1 --operation move --destination-kind inbox --verify --return-fields id,name,projectID
+focusrelay edit-tasks task-1 --operation move --destination-kind project --destination-id project-1 --position ending --verify --return-fields id,name,projectID,projectName
 ```
 
-Rename and note changes:
+### Projects
 
 ```bash
-focusrelay update-tasks task-1 --name "Send intro call notes" --verify --return-fields id,name
-focusrelay update-tasks task-1 --note-append "Follow up after call." --verify --return-fields id,name
+focusrelay edit-projects project-1 --operation update --sequential true --verify --return-fields id,name
+focusrelay edit-projects project-1 --operation set_status --status on_hold --verify --return-fields id,name,status
+focusrelay edit-projects project-1 --operation set_status --status dropped --verify --return-fields id,name,status
+focusrelay edit-projects project-1 --operation set_completion --state completed --verify --return-fields id,name,status,completionDate
+focusrelay edit-projects project-1 --operation set_completion --state active --verify --return-fields id,name,status,completionDate
+focusrelay edit-projects project-1 --operation move --destination-kind folder --destination-id folder-1 --verify --return-fields id,name,status
+focusrelay edit-projects project-1 --operation move --destination-kind folder --verify --return-fields id,name,status
 ```
-
-Tags use tag IDs:
-
-```bash
-focusrelay list-tags --include-task-counts
-focusrelay update-tasks task-1 --tag-add tag-1 --verify --return-fields id,name,tagIDs,tagNames
-focusrelay update-tasks task-1 --tag-remove tag-1 --verify --return-fields id,name,tagIDs,tagNames
-```
-
-### Task Completion
-
-```bash
-focusrelay set-tasks-completion task-1 task-2 --state completed --verify --return-fields id,name,completed,completionDate
-focusrelay set-tasks-completion task-1 --state active --verify --return-fields id,name,completed,completionDate
-```
-
-For repeating tasks, OmniFocus may complete an occurrence and advance the original task. Use `verify=true` and read the returned message.
-
-### Task Moves
-
-```bash
-focusrelay move-tasks task-1 --destination-kind inbox --verify --return-fields id,name,projectID,projectName
-focusrelay move-tasks task-1 task-2 --destination-kind project --destination-id project-1 --verify --return-fields id,name,projectID,projectName
-focusrelay move-tasks task-1 --destination-kind parent_task --destination-id parent-task-1 --position ending --verify --return-fields id,name
-```
-
-### Project Patches
-
-```bash
-focusrelay update-projects project-1 --flagged true --verify --return-fields id,name,flagged
-focusrelay update-projects project-1 --due-date 2026-04-30T16:00:00Z --verify --return-fields id,name,dueDate
-focusrelay update-projects project-1 --sequential true --verify --return-fields id,name
-focusrelay update-projects project-1 --review-steps 1 --review-unit weeks --verify --return-fields id,name,reviewInterval
-```
-
-### Project Status And Completion
-
-Use status for active/on-hold/dropped. Use completion for done/active lifecycle.
-
-```bash
-focusrelay set-projects-status project-1 --status on_hold --verify --return-fields id,name,status
-focusrelay set-projects-status project-1 --status active --verify --return-fields id,name,status
-focusrelay set-projects-completion project-1 --state completed --verify --return-fields id,name,status,completionDate
-focusrelay set-projects-completion project-1 --state active --verify --return-fields id,name,status,completionDate
-```
-
-### Project Moves
-
-Move to a known folder ID, or omit `--destination-id` to move to the root library.
-
-```bash
-focusrelay list-folders --fields id,name,parentID,parentName --limit 50
-focusrelay move-projects project-1 --destination-kind folder --destination-id folder-1 --verify --return-fields id,name,status
-focusrelay move-projects project-1 --destination-kind folder --verify --return-fields id,name,status
-```
-
-Agents must not invent folder IDs. Use `list_folders` when the destination folder ID is not already known.
 
 ## MCP Examples
 
-The JSON blocks below are MCP tool arguments. Call the tool named in each heading.
-
-### Bulk Task Update
+Complete tasks:
 
 ```json
 {
-  "targetIDs": ["task-1", "task-2"],
-  "taskPatch": {
-    "flagged": true,
-    "dueDate": "2026-04-18T16:00:00Z"
-  },
-  "previewOnly": true,
-  "returnFields": ["id", "name", "flagged", "dueDate"]
-}
-```
-
-Call `update_tasks` again with `"previewOnly": false` and `"verify": true` after confirmation.
-
-### Complete Tasks
-
-```json
-{
+  "operation": "set_completion",
   "targetIDs": ["task-1", "task-2"],
   "completion": { "state": "completed" },
   "verify": true,
@@ -187,25 +101,26 @@ Call `update_tasks` again with `"previewOnly": false` and `"verify": true` after
 }
 ```
 
-### Move Tasks To A Project
+Move tasks to a project:
 
 ```json
 {
-  "targetIDs": ["task-1", "task-2"],
+  "operation": "move",
+  "targetIDs": ["task-1"],
   "move": {
     "destinationKind": "project",
     "destinationID": "project-1",
     "position": "ending"
   },
-  "verify": true,
-  "returnFields": ["id", "name", "projectID", "projectName"]
+  "verify": true
 }
 ```
 
-### Update Project Status
+Put a project on hold:
 
 ```json
 {
+  "operation": "set_status",
   "targetIDs": ["project-1"],
   "projectStatus": { "status": "on_hold" },
   "verify": true,
@@ -213,39 +128,36 @@ Call `update_tasks` again with `"previewOnly": false` and `"verify": true` after
 }
 ```
 
-### Move Projects
-
-Before a folder move, call `list_folders` with compact fields if you do not already have the folder ID:
+Move a project to a folder:
 
 ```json
 {
-  "fields": ["id", "name", "parentID", "parentName"],
-  "limit": 50
-}
-```
-
-Then call `move_projects`:
-
-```json
-{
+  "operation": "move",
   "targetIDs": ["project-1"],
   "move": {
     "destinationKind": "folder",
     "destinationID": "folder-1",
     "position": "ending"
   },
-  "verify": true,
-  "returnFields": ["id", "name", "status"]
+  "verify": true
 }
 ```
 
-For root-library moves, omit `destinationID`.
+## Breaking Migration
 
-## Safety Notes
+There are no compatibility aliases. Add the discriminator and keep the former
+payload unchanged:
 
-- Prefer preview for every bulk write.
-- Ask for confirmation before real writes when the user has not explicitly approved the exact IDs and operation.
-- Do not use `update_tasks` to complete tasks; use `set_tasks_completion`.
-- Do not use `update_projects` to complete, drop, or move projects; use the lifecycle/status/move tools.
-- Do not mutate by name. Names are only for read-side discovery and user confirmation.
-- Do not attempt create/delete/repeat-rule/planned-date writes in v1.
+| Removed MCP tool | Replacement MCP arguments | Removed CLI command | Replacement CLI example |
+| --- | --- | --- | --- |
+| `update_tasks` | `edit_tasks`: `{"operation":"update","targetIDs":["ID"],"taskPatch":{"flagged":true}}` | `update-tasks` | `edit-tasks ID --operation update --flagged true` |
+| `set_tasks_completion` | `edit_tasks`: `{"operation":"set_completion","targetIDs":["ID"],"completion":{"state":"completed"}}` | `set-tasks-completion` | `edit-tasks ID --operation set_completion --state completed` |
+| `move_tasks` | `edit_tasks`: `{"operation":"move","targetIDs":["ID"],"move":{"destinationKind":"inbox"}}` | `move-tasks` | `edit-tasks ID --operation move --destination-kind inbox` |
+| `update_projects` | `edit_projects`: `{"operation":"update","targetIDs":["ID"],"projectPatch":{"flagged":true}}` | `update-projects` | `edit-projects ID --operation update --flagged true` |
+| `set_projects_status` | `edit_projects`: `{"operation":"set_status","targetIDs":["ID"],"projectStatus":{"status":"on_hold"}}` | `set-projects-status` | `edit-projects ID --operation set_status --status on_hold` |
+| `set_projects_completion` | `edit_projects`: `{"operation":"set_completion","targetIDs":["ID"],"completion":{"state":"completed"}}` | `set-projects-completion` | `edit-projects ID --operation set_completion --state completed` |
+| `move_projects` | `edit_projects`: `{"operation":"move","targetIDs":["ID"],"move":{"destinationKind":"folder","destinationID":"FOLDER_ID"}}` | `move-projects` | `edit-projects ID --operation move --destination-kind folder --destination-id FOLDER_ID` |
+
+Default mutation responses remain compact. For repeating tasks or projects,
+OmniFocus may complete an occurrence and advance the original item; use
+`verify=true` and inspect the returned per-target message.

--- a/docs/omni-automation-write-contract.md
+++ b/docs/omni-automation-write-contract.md
@@ -25,24 +25,23 @@ Relevant reference pages:
 - Keep CLI and MCP mutation semantics aligned to one shared contract.
 - v1 mutations are homogeneous bulk only: one call, one operation kind, one patch or destination or state applied to all passed IDs.
 - v1 mutations are ID-only. Name lookup remains a read-side concern.
-- `update_*` is for field patches only.
-- `set_*_completion` owns completion lifecycle transitions.
-- `set_projects_status` owns project status transitions.
-- `move_*` owns structural location changes.
+- `edit_tasks` and `edit_projects` require one explicit operation and exactly
+  one matching payload.
+- `update` is for field patches only.
+- `set_completion` owns completion lifecycle transitions.
+- Project `set_status` owns project status transitions.
+- `move` owns structural location changes.
+- Task status/drop changes are not supported until the task edit surface gains
+  a distinct status operation.
 - Successful mutations must invalidate cached `list_projects` and `list_tags` results before later reads.
 
 ## Locked V1 Public Surface
 
-### Task tools
-- `update_tasks`
-- `set_tasks_completion`
-- `move_tasks`
+### Task tool
+- `edit_tasks`: `update`, `set_completion`, or `move`
 
-### Project tools
-- `update_projects`
-- `set_projects_status`
-- `set_projects_completion`
-- `move_projects`
+### Project tool
+- `edit_projects`: `update`, `set_status`, `set_completion`, or `move`
 
 ## Shared Request Semantics
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -62,8 +62,8 @@ This document captures real-world use cases and questions users ask AI about the
 **MCP Tools Needed**:
 - `list_tasks` with inbox filter
 - `list_projects` (for categorization context)
-- `update_tasks` (rename, flag, tag, due/defer dates, estimates)
-- `move_tasks` (move inbox items to a project or parent task)
+- `edit_tasks` with `update` (rename, flag, tag, due/defer dates, estimates)
+- `edit_tasks` with `move` (move inbox items to a project or parent task)
 - Future: `create_task`, `create_project` when an inbox item needs a new destination
 
 ---
@@ -83,7 +83,7 @@ This document captures real-world use cases and questions users ask AI about the
 **MCP Tools Needed**:
 - `list_tasks` with estimatedMinutes field
 - `list_tasks` with due date filters
-- `update_tasks` to set estimates
+- `edit_tasks` with `update` to set estimates
 
 ---
 
@@ -162,8 +162,8 @@ This document captures real-world use cases and questions users ask AI about the
 - `list_tasks` by project
 - `get_project_counts`
 - `get_task_counts`
-- `set_projects_status` (put projects on hold, reactivate, or drop)
-- `set_projects_completion` (complete or uncomplete projects)
+- `edit_projects` with `set_status` (put projects on hold, reactivate, or drop)
+- `edit_projects` with `set_completion` (complete or uncomplete projects)
 
 ---
 
@@ -316,13 +316,13 @@ This document captures real-world use cases and questions users ask AI about the
 
 ### Current Write Capabilities
 ✅ **Working Today**:
-- Update existing task fields with `update_tasks`
-- Complete or uncomplete tasks with `set_tasks_completion`
-- Move tasks to inbox, project, or parent task with `move_tasks`
-- Update existing project fields with `update_projects`
-- Set project active/on-hold/dropped status with `set_projects_status`
-- Complete or uncomplete projects with `set_projects_completion`
-- Move projects to a known folder ID or root library with `move_projects`
+- Update existing task fields with `edit_tasks` operation `update`
+- Complete or uncomplete tasks with `edit_tasks` operation `set_completion`
+- Move tasks with `edit_tasks` operation `move`
+- Update existing project fields with `edit_projects` operation `update`
+- Set project active/on-hold/dropped status with `edit_projects` operation `set_status`
+- Complete or uncomplete projects with `edit_projects` operation `set_completion`
+- Move projects with `edit_projects` operation `move`
 
 ⚠️ **Important Constraints**:
 - Writes target IDs only; use read tools first to resolve names to IDs.


### PR DESCRIPTION
## Summary
- replace seven MCP mutation tools and CLI subcommands with `edit_tasks`/`edit_projects` and `edit-tasks`/`edit-projects`
- enforce operation-discriminated payloads while preserving the existing mutation service contract
- add wire, CLI, parity, schema, annotation, and golden production-catalog coverage
- document one-to-one migration and controlled model evaluation evidence

## Validation
- `swift run focusrelay-dev validate --impact server-wire`
- 148 enabled Swift tests passed; live-only tests skipped by their explicit traits
- release binary built successfully
- direct MCP handshake confirmed 9 tools and legacy-tool rejection
- reversible live UAT passed for all seven replaced mutation operations and restored original OmniFocus state
- Kimi K2.7 Code: 8/8 scenarios on released and consolidated catalogs
- OpenAI GPT-5.4 Mini: 8/8 scenarios on released and consolidated catalogs
- final independent review: no findings

## Catalog
- 9 public tools
- 25,154 serialized bytes
- 5,470 description characters

Closes #91