### PR TITLE
Refresh consolidated edit command documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** Seven task and project mutation tools and CLI commands were
+  consolidated into `edit_tasks` / `edit-tasks` and
+  `edit_projects` / `edit-projects`. Each request now selects an explicit
+  operation and supplies exactly one matching payload; legacy aliases were
+  removed. See the
+  [migration table](docs/mutation-workflows.md#breaking-migration).
+
 ## [0.10.1-beta] - 2026-07-19
 
 ### Added

--- a/NEXT-STEPS.md
+++ b/NEXT-STEPS.md
@@ -1,6 +1,6 @@
 # FocusRelay Next Steps
 
-Last updated: 2026-07-19
+Last updated: 2026-07-20
 
 GitHub issues are the source of truth for deliverables and validation evidence.
 The concise dependency order lives in
@@ -8,15 +8,11 @@ The concise dependency order lives in
 
 ## Current Priority
 
-1. [#75](https://github.com/deverman/FocusRelayMCP/issues/75) — upgrade the
-   Swift MCP SDK and remove deprecated response construction.
-2. [#91](https://github.com/deverman/FocusRelayMCP/issues/91) — consolidate task
-   and project editing without reducing model correctness.
-3. [#129](https://github.com/deverman/FocusRelayMCP/issues/129) — support true
+1. [#129](https://github.com/deverman/FocusRelayMCP/issues/129) — support true
    task dropping and restoration without recording false completion history.
-4. [#94](https://github.com/deverman/FocusRelayMCP/issues/94) — research
+2. [#94](https://github.com/deverman/FocusRelayMCP/issues/94) — research
    discoverable MCP workflow prompts and slash-command compatibility.
-5. [#82](https://github.com/deverman/FocusRelayMCP/issues/82) and
+3. [#82](https://github.com/deverman/FocusRelayMCP/issues/82) and
    [#83](https://github.com/deverman/FocusRelayMCP/issues/83) — create tasks,
    subtasks, and projects safely.
 

--- a/README.md
+++ b/README.md
@@ -28,23 +28,23 @@ Try prompts like:
 - “Set [task name] due tomorrow at 5 PM in my local timezone and verify the
   change.”
 
-These workflows were tested against the released Homebrew build with Kimi K2.7
-Code, and the inbox query with a second MCP-capable model. Updates target stable
-OmniFocus IDs and can verify the saved result. If names are duplicated, ask to
-see the candidates before changing anything.
+These workflows were tested with Kimi K2.7 Code and another MCP-capable model.
+Updates target stable OmniFocus IDs and can verify the saved result. If names
+are duplicated, ask to see the candidates before changing anything.
 
-FocusRelay 0.10.0-beta can:
+The current source build can:
 
 - find and count tasks using dates, flags, tags, projects, availability, inbox
   state, completion, estimates, and text search;
 - review projects, folders, tags, task counts, and stalled work;
 - update names, notes, flags, dates, estimates, tags, project settings, and
   review intervals;
-- complete, reactivate, change status, and move existing tasks and projects;
+- complete, reactivate, and move existing tasks;
+- complete, reactivate, change status, and move existing projects;
 - preview a proposed change and verify the saved result.
 
-The current beta updates existing tasks and projects. Creating or deleting
-items is not part of this release; creation is tracked in
+The current source build updates existing tasks and projects. Creating or
+deleting items is not supported; creation is tracked in
 [#82](https://github.com/deverman/FocusRelayMCP/issues/82) and
 [#83](https://github.com/deverman/FocusRelayMCP/issues/83).
 
@@ -52,9 +52,10 @@ items is not part of this release; creation is tracked in
 
 ### Keep the assistant focused
 
-FocusRelay exposes 14 model-facing tools—seven for reading and seven for making
-supported changes. Internal diagnostics stay in the CLI, count commands avoid
-returning long item lists, and field selection keeps responses compact.
+The current source build exposes nine model-facing tools: seven read tools plus
+`edit_tasks` and `edit_projects` for supported changes. Internal diagnostics
+stay in the CLI, count commands avoid returning long item lists, and field
+selection keeps responses compact.
 
 ### Native Swift speed at real-library scale
 
@@ -73,7 +74,7 @@ database.
 
 ### Make changes you can check
 
-Update tools target stable IDs and support previews, per-item results, compact
+Edit tools target stable IDs and support previews, per-item results, compact
 return fields, and optional verification. A failed save, update, or verification
 is reported as a failure—not success.
 
@@ -201,6 +202,11 @@ MCP lets compatible assistants discover FocusRelay and choose the right action.
 The CLI is useful for scripts, debugging, and agents that already have shell
 access.
 
+The examples below target the current source build. The latest Homebrew release,
+`v0.10.1-beta`, predates the consolidated edit commands and still exposes the
+former 14-tool surface. Build from source to use `edit-tasks` and
+`edit-projects` before the next release updates Homebrew.
+
 ```bash
 # Count without returning every matching task
 focusrelay task-counts --flagged true
@@ -235,7 +241,7 @@ and applies changes through documented OmniFocus APIs.
 | --- | --- | --- | --- | --- | --- |
 | Runtime | **Native Swift · Homebrew** | TypeScript · npx | TypeScript · npx | Native Rust · Homebrew; Python and TypeScript available | Python · uvx |
 | OmniFocus access | **Bridge plug-in inside Omni Automation; documented APIs** | JXA and Omni Automation through `osascript` | Omni Automation through `osascript` | Omni Automation through `osascript` | Internal SQLite read cache; OmniJS fallback |
-| Public MCP tools | **9 after [#91](https://github.com/deverman/FocusRelayMCP/issues/91); 11 after planned creation tools [#82](https://github.com/deverman/FocusRelayMCP/issues/82) and [#83](https://github.com/deverman/FocusRelayMCP/issues/83)** | 12 | 18 | 45 | 11 |
+| Public MCP tools | **Current source: 9, with seven read tools plus `edit_tasks` and `edit_projects`; 11 after planned creation tools [#82](https://github.com/deverman/FocusRelayMCP/issues/82) and [#83](https://github.com/deverman/FocusRelayMCP/issues/83)** | 12 | 18 | 45 | 11 |
 | Find, filter, and count tasks | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Update existing tasks | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Update existing projects | ✅ | ✅ | ✅ | ✅ | ◇ v1.5 roadmap |

--- a/docs/inbox-filing-architecture.md
+++ b/docs/inbox-filing-architecture.md
@@ -85,5 +85,7 @@ do {
 ```
 
 ## Notes
-- If we add write tools later, batch updates and require explicit confirmations.
+- For existing inbox tasks, use homogeneous `edit_tasks` `update` and `move`
+  operations and require explicit confirmation for broad changes.
+- Creating a missing project, tag, or destination remains future work.
 - Avoid sending full catalogs into the prompt unless asked.

--- a/docs/mutation-change-checklist.md
+++ b/docs/mutation-change-checklist.md
@@ -3,17 +3,16 @@
 Use this before changing any production mutation path in FocusRelay.
 
 Scope:
-- Future mutation logic in `Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js`
 - Mutation logic in `Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js`
-- Future shared mutation models and services
-- Future CLI and MCP mutation command wiring
+- Shared mutation models and services
+- CLI and MCP edit-command wiring
 
 ## 1. Freeze The Contract First
 
 Before coding, write down:
 - the documented Omni Automation write APIs the change is allowed to use
 - the exact public tool or CLI shape being introduced or modified
-- whether the mutation is a patch, lifecycle transition, or move
+- whether the mutation is a patch, lifecycle transition, status change, or move
 - the validation and failure semantics
 - whether cache invalidation is required after success
 
@@ -92,7 +91,7 @@ Do not:
 
 ## 6. Verify The Read-After-Write Contract
 
-For every mutation tool, define the post-write readback rule up front:
+For every mutation operation, define the post-write readback rule up front:
 - what fields are returned by default
 - what fields are returned only when `returnFields` is set
 - when `verify=true` is required or recommended
@@ -100,8 +99,8 @@ For every mutation tool, define the post-write readback rule up front:
 
 Minimum readback invariants:
 - the target ID remains stable after non-repeating updates and moves
-- completion/status tools report the final lifecycle state accurately
-- repeating completion tools document and verify the returned object identity behavior
+- completion/status operations report the final lifecycle state accurately
+- repeating completion operations document and verify the returned object identity behavior
 - cache invalidation prevents stale `list_projects` and `list_tags` responses after success
 
 ## 7. Update Docs Before Shipping
@@ -109,7 +108,7 @@ Minimum readback invariants:
 Before merge, make sure:
 - public docs reflect the exact tool names and schemas
 - examples show both single-item and homogeneous-bulk usage
-- docs explain the split between patch vs lifecycle vs move tools
+- docs explain the split between patch, lifecycle, status, and move operations
 - docs state what is intentionally out of scope for v1
 
 If the change alters install, approval, or restart behavior:

--- a/docs/omni-automation-write-contract.md
+++ b/docs/omni-automation-write-contract.md
@@ -3,9 +3,9 @@
 This document defines the Omni Automation APIs and product rules that are allowed in FocusRelay v1 mutation paths.
 
 Scope:
-- Any future task or project mutation helper in `Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js`
-- Mutation helpers in `Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js`
-- Any future shared mutation core used by CLI and MCP
+- Current and future task or project mutation helpers in
+  `Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js`
+- The shared mutation core used by CLI and MCP
 
 Workflow companion:
 - [`docs/mutation-change-checklist.md`](./mutation-change-checklist.md)
@@ -59,7 +59,7 @@ Relevant reference pages:
 - `previewOnly=true` validates and resolves targets without mutating OmniFocus.
 - `verify=true` performs a post-write readback using the documented read path and returns the resolved post-state.
 - `returnFields` is opt-in and limits post-write payload shape.
-- Mutation tools should default to compact result summaries rather than full object payloads.
+- Mutation operations should default to compact result summaries rather than full object payloads.
 
 ### Failure semantics
 - Validation failures should be reported before any mutation is attempted.
@@ -140,7 +140,7 @@ Relevant reference pages:
 - Notification mutation
 - Repetition-rule mutation
 - Project review date direct mutation using undocumented surfaces
-- Tag reordering as part of update tools
+- Tag reordering as part of the `update` operation
 - Placement controls beyond documented move destinations unless a later issue validates a concrete use case
 - `plannedDate` writes
 
@@ -148,7 +148,8 @@ Relevant reference pages:
 
 ### Repeating completion semantics
 - `markComplete(...)` on repeating tasks and projects can clone the repeated item and mark that clone complete.
-- `set_*_completion` must treat repeating items as lifecycle operations that require post-write verification rather than assuming a simple boolean flip.
+- `set_completion` must treat repeating items as lifecycle operations that
+  require post-write verification rather than assuming a simple boolean flip.
 
 ### Project root-task details
 - Omni Automation documents that many “task-like” project properties are ultimately held on the project’s root task.

--- a/docs/roadmap-execution-plan.md
+++ b/docs/roadmap-execution-plan.md
@@ -1,47 +1,40 @@
 # FocusRelay Roadmap Execution Plan
 
-Last updated: 2026-07-19
+Last updated: 2026-07-20
 
 GitHub issues own requirements, discussion, and validation evidence. This file
 records only current sequencing and cross-issue dependencies.
 
 ## Delivery Order
 
-1. [#75 — Swift MCP SDK maintenance](https://github.com/deverman/FocusRelayMCP/issues/75)
-   - Upgrade to `0.12.1` and remove deprecated response construction before
-     adding prompt responses.
-2. [#91 — Smaller edit interface](https://github.com/deverman/FocusRelayMCP/issues/91)
-   - Preserve or improve model tool selection, correctness, call count,
-     retries, latency, and user experience. Catalog size is supporting evidence,
-     not a hard limit.
-3. [#129 — task dropping and restoration](https://github.com/deverman/FocusRelayMCP/issues/129)
+1. [#129 — task dropping and restoration](https://github.com/deverman/FocusRelayMCP/issues/129)
    - Keep dropping distinct from completing so cleanup does not create false
      completion history.
-4. [#94 — Discoverable MCP workflows](https://github.com/deverman/FocusRelayMCP/issues/94)
+2. [#94 — Discoverable MCP workflows](https://github.com/deverman/FocusRelayMCP/issues/94)
    - Research daily focus, weekly review, inbox processing, and project
      planning before fixing the public prompt set.
-5. [#82 — Task/subtask creation](https://github.com/deverman/FocusRelayMCP/issues/82), then
+3. [#82 — Task/subtask creation](https://github.com/deverman/FocusRelayMCP/issues/82), then
    [#83 — project creation/conversion](https://github.com/deverman/FocusRelayMCP/issues/83)
    - Build on the consolidated edit surface, support safe project folder
      destinations, and retain duplicate/write safety.
-6. [#93 — repetition support](https://github.com/deverman/FocusRelayMCP/issues/93)
+4. [#93 — repetition support](https://github.com/deverman/FocusRelayMCP/issues/93)
    - After task creation and truthful drop behavior stabilize, establish complete
      schedule readback before adding create, edit, and lifecycle mutation slices.
-7. [#70 — parent-aware tag discovery](https://github.com/deverman/FocusRelayMCP/issues/70), then
+5. [#70 — parent-aware tag discovery](https://github.com/deverman/FocusRelayMCP/issues/70), then
    [#130 — project tag membership and filtering](https://github.com/deverman/FocusRelayMCP/issues/130), then
    [#128 — create and assign missing tags](https://github.com/deverman/FocusRelayMCP/issues/128)
    - Resolve root and nested tags safely, query direct project membership by
      stable ID, then create missing tags during assignment.
-8. [#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88), then
+6. [#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88), then
    [#87 — project-health filters](https://github.com/deverman/FocusRelayMCP/issues/87)
    - Reduce context before expanding project-review workflows.
-9. [#85 — safe Forecast contract](https://github.com/deverman/FocusRelayMCP/issues/85), then
+7. [#85 — safe Forecast contract](https://github.com/deverman/FocusRelayMCP/issues/85), then
    [#125 — Forecast-based attention](https://github.com/deverman/FocusRelayMCP/issues/125), then
    [#126 — broader ranked task search](https://github.com/deverman/FocusRelayMCP/issues/126)
    - Reuse one documented task-only Forecast classifier for attention ranking.
    - Keep search independent, broad, relevance-ranked, and lightweight.
-10. Small independent query improvements: #11, #22, #18, #59, and #62.
-11. Feasibility work for #10 custom perspectives and #16 planned-date writes.
+8. Small independent query improvements: #11, #22, #18, #59, and #62.
+9. Feasibility work for #10 custom perspectives and #16 planned-date writes.
 
 ## Standing Decisions
 

--- a/docs/search-discovery-task-list.md
+++ b/docs/search-discovery-task-list.md
@@ -99,13 +99,16 @@ Future alternative, only if client-managed installation becomes valuable:
 
 ## 3. Correct directory listings
 
-Use this correction packet for every listing:
+Use this correction packet after the consolidated edit commands ship in a
+Homebrew release. Until then, keep directory listings aligned with the current
+released catalog rather than advertising source-only commands.
 
 > **FocusRelay** is a free, open-source OmniFocus MCP server and CLI for macOS.
 > It is written in Swift, runs locally, and uses documented OmniFocus APIs. The
-> current beta provides 14 focused MCP tools for reading and safely updating
-> tasks and projects. Install it with Homebrew; it is not an npm package and is
-> not cross-platform. License: MIT. Repository:
+> current build provides nine focused MCP tools: seven read tools and two
+> consolidated edit tools for safely updating tasks and projects. Install it
+> with Homebrew; it is not an npm package and is not cross-platform. License:
+> MIT. Repository:
 > https://github.com/deverman/FocusRelayMCP
 
 Install commands:
@@ -146,14 +149,17 @@ Ready-to-post update:
 > **FocusRelay 0.10 beta: AI can now safely update OmniFocus**
 >
 > FocusRelay can now do more than answer questions about your OmniFocus data.
-> AI tools can update task and project details, dates, flags, tags, status, and
-> location while previewing or verifying important changes. FocusRelay remains
-> a fast, local Swift app that uses documented OmniFocus APIs and keeps its MCP
-> tool set deliberately small to reduce context use. Install it with Homebrew
-> and see examples at https://github.com/deverman/FocusRelayMCP
+> AI tools can update task and project details, dates, flags, tags, and location;
+> complete or reopen tasks and projects; and change project status while
+> previewing or verifying important changes. Task dropping and restoration are
+> not yet supported. FocusRelay remains a fast, local Swift app that uses
+> documented OmniFocus APIs and keeps its MCP tool set deliberately small to
+> reduce context use. Install it with Homebrew and see examples at
+> https://github.com/deverman/FocusRelayMCP
 
 Before posting, replace `0.10 beta` if a newer release is current and confirm
-every listed update still works in the release UAT.
+every listed update still works in the release UAT. Do not post the nine-tool
+claim before the consolidated edit commands are available through Homebrew.
 
 ## 5. Submit to maintained collections
 


### PR DESCRIPTION
## Summary
- update the README and discovery copy for the nine-tool source catalog and two consolidated edit tools
- distinguish the current source interface from the released `v0.10.1-beta` Homebrew interface
- record the breaking command migration under Unreleased
- remove completed #75/#91 work from active roadmap sequencing
- align mutation contracts, checklists, and inbox architecture with operation-based edits

## Validation
- `swift run focusrelay-dev validate --impact docs`
- Markdown links valid
- whitespace checks clean
- stale-language scan leaves legacy command names only in the explicit migration table and historical records
- independent final review: no findings

Closes #136