### PR TITLE
Clarify roadmap ownership and sequencing

### DIFF
--- a/NEXT-STEPS.md
+++ b/NEXT-STEPS.md
@@ -1,20 +1,10 @@
 # FocusRelay Next Steps
 
-Last updated: 2026-07-20
+Last updated: 2026-07-23
 
 GitHub issues are the source of truth for deliverables and validation evidence.
 The concise dependency order lives in
 [`docs/roadmap-execution-plan.md`](docs/roadmap-execution-plan.md).
-
-## Current Priority
-
-1. [#129](https://github.com/deverman/FocusRelayMCP/issues/129) — support true
-   task dropping and restoration without recording false completion history.
-2. [#94](https://github.com/deverman/FocusRelayMCP/issues/94) — research
-   discoverable MCP workflow prompts and slash-command compatibility.
-3. [#82](https://github.com/deverman/FocusRelayMCP/issues/82) and
-   [#83](https://github.com/deverman/FocusRelayMCP/issues/83) — create tasks,
-   subtasks, and projects safely.
 
 The `v0.10.1-beta` release and its evidence are recorded in the GitHub release,
 release tracker #131, and the repository history rather than duplicated

--- a/docs/roadmap-execution-plan.md
+++ b/docs/roadmap-execution-plan.md
@@ -13,31 +13,43 @@ records only current sequencing and cross-issue dependencies.
 2. [#138 — mark projects reviewed](https://github.com/deverman/FocusRelayMCP/issues/138)
    - Prove native Mark Reviewed parity with disposable projects before allowing
      the semantic `reviewedNow` mutation in production.
-3. [#94 — Discoverable MCP workflows](https://github.com/deverman/FocusRelayMCP/issues/94)
+3. [#144 — all-or-nothing bulk mutation preflight](https://github.com/deverman/FocusRelayMCP/issues/144)
+   - Block release until every target resolves and is eligible before any
+     task or project mutation applies or saves.
+4. [#143 — reject unknown MCP arguments](https://github.com/deverman/FocusRelayMCP/issues/143)
+   - Fail closed at the public MCP boundary so invalid filters cannot silently
+     become plausible unfiltered queries.
+5. [#145 — Review perspective status filtering](https://github.com/deverman/FocusRelayMCP/issues/145), then
+   [#146 — query-bound pagination cursors](https://github.com/deverman/FocusRelayMCP/issues/146), then
+   [#69 — project name search](https://github.com/deverman/FocusRelayMCP/issues/69)
+   - Make project discovery semantically scoped and pagination-safe before
+     expanding the read-before-write lookup contract.
+6. [#94 — Discoverable MCP workflows](https://github.com/deverman/FocusRelayMCP/issues/94)
    - Research daily focus, weekly review, inbox processing, and project
-     planning before fixing the public prompt set.
-4. [#82 — Task/subtask creation](https://github.com/deverman/FocusRelayMCP/issues/82), then
+     planning before fixing the public prompt set; implementation follows the
+     argument, Review, cursor, and project-lookup correctness work above.
+7. [#82 — Task/subtask creation](https://github.com/deverman/FocusRelayMCP/issues/82), then
    [#83 — project creation/conversion](https://github.com/deverman/FocusRelayMCP/issues/83)
    - Build on the consolidated edit surface, support safe project folder
      destinations, and retain duplicate/write safety.
-5. [#93 — repetition support](https://github.com/deverman/FocusRelayMCP/issues/93)
+8. [#93 — repetition support](https://github.com/deverman/FocusRelayMCP/issues/93)
    - After task creation and truthful drop behavior stabilize, establish complete
      schedule readback before adding create, edit, and lifecycle mutation slices.
-6. [#70 — parent-aware tag discovery](https://github.com/deverman/FocusRelayMCP/issues/70), then
+9. [#70 — parent-aware tag discovery](https://github.com/deverman/FocusRelayMCP/issues/70), then
    [#130 — project tag membership and filtering](https://github.com/deverman/FocusRelayMCP/issues/130), then
    [#128 — create and assign missing tags](https://github.com/deverman/FocusRelayMCP/issues/128)
    - Resolve root and nested tags safely, query direct project membership by
      stable ID, then create missing tags during assignment.
-7. [#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88), then
+10. [#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88), then
    [#87 — project-health filters](https://github.com/deverman/FocusRelayMCP/issues/87)
    - Reduce context before expanding project-review workflows.
-8. [#85 — safe Forecast contract](https://github.com/deverman/FocusRelayMCP/issues/85), then
+11. [#85 — safe Forecast contract](https://github.com/deverman/FocusRelayMCP/issues/85), then
    [#125 — Forecast-based attention](https://github.com/deverman/FocusRelayMCP/issues/125), then
    [#126 — broader ranked task search](https://github.com/deverman/FocusRelayMCP/issues/126)
    - Reuse one documented task-only Forecast classifier for attention ranking.
    - Keep search independent, broad, relevance-ranked, and lightweight.
-9. Small independent query improvements: #11, #22, #18, #59, and #62.
-10. Feasibility work for #10 custom perspectives and #16 planned-date writes.
+12. Small independent query improvements: #11, #22, #18, #59, and #62.
+13. Feasibility work for #10 custom perspectives and #16 planned-date writes.
 
 ## Standing Decisions
 
@@ -50,6 +62,11 @@ records only current sequencing and cross-issue dependencies.
 - Run the realistic 1.5-hour suite once per frozen production fingerprint.
 - Performance work must show a user-relevant latency/reliability win after
   semantic correctness passes.
+- Review-bankruptcy UAT measured project queries at 0.38–0.89 seconds; its
+  multi-minute delay came from inconsistent pagination, large ID/result
+  payloads, manual target reconstruction, and retry work. Reduce returned
+  context through scoped queries and existing #69/#87 work before proposing a
+  raw query-engine optimization.
 - Public tool count and serialized catalog size are directional optimization
   evidence; they must not override correctness, routing reliability, or real
   and perceived performance.

--- a/docs/roadmap-execution-plan.md
+++ b/docs/roadmap-execution-plan.md
@@ -1,6 +1,6 @@
 # FocusRelay Roadmap Execution Plan
 
-Last updated: 2026-07-20
+Last updated: 2026-07-23
 
 GitHub issues own requirements, discussion, and validation evidence. This file
 records only current sequencing and cross-issue dependencies.
@@ -10,31 +10,34 @@ records only current sequencing and cross-issue dependencies.
 1. [#129 — task dropping and restoration](https://github.com/deverman/FocusRelayMCP/issues/129)
    - Keep dropping distinct from completing so cleanup does not create false
      completion history.
-2. [#94 — Discoverable MCP workflows](https://github.com/deverman/FocusRelayMCP/issues/94)
+2. [#138 — mark projects reviewed](https://github.com/deverman/FocusRelayMCP/issues/138)
+   - Prove native Mark Reviewed parity with disposable projects before allowing
+     the semantic `reviewedNow` mutation in production.
+3. [#94 — Discoverable MCP workflows](https://github.com/deverman/FocusRelayMCP/issues/94)
    - Research daily focus, weekly review, inbox processing, and project
      planning before fixing the public prompt set.
-3. [#82 — Task/subtask creation](https://github.com/deverman/FocusRelayMCP/issues/82), then
+4. [#82 — Task/subtask creation](https://github.com/deverman/FocusRelayMCP/issues/82), then
    [#83 — project creation/conversion](https://github.com/deverman/FocusRelayMCP/issues/83)
    - Build on the consolidated edit surface, support safe project folder
      destinations, and retain duplicate/write safety.
-4. [#93 — repetition support](https://github.com/deverman/FocusRelayMCP/issues/93)
+5. [#93 — repetition support](https://github.com/deverman/FocusRelayMCP/issues/93)
    - After task creation and truthful drop behavior stabilize, establish complete
      schedule readback before adding create, edit, and lifecycle mutation slices.
-5. [#70 — parent-aware tag discovery](https://github.com/deverman/FocusRelayMCP/issues/70), then
+6. [#70 — parent-aware tag discovery](https://github.com/deverman/FocusRelayMCP/issues/70), then
    [#130 — project tag membership and filtering](https://github.com/deverman/FocusRelayMCP/issues/130), then
    [#128 — create and assign missing tags](https://github.com/deverman/FocusRelayMCP/issues/128)
    - Resolve root and nested tags safely, query direct project membership by
      stable ID, then create missing tags during assignment.
-6. [#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88), then
+7. [#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88), then
    [#87 — project-health filters](https://github.com/deverman/FocusRelayMCP/issues/87)
    - Reduce context before expanding project-review workflows.
-7. [#85 — safe Forecast contract](https://github.com/deverman/FocusRelayMCP/issues/85), then
+8. [#85 — safe Forecast contract](https://github.com/deverman/FocusRelayMCP/issues/85), then
    [#125 — Forecast-based attention](https://github.com/deverman/FocusRelayMCP/issues/125), then
    [#126 — broader ranked task search](https://github.com/deverman/FocusRelayMCP/issues/126)
    - Reuse one documented task-only Forecast classifier for attention ranking.
    - Keep search independent, broad, relevance-ranked, and lightweight.
-8. Small independent query improvements: #11, #22, #18, #59, and #62.
-9. Feasibility work for #10 custom perspectives and #16 planned-date writes.
+9. Small independent query improvements: #11, #22, #18, #59, and #62.
+10. Feasibility work for #10 custom perspectives and #16 planned-date writes.
 
 ## Standing Decisions
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -337,28 +337,11 @@ This document captures real-world use cases and questions users ask AI about the
 - Name-based or fuzzy mutation targeting
 - Planned-date writes
 
-## Priority Roadmap
+## Product Roadmap
 
-### Phase 1: Read And Write Foundation
-1. Date range filters (`dueBefore`, `dueAfter`, completion windows)
-2. Duration filtering (`maxEstimatedMinutes`)
-3. Tag-based filtering
-4. Completion date parity
-5. V1 mutation tools for existing tasks and projects
-
-### Phase 2: Search & Discovery (Medium Priority)
-1. Add `search_projects` tool
-2. Add `search_tags` tool
-3. Add per-project task counts
-4. Add folder discovery for project moves
-5. Add analytics endpoints
-
-### Phase 3: Creation And Advanced Writes (Future)
-1. Task creation tools
-2. Project creation tools
-3. Inbox processing automation that can create missing destinations
-4. Delete/archive tools with explicit confirmation
-5. Advanced batch workflows if a clear safe contract emerges
+Current delivery order and dependencies live only in
+[`roadmap-execution-plan.md`](roadmap-execution-plan.md). GitHub issues own the
+detailed behavior contracts and validation evidence.
 
 ## Success Metrics
 


### PR DESCRIPTION
## Summary

- make the execution plan the only canonical delivery sequence
- insert issue #138 after #129 and before workflow research and creation work
- replace duplicate and stale roadmap sections with links to the canonical plan

## Validation

- swift run focusrelay-dev validate --impact docs
- git diff --check

The documented --base option is not accepted by the current focusrelay-dev helper, so the supported docs impact command was used.