### PR TITLE
Add task drop and restore status mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Task dropping and restoration through `edit_tasks` / `edit-tasks` operation
+  `set_status`, including explicit repeating occurrence/series scope, preview,
+  verified `taskStatus` and `dropDate` readback, and all-or-nothing preflight.
+
 ### Changed
 
 - **Breaking:** Seven task and project mutation tools and CLI commands were

--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -107,6 +107,7 @@
       const dueDate = hasField("dueDate") ? safe(() => t.dueDate) : null;
       const plannedDate = hasField("plannedDate") ? safe(() => t.plannedDate) : null;
       const deferDate = hasField("deferDate") ? safe(() => t.deferDate) : null;
+      const dropDate = hasField("dropDate") ? safe(() => t.dropDate) : null;
 
       return {
         id: hasField("id") ? String(safe(() => t.id.primaryKey) || "") : null,
@@ -120,6 +121,8 @@
         plannedDate: hasField("plannedDate") && plannedDate ? plannedDate.toISOString() : null,
         deferDate: hasField("deferDate") && deferDate ? deferDate.toISOString() : null,
         completionDate: hasField("completionDate") ? (safe(() => t.completionDate) ? t.completionDate.toISOString() : null) : null,
+        dropDate: hasField("dropDate") && dropDate ? dropDate.toISOString() : null,
+        taskStatus: hasField("taskStatus") ? normalizedTaskLifecycleStatus(t) : null,
         completed: hasField("completed") ? isCompletedStatus(t) : null,
         flagged: hasField("flagged") ? Boolean(t.flagged) : null,
         effectiveFlagged: hasField("effectiveFlagged") ? isTaskEffectivelyFlagged(t) : null,
@@ -193,7 +196,7 @@
     }
 
     function mutationEnvelope(targetType, operationKind, mutation, ids, results, previewOnlyOverride) {
-      const successCount = results.filter(result => result.status === "previewed" || result.status === "mutated").length;
+      const successCount = results.filter(result => result.status === "previewed" || result.status === "mutated" || result.status === "unchanged").length;
       return {
         targetType: targetType,
         operationKind: operationKind,
@@ -304,6 +307,21 @@
           } catch (error) {
             results.push(stageFailure(id, "preview validation", error));
           }
+          return;
+        }
+
+        if (options.isNoOp && options.isNoOp(target, id)) {
+          const unchanged = {
+            id: id,
+            status: "unchanged",
+            message: options.unchangedMessage ? options.unchangedMessage(target, id) : "Target already satisfies the requested state."
+          };
+          try {
+            unchanged.returnedFields = options.returnedFields(target, {}, id);
+          } catch (error) {
+            unchanged.message += " Unable to return requested fields: " + errorDetail(error);
+          }
+          results.push(unchanged);
           return;
         }
 
@@ -716,6 +734,77 @@
         return "Completion state must be either active or completed.";
       }
       return null;
+    }
+
+    function normalizedTaskLifecycleStatus(task) {
+      if (isCompletedStatus(task)) { return "completed"; }
+      if (isDroppedStatus(task)) { return "dropped"; }
+      return "active";
+    }
+
+    function validateTaskStatusMutation(taskStatusMutation) {
+      if (!taskStatusMutation || !taskStatusMutation.status) {
+        return "set_tasks_status requires a taskStatus payload.";
+      }
+      if (taskStatusMutation.status !== "active" && taskStatusMutation.status !== "dropped") {
+        return "Task status must be either active or dropped.";
+      }
+      if (taskStatusMutation.status === "active" && taskStatusMutation.recurrenceScope) {
+        return "recurrenceScope is only valid when dropping a repeating task.";
+      }
+      if (taskStatusMutation.recurrenceScope && taskStatusMutation.recurrenceScope !== "occurrence" && taskStatusMutation.recurrenceScope !== "series") {
+        return "recurrenceScope must be occurrence or series.";
+      }
+      return null;
+    }
+
+    function preflightTaskStatusMutation(ids, taskByID, taskStatusMutation) {
+      const failures = [];
+      ids.forEach(id => {
+        const task = taskByID[id];
+        if (!task) {
+          failures.push(id + ": target ID not found");
+          return;
+        }
+        if (isCompletedStatus(task)) {
+          failures.push(id + ": completed tasks must first be reopened with set_completion");
+          return;
+        }
+        const isRepeating = Boolean(safe(() => task.repetitionRule));
+        if (taskStatusMutation.status === "dropped" && isRepeating && !taskStatusMutation.recurrenceScope) {
+          failures.push(id + ": repeating tasks require recurrenceScope occurrence or series");
+        }
+        if (taskStatusMutation.status === "dropped" && !isRepeating && taskStatusMutation.recurrenceScope) {
+          failures.push(id + ": recurrenceScope is not valid for a non-repeating task");
+        }
+      });
+      if (failures.length === 0) { return null; }
+      return "Task status preflight failed: " + failures.join("; ") + ". No tasks were changed.";
+    }
+
+    function taskStatusPreviewMessage(task, taskStatusMutation) {
+      const requestedStatus = taskStatusMutation.status;
+      const currentStatus = normalizedTaskLifecycleStatus(task);
+      const descendants = toTaskArray(safe(() => task.flattenedTasks)).filter(child => !isCompletedStatus(child) && !isDroppedStatus(child)).length;
+      const descendantMessage = descendants > 0 ? " " + descendants + " descendant task(s) may change effective availability." : "";
+      if (currentStatus === requestedStatus) {
+        return "Validated target; task already has " + requestedStatus + " status and no write is needed." + descendantMessage;
+      }
+      return "Validated target for " + requestedStatus + " status preview." + descendantMessage;
+    }
+
+    function applyTaskStatus(task, taskStatusMutation) {
+      if (taskStatusMutation.status === "active") {
+        task.active = true;
+      } else {
+        task.drop(taskStatusMutation.recurrenceScope === "series");
+      }
+      return {};
+    }
+
+    function verifyTaskStatus(task, requestedStatus) {
+      const actual = normalizedTaskLifecycleStatus(task);
+      return actual === requestedStatus ? null : "task did not reach " + requestedStatus + " status.";
     }
 
     function currentTaskTagIDs(task) {
@@ -1654,6 +1743,30 @@
                   verify: project => verifyProjectMove(project, destination),
                   returnedFields: project => projectReturnedFields(project, mutation.returnFields),
                   mutatedMessage: () => verifiedMessage("Project moved to " + destination.label + ".", mutation.verify)
+                });
+                response.data = mutationEnvelope(targetType, operation.kind, mutation, ids, results);
+              }
+            }
+          } else if (operation.kind === "set_tasks_status") {
+            const statusError = validateTaskStatusMutation(operation.taskStatus);
+            if (statusError) {
+              response.data = failedMutationEnvelope(targetType, operation.kind, mutation, ids, statusError);
+            } else {
+              const taskByID = taskByIDIndex();
+              const preflightError = preflightTaskStatusMutation(ids, taskByID, operation.taskStatus);
+              if (preflightError) {
+                response.data = failedMutationEnvelope(targetType, operation.kind, mutation, ids, preflightError);
+              } else {
+                const requestedStatus = operation.taskStatus.status;
+                const results = executeTargetMutation(ids, taskByID, mutation, {
+                  saveMode: "batch",
+                  previewMessage: task => taskStatusPreviewMessage(task, operation.taskStatus),
+                  isNoOp: task => normalizedTaskLifecycleStatus(task) === requestedStatus,
+                  unchangedMessage: () => "Task already has " + requestedStatus + " status; no write was needed.",
+                  apply: task => applyTaskStatus(task, operation.taskStatus),
+                  verify: task => verifyTaskStatus(task, requestedStatus),
+                  returnedFields: task => taskReturnedFields(task, mutation.returnFields),
+                  mutatedMessage: () => verifiedMessage(requestedStatus === "dropped" ? "Task dropped." : "Task restored to active.", mutation.verify)
                 });
                 response.data = mutationEnvelope(targetType, operation.kind, mutation, ids, results);
               }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The current source build can:
 - review projects, folders, tags, task counts, and stalled work;
 - update names, notes, flags, dates, estimates, tags, project settings, and
   review intervals;
-- complete, reactivate, and move existing tasks;
+- drop, restore, complete, reactivate, and move existing tasks;
 - complete, reactivate, change status, and move existing projects;
 - preview a proposed change and verify the saved result.
 

--- a/Sources/FocusRelayCLI/CLIHelpers.swift
+++ b/Sources/FocusRelayCLI/CLIHelpers.swift
@@ -3,6 +3,8 @@ import Foundation
 import OmniFocusCore
 
 extension MutationCompletionState: ExpressibleByArgument {}
+extension MutationTaskStatus: ExpressibleByArgument {}
+extension MutationRecurrenceScope: ExpressibleByArgument {}
 extension MutationMoveDestinationKind: ExpressibleByArgument {}
 extension MutationProjectStatus: ExpressibleByArgument {}
 extension TaskEditOperation: ExpressibleByArgument {}

--- a/Sources/FocusRelayCLI/FocusRelayCLI.swift
+++ b/Sources/FocusRelayCLI/FocusRelayCLI.swift
@@ -232,20 +232,26 @@ struct ListFolders: AsyncParsableCommand {
 struct EditTasks: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "edit-tasks",
-        abstract: "Update, complete/reopen, or move existing tasks by ID.",
+        abstract: "Update, drop/restore, complete/reopen, or move existing tasks by ID.",
         aliases: ["edit_tasks"]
     )
 
     @Argument(help: "Task IDs to edit.")
     var ids: [String] = []
 
-    @Option(help: "Operation: update, set_completion, or move.")
+    @Option(help: "Operation: update, set_status, set_completion, or move.")
     var operation: TaskEditOperation
 
     @OptionGroup var patch: TaskPatchOptions
 
     @Option(help: "Completion state for set_completion: active or completed.")
     var state: MutationCompletionState?
+
+    @Option(help: "Task status for set_status: active or dropped.")
+    var status: MutationTaskStatus?
+
+    @Option(name: .customLong("recurrence-scope"), help: "Repeating drop scope: occurrence or series.")
+    var recurrenceScope: MutationRecurrenceScope?
 
     @Option(help: "Destination kind for move: inbox, project, or parent_task.")
     var destinationKind: MutationMoveDestinationKind?
@@ -267,6 +273,9 @@ struct EditTasks: AsyncParsableCommand {
 
     func makeRequest() throws -> MutationRequest {
         let taskPatch = try patch.makeTaskPatchMutation()
+        if recurrenceScope != nil, status == nil {
+            throw ValidationError("--recurrence-scope requires --status dropped.")
+        }
         let hasMovePayload = destinationKind != nil || destinationID != nil || position != nil
         let move: MoveMutation?
         if hasMovePayload {
@@ -282,6 +291,7 @@ struct EditTasks: AsyncParsableCommand {
             targetIDs: ids,
             operation: operation,
             taskPatch: taskPatch.isEmpty ? nil : taskPatch,
+            taskStatus: status.map { TaskStatusMutation(status: $0, recurrenceScope: recurrenceScope) },
             completion: state.map(CompletionMutation.init(state:)),
             move: move,
             previewOnly: previewOnly,

--- a/Sources/FocusRelayServer/FocusRelayServer.swift
+++ b/Sources/FocusRelayServer/FocusRelayServer.swift
@@ -49,6 +49,7 @@ public enum FocusRelayServer {
             properties: properties,
             operationPayloads: [
                 "update": "taskPatch",
+                "set_status": "taskStatus",
                 "set_completion": "completion",
                 "move": "move"
             ]
@@ -393,12 +394,12 @@ public enum FocusRelayServer {
                 ),
                 Tool(
                     name: "edit_tasks",
-                    description: "Edit existing OmniFocus tasks by ID. Choose exactly one operation and include only its matching payload: update with taskPatch, set_completion with completion, or move with move. One call applies the same operation and payload to every target.\n\nUse update for fields and tags, set_completion only for complete/reopen, and move for inbox/project/parent changes. Dropping, discarding, abandoning, or cancelling tasks is not supported and must not be treated as completion. No plannedDate writes.\n\nSet previewOnly=true to validate without writing. Use verify=true for post-write readback. Repeating completion may advance the original task.",
+                    description: "Edit existing OmniFocus tasks by ID. Choose exactly one operation and include only its matching payload: update with taskPatch, set_status with taskStatus, set_completion with completion, or move with move. One call applies the same operation and payload to every target.\n\nUse update for fields and tags, set_status for dropping/restoring, set_completion only for complete/reopen, and move for inbox/project/parent changes. Never translate drop, discard, abandon, or cancel into completion. Repeating drops require an explicit occurrence or series scope. No plannedDate writes.\n\nSet previewOnly=true to validate without writing. Use verify=true for post-write readback. Repeating completion may advance the original task.",
                     inputSchema: makeTaskEditSchema(
                         properties: [
                             "operation": .object([
                                 "type": .string("string"),
-                                "enum": .array([.string("update"), .string("set_completion"), .string("move")]),
+                                "enum": .array([.string("update"), .string("set_status"), .string("set_completion"), .string("move")]),
                                 "description": .string("Required edit operation. Include exactly one matching payload.")
                             ]),
                             "targetIDs": .object([
@@ -441,6 +442,22 @@ public enum FocusRelayServer {
                                     ])
                                 ]),
                                 "required": .array([.string("state")])
+                            ]),
+                            "taskStatus": .object([
+                                "type": .string("object"),
+                                "description": .string("Required only for operation=set_status. Use dropped to discard without completion or active to restore a dropped task."),
+                                "properties": .object([
+                                    "status": .object([
+                                        "type": .string("string"),
+                                        "enum": .array([.string("active"), .string("dropped")])
+                                    ]),
+                                    "recurrenceScope": .object([
+                                        "type": .string("string"),
+                                        "enum": .array([.string("occurrence"), .string("series")]),
+                                        "description": .string("Required when dropping a repeating task and forbidden otherwise.")
+                                    ])
+                                ]),
+                                "required": .array([.string("status")])
                             ]),
                             "move": .object([
                                 "type": .string("object"),
@@ -753,10 +770,7 @@ public enum FocusRelayServer {
     static func decodeTaskEditRequest(from args: [String: Value]?) throws -> MutationRequest {
         let operationName = try decodeArgument(String.self, from: args, key: "operation")
         guard let operationName else {
-            throw MutationValidationError("edit_tasks requires an operation: update, set_completion, or move.")
-        }
-        if operationName == "set_status" {
-            throw MutationValidationError("Task dropping is not supported. Do not use set_completion to drop, discard, abandon, or cancel a task.")
+            throw MutationValidationError("edit_tasks requires an operation: update, set_status, set_completion, or move.")
         }
         guard let operation = TaskEditOperation(rawValue: operationName) else {
             throw MutationValidationError("Unsupported edit_tasks operation: \(operationName).")
@@ -766,6 +780,7 @@ public enum FocusRelayServer {
             targetIDs: try decodeArgument([String].self, from: args, key: "targetIDs") ?? [],
             operation: operation,
             taskPatch: try decodeArgument(TaskPatchMutation.self, from: args, key: "taskPatch"),
+            taskStatus: try decodeArgument(TaskStatusMutation.self, from: args, key: "taskStatus"),
             completion: try decodeArgument(CompletionMutation.self, from: args, key: "completion"),
             move: try decodeArgument(MoveMutation.self, from: args, key: "move"),
             previewOnly: try decodeArgument(Bool.self, from: args, key: "previewOnly") ?? false,

--- a/Sources/OmniFocusCore/MutationModels.swift
+++ b/Sources/OmniFocusCore/MutationModels.swift
@@ -7,6 +7,7 @@ public enum MutationTargetType: String, Codable, Sendable {
 
 public enum MutationOperationKind: String, Codable, Sendable {
     case updateTasks = "update_tasks"
+    case setTasksStatus = "set_tasks_status"
     case setTasksCompletion = "set_tasks_completion"
     case moveTasks = "move_tasks"
     case updateProjects = "update_projects"
@@ -17,6 +18,7 @@ public enum MutationOperationKind: String, Codable, Sendable {
 
 public enum TaskEditOperation: String, Codable, Sendable {
     case update
+    case setStatus = "set_status"
     case setCompletion = "set_completion"
     case move
 }
@@ -31,6 +33,16 @@ public enum ProjectEditOperation: String, Codable, Sendable {
 public enum MutationCompletionState: String, Codable, Sendable {
     case active
     case completed
+}
+
+public enum MutationTaskStatus: String, Codable, Sendable {
+    case active
+    case dropped
+}
+
+public enum MutationRecurrenceScope: String, Codable, Sendable {
+    case occurrence
+    case series
 }
 
 public enum MutationProjectStatus: String, Codable, Sendable {
@@ -49,6 +61,7 @@ public enum MutationMoveDestinationKind: String, Codable, Sendable {
 public enum MutationItemStatus: String, Codable, Sendable {
     case previewed
     case mutated
+    case unchanged
     case failed
 }
 
@@ -378,6 +391,22 @@ public struct CompletionMutation: Codable, Sendable, Equatable {
     }
 }
 
+public struct TaskStatusMutation: Codable, Sendable, Equatable {
+    public let status: MutationTaskStatus
+    public let recurrenceScope: MutationRecurrenceScope?
+
+    public init(status: MutationTaskStatus, recurrenceScope: MutationRecurrenceScope? = nil) {
+        self.status = status
+        self.recurrenceScope = recurrenceScope
+    }
+
+    public func validate() throws {
+        if status == .active, recurrenceScope != nil {
+            throw MutationValidationError("recurrenceScope is only valid when dropping a repeating task.")
+        }
+    }
+}
+
 public struct ProjectStatusMutation: Codable, Sendable, Equatable {
     public let status: MutationProjectStatus
 
@@ -441,6 +470,7 @@ public struct MutationOperation: Codable, Sendable, Equatable {
     public let taskPatch: TaskPatchMutation?
     public let projectPatch: ProjectPatchMutation?
     public let completion: CompletionMutation?
+    public let taskStatus: TaskStatusMutation?
     public let projectStatus: ProjectStatusMutation?
     public let move: MoveMutation?
 
@@ -449,6 +479,7 @@ public struct MutationOperation: Codable, Sendable, Equatable {
         taskPatch: TaskPatchMutation? = nil,
         projectPatch: ProjectPatchMutation? = nil,
         completion: CompletionMutation? = nil,
+        taskStatus: TaskStatusMutation? = nil,
         projectStatus: ProjectStatusMutation? = nil,
         move: MoveMutation? = nil
     ) {
@@ -456,6 +487,7 @@ public struct MutationOperation: Codable, Sendable, Equatable {
         self.taskPatch = taskPatch
         self.projectPatch = projectPatch
         self.completion = completion
+        self.taskStatus = taskStatus
         self.projectStatus = projectStatus
         self.move = move
     }
@@ -489,31 +521,37 @@ public struct MutationRequest: Codable, Sendable, Equatable {
         targetIDs: [String],
         operation: TaskEditOperation,
         taskPatch: TaskPatchMutation? = nil,
+        taskStatus: TaskStatusMutation? = nil,
         completion: CompletionMutation? = nil,
         move: MoveMutation? = nil,
         previewOnly: Bool = false,
         verify: Bool = false,
         returnFields: [String]? = nil
     ) throws -> MutationRequest {
-        let payloads = [taskPatch != nil, completion != nil, move != nil].filter { $0 }.count
+        let payloads = [taskPatch != nil, taskStatus != nil, completion != nil, move != nil].filter { $0 }.count
         guard payloads == 1 else {
-            throw MutationValidationError("edit_tasks requires exactly one operation payload: taskPatch, completion, or move.")
+            throw MutationValidationError("edit_tasks requires exactly one operation payload: taskPatch, taskStatus, completion, or move.")
         }
 
         let mutationOperation: MutationOperation
         switch operation {
         case .update:
-            guard let taskPatch, completion == nil, move == nil else {
+            guard let taskPatch, taskStatus == nil, completion == nil, move == nil else {
                 throw MutationValidationError("edit_tasks operation update requires only taskPatch.")
             }
             mutationOperation = MutationOperation(kind: .updateTasks, taskPatch: taskPatch)
+        case .setStatus:
+            guard let taskStatus, taskPatch == nil, completion == nil, move == nil else {
+                throw MutationValidationError("edit_tasks operation set_status requires only taskStatus.")
+            }
+            mutationOperation = MutationOperation(kind: .setTasksStatus, taskStatus: taskStatus)
         case .setCompletion:
-            guard let completion, taskPatch == nil, move == nil else {
+            guard let completion, taskPatch == nil, taskStatus == nil, move == nil else {
                 throw MutationValidationError("edit_tasks operation set_completion requires only completion.")
             }
             mutationOperation = MutationOperation(kind: .setTasksCompletion, completion: completion)
         case .move:
-            guard let move, taskPatch == nil, completion == nil else {
+            guard let move, taskPatch == nil, taskStatus == nil, completion == nil else {
                 throw MutationValidationError("edit_tasks operation move requires only move.")
             }
             mutationOperation = MutationOperation(kind: .moveTasks, move: move)
@@ -600,6 +638,14 @@ public struct MutationRequest: Codable, Sendable, Equatable {
                 throw MutationValidationError("update_tasks requires a non-empty taskPatch.")
             }
             try taskPatch.validate()
+        case .setTasksStatus:
+            guard targetType == .task else {
+                throw MutationValidationError("set_tasks_status requires task targets.")
+            }
+            guard let taskStatus = operation.taskStatus else {
+                throw MutationValidationError("set_tasks_status requires a taskStatus payload.")
+            }
+            try taskStatus.validate()
         case .setTasksCompletion:
             guard targetType == .task else {
                 throw MutationValidationError("set_tasks_completion requires task targets.")
@@ -659,7 +705,7 @@ public struct MutationRequest: Codable, Sendable, Equatable {
     private static let allowedTaskReturnFields: Set<String> = [
         "id", "name", "note", "projectID", "projectName",
         "tagIDs", "tagNames", "dueDate", "plannedDate", "deferDate",
-        "completionDate", "completed", "flagged", "effectiveFlagged", "estimatedMinutes", "available"
+        "completionDate", "dropDate", "taskStatus", "completed", "flagged", "effectiveFlagged", "estimatedMinutes", "available"
     ]
 
     private static let allowedProjectReturnFields: Set<String> = [

--- a/Tests/FocusRelayCLITests/FocusRelayCLITests.swift
+++ b/Tests/FocusRelayCLITests/FocusRelayCLITests.swift
@@ -97,6 +97,37 @@ func editTasksParsesAndBuildsCompletionRequest() throws {
 }
 
 @Test
+func editTasksParsesAndBuildsStatusRequest() throws {
+    let command = try EditTasks.parse([
+        "task-1",
+        "--operation", "set_status",
+        "--status", "dropped",
+        "--recurrence-scope", "occurrence",
+        "--verify",
+        "--return-fields", "id,name,taskStatus,dropDate,completionDate"
+    ])
+
+    let request = try command.makeRequest()
+    #expect(request.operation.kind == .setTasksStatus)
+    #expect(request.operation.taskStatus == TaskStatusMutation(status: .dropped, recurrenceScope: .occurrence))
+    #expect(command.verify)
+}
+
+@Test
+func editTasksRejectsRecurrenceScopeWithoutStatus() throws {
+    let command = try EditTasks.parse([
+        "task-1",
+        "--operation", "set_completion",
+        "--state", "completed",
+        "--recurrence-scope", "series"
+    ])
+
+    #expect(throws: Error.self) {
+        _ = try command.makeRequest()
+    }
+}
+
+@Test
 func editTasksParsesAndBuildsMoveRequest() throws {
     let command = try EditTasks.parse([
         "task-1",

--- a/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
+++ b/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
@@ -259,6 +259,7 @@ func editToolSchemasRequireExactlyOneMatchingPayload() throws {
     ]
     let taskSchema = FocusRelayServer.makeTaskEditSchema(properties: common.merging([
         "taskPatch": .object(["type": .string("object")]),
+        "taskStatus": .object(["type": .string("object")]),
         "completion": .object(["type": .string("object")]),
         "move": .object(["type": .string("object")])
     ]) { _, new in new })
@@ -273,6 +274,7 @@ func editToolSchemasRequireExactlyOneMatchingPayload() throws {
         taskSchema,
         operationPayloads: [
             "update": "taskPatch",
+            "set_status": "taskStatus",
             "set_completion": "completion",
             "move": "move"
         ]
@@ -297,6 +299,17 @@ func taskEditWireArgumentsDispatchEveryOperation() throws {
     ])
     #expect(update.operation.kind == .updateTasks)
     #expect(update.operation.taskPatch?.flagged == true)
+
+    let status = try FocusRelayServer.decodeTaskEditRequest(from: [
+        "operation": .string("set_status"),
+        "targetIDs": .array([.string("task-1")]),
+        "taskStatus": .object([
+            "status": .string("dropped"),
+            "recurrenceScope": .string("series")
+        ])
+    ])
+    #expect(status.operation.kind == .setTasksStatus)
+    #expect(status.operation.taskStatus == TaskStatusMutation(status: .dropped, recurrenceScope: .series))
 
     let completion = try FocusRelayServer.decodeTaskEditRequest(from: [
         "operation": .string("set_completion"),
@@ -358,16 +371,13 @@ func editWireArgumentsRejectMissingMismatchedAndContradictoryPayloads() {
 }
 
 @Test
-func taskEditRejectsStatusInsteadOfTreatingDropAsCompletion() {
-    do {
-        _ = try FocusRelayServer.decodeTaskEditRequest(from: [
+func taskEditStatusRequiresTaskStatusPayload() {
+    #expect(throws: MutationValidationError.self) {
+        try FocusRelayServer.decodeTaskEditRequest(from: [
             "operation": .string("set_status"),
             "targetIDs": .array([.string("task-1")]),
             "projectStatus": .object(["status": .string("dropped")])
         ])
-        Issue.record("Expected task set_status to be rejected")
-    } catch {
-        #expect(error.localizedDescription.contains("Task dropping is not supported"))
     }
 }
 

--- a/Tests/OmniFocusCoreTests/MutationModelsTests.swift
+++ b/Tests/OmniFocusCoreTests/MutationModelsTests.swift
@@ -124,6 +124,7 @@ func consolidatedEditFactoriesPreserveSpecializedRequestShapes() throws {
     let shared = (previewOnly: true, verify: true, returnFields: ["id", "name"])
     let taskPatch = TaskPatchMutation(flagged: true)
     let completion = CompletionMutation(state: .completed)
+    let taskStatus = TaskStatusMutation(status: .dropped, recurrenceScope: .series)
     let taskMove = MoveMutation(destinationKind: .project, destinationID: "project-2", position: "ending")
     let projectPatch = ProjectPatchMutation(flagged: true)
     let projectStatus = ProjectStatusMutation(status: .onHold)
@@ -133,6 +134,10 @@ func consolidatedEditFactoriesPreserveSpecializedRequestShapes() throws {
         (
             try MutationRequest.editTasks(targetIDs: ["task-1"], operation: .update, taskPatch: taskPatch, previewOnly: shared.previewOnly, verify: shared.verify, returnFields: shared.returnFields),
             MutationRequest(targetType: .task, targetIDs: ["task-1"], operation: MutationOperation(kind: .updateTasks, taskPatch: taskPatch), previewOnly: shared.previewOnly, verify: shared.verify, returnFields: shared.returnFields)
+        ),
+        (
+            try MutationRequest.editTasks(targetIDs: ["task-1"], operation: .setStatus, taskStatus: taskStatus, previewOnly: shared.previewOnly, verify: shared.verify, returnFields: ["id", "taskStatus", "dropDate"]),
+            MutationRequest(targetType: .task, targetIDs: ["task-1"], operation: MutationOperation(kind: .setTasksStatus, taskStatus: taskStatus), previewOnly: shared.previewOnly, verify: shared.verify, returnFields: ["id", "taskStatus", "dropDate"])
         ),
         (
             try MutationRequest.editTasks(targetIDs: ["task-1"], operation: .setCompletion, completion: completion, previewOnly: shared.previewOnly, verify: shared.verify, returnFields: shared.returnFields),
@@ -162,6 +167,17 @@ func consolidatedEditFactoriesPreserveSpecializedRequestShapes() throws {
 
     for (consolidated, specialized) in cases {
         #expect(consolidated == specialized)
+    }
+}
+
+@Test
+func taskStatusMutationRejectsRecurrenceScopeWhenRestoring() {
+    #expect(throws: MutationValidationError.self) {
+        _ = try MutationRequest.editTasks(
+            targetIDs: ["task-1"],
+            operation: .setStatus,
+            taskStatus: TaskStatusMutation(status: .active, recurrenceScope: .occurrence)
+        )
     }
 }
 

--- a/Tests/OmniFocusIntegrationTests/BridgeMutationExecutionTests.swift
+++ b/Tests/OmniFocusIntegrationTests/BridgeMutationExecutionTests.swift
@@ -135,6 +135,57 @@ func successMessageFailurePreservesSavedMutationStatus() throws {
     #expect((results[0]["returnedFields"] as? [String: Any])?["value"] as? Int == 1)
 }
 
+@Test
+func alreadySatisfiedMutationSkipsApplyAndSave() throws {
+    let results = try evaluateMutationExecutor(
+        body: """
+        const target = { value: "dropped" };
+        let saveCount = 0;
+        globalThis.save = () => { saveCount += 1; };
+        const output = executeTargetMutation(["task-1"], { "task-1": target }, mutation, {
+          saveMode: "batch",
+          isNoOp: item => item.value === "dropped",
+          unchangedMessage: () => "Already dropped.",
+          apply: item => { item.value = "dropped"; return {}; },
+          verify: () => null,
+          returnedFields: item => ({ value: item.value }),
+          mutatedMessage: () => "Dropped."
+        });
+        output[0].saveCount = saveCount;
+        return output;
+        """
+    )
+
+    #expect(results[0]["status"] as? String == "unchanged")
+    #expect(results[0]["saveCount"] as? Int == 0)
+    #expect((results[0]["returnedFields"] as? [String: Any])?["value"] as? String == "dropped")
+}
+
+@Test
+func taskStatusPreflightRejectsEntireMixedBatch() throws {
+    let source = try String(contentsOf: bridgeLibraryURL, encoding: .utf8)
+    let preflight = try extractJavaScriptFunction(named: "preflightTaskStatusMutation", from: source)
+    let context = try #require(JSContext())
+    let script = """
+    const safe = fn => { try { return fn(); } catch (_) { return null; } };
+    const isCompletedStatus = task => task.status === "completed";
+    \(preflight)
+    preflightTaskStatusMutation(
+      ["eligible", "completed", "missing"],
+      {
+        eligible: { status: "active", repetitionRule: null },
+        completed: { status: "completed", repetitionRule: null }
+      },
+      { status: "dropped" }
+    );
+    """
+
+    let message = context.evaluateScript(script)?.toString()
+    #expect(message?.contains("completed: completed tasks must first be reopened") == true)
+    #expect(message?.contains("missing: target ID not found") == true)
+    #expect(message?.contains("No tasks were changed") == true)
+}
+
 private func evaluateMutationExecutor(body: String) throws -> [[String: Any]] {
     let source = try String(contentsOf: bridgeLibraryURL, encoding: .utf8)
     let safe = try extractJavaScriptFunction(named: "safe", from: source)

--- a/Tests/OmniFocusIntegrationTests/LiveTestEnvironment.swift
+++ b/Tests/OmniFocusIntegrationTests/LiveTestEnvironment.swift
@@ -2,6 +2,12 @@ import Foundation
 
 enum LiveTestEnvironment {
     static let bridgeEnabled = enabled("FOCUS_RELAY_BRIDGE_TESTS")
+    static let taskStatusMutationEnabled = bridgeEnabled && value("FOCUS_RELAY_TASK_STATUS_FIXTURE_ID") != nil
+
+    static func value(_ name: String) -> String? {
+        guard let value = ProcessInfo.processInfo.environment[name], !value.isEmpty else { return nil }
+        return value
+    }
 
     private static func enabled(_ name: String) -> Bool {
         ProcessInfo.processInfo.environment[name] == "1"

--- a/Tests/OmniFocusIntegrationTests/TaskStatusMutationLiveTests.swift
+++ b/Tests/OmniFocusIntegrationTests/TaskStatusMutationLiveTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Testing
+@testable import OmniFocusAutomation
+@testable import OmniFocusCore
+
+@Test(.enabled(
+    if: LiveTestEnvironment.taskStatusMutationEnabled,
+    "Set FOCUS_RELAY_BRIDGE_TESTS=1 and FOCUS_RELAY_TASK_STATUS_FIXTURE_ID to a disposable active, non-repeating task."
+))
+func taskStatusDropVerifyRestoreLive() async throws {
+    let taskID = try #require(LiveTestEnvironment.value("FOCUS_RELAY_TASK_STATUS_FIXTURE_ID"))
+    let service = OmniFocusBridgeService()
+    let fields = ["id", "name", "taskStatus", "dropDate", "completionDate"]
+
+    let preview = try await service.performMutation(try MutationRequest.editTasks(
+        targetIDs: [taskID],
+        operation: .setStatus,
+        taskStatus: TaskStatusMutation(status: .dropped),
+        previewOnly: true,
+        verify: true,
+        returnFields: fields
+    ))
+    #expect(preview.successCount == 1)
+    #expect(preview.failureCount == 0)
+
+    var requiresRestore = false
+    do {
+        let dropped = try await service.performMutation(try MutationRequest.editTasks(
+            targetIDs: [taskID],
+            operation: .setStatus,
+            taskStatus: TaskStatusMutation(status: .dropped),
+            verify: true,
+            returnFields: fields
+        ))
+        requiresRestore = true
+        let droppedFields = try #require(dropped.results.first?.returnedFields)
+        #expect(dropped.successCount == 1)
+        #expect(dropped.failureCount == 0)
+        #expect(droppedFields["taskStatus"] == .string("dropped"))
+        #expect(droppedFields["dropDate"] != .null)
+        #expect(droppedFields["completionDate"] == .null)
+
+        let restored = try await restoreTask(taskID, service: service, fields: fields)
+        requiresRestore = false
+        let restoredFields = try #require(restored.results.first?.returnedFields)
+        #expect(restored.successCount == 1)
+        #expect(restored.failureCount == 0)
+        #expect(restoredFields["taskStatus"] == .string("active"))
+        #expect(restoredFields["completionDate"] == .null)
+    } catch {
+        if requiresRestore {
+            _ = try? await restoreTask(taskID, service: service, fields: fields)
+        }
+        throw error
+    }
+}
+
+private func restoreTask(
+    _ taskID: String,
+    service: OmniFocusBridgeService,
+    fields: [String]
+) async throws -> MutationResponse {
+    try await service.performMutation(try MutationRequest.editTasks(
+        targetIDs: [taskID],
+        operation: .setStatus,
+        taskStatus: TaskStatusMutation(status: .active),
+        verify: true,
+        returnFields: fields
+    ))
+}

--- a/docs/mutation-change-checklist.md
+++ b/docs/mutation-change-checklist.md
@@ -24,6 +24,7 @@ Minimum invariant list:
 - v1 writes target IDs only
 - `update` is field patch only
 - `set_completion` owns completion lifecycle
+- `edit_tasks` operation `set_status` owns task active/dropped transitions
 - `edit_projects` operation `set_status` owns project active/on-hold/dropped transitions
 - `move` owns structural location changes
 - successful writes invalidate cached `list_projects` and `list_tags`
@@ -57,6 +58,7 @@ Minimum categories:
 
 Add focused coverage when applicable:
 - repeating task completion
+- repeating task occurrence/series drop behavior
 - repeating project completion
 - move destination validation
 - task tag add/remove/set behavior

--- a/docs/mutation-workflows.md
+++ b/docs/mutation-workflows.md
@@ -16,14 +16,17 @@ and payload to every target ID.
 - Use `verify=true` when post-write readback matters.
 - Use compact `returnFields` for only the state needed next.
 - Do not combine field, lifecycle, status, or move payloads in one request.
-- Task dropping is not supported. Never translate drop, discard, abandon, or
-  cancel into task completion.
+- Use task `set_status` for drop/restore. Never translate drop, discard,
+  abandon, or cancel into task completion.
+- Repeating task drops require `recurrenceScope=occurrence` or `series`;
+  non-repeating drops reject that field as irrelevant.
 
 ## Operation Routing
 
 | Intent | Tool | Operation | Matching payload |
 | --- | --- | --- | --- |
 | Change task fields or tags | `edit_tasks` | `update` | `taskPatch` |
+| Drop or restore tasks | `edit_tasks` | `set_status` | `taskStatus` |
 | Complete or reopen tasks | `edit_tasks` | `set_completion` | `completion` |
 | Move tasks | `edit_tasks` | `move` | `move` |
 | Change project fields | `edit_projects` | `update` | `projectPatch` |
@@ -69,6 +72,9 @@ Equivalent MCP call:
 ```bash
 focusrelay edit-tasks task-1 task-2 --operation update --estimated-minutes 30 --verify --return-fields id,name,estimatedMinutes
 focusrelay edit-tasks task-1 --operation update --tag-add tag-1 --verify --return-fields id,name,tagIDs,tagNames
+focusrelay edit-tasks task-1 --operation set_status --status dropped --verify --return-fields id,name,taskStatus,dropDate,completionDate
+focusrelay edit-tasks repeating-task-1 --operation set_status --status dropped --recurrence-scope occurrence --verify --return-fields id,name,taskStatus,dropDate,completionDate
+focusrelay edit-tasks task-1 --operation set_status --status active --verify --return-fields id,name,taskStatus,dropDate,completionDate
 focusrelay edit-tasks task-1 --operation set_completion --state completed --verify --return-fields id,name,completed,completionDate
 focusrelay edit-tasks task-1 --operation set_completion --state active --verify --return-fields id,name,completed,completionDate
 focusrelay edit-tasks task-1 --operation move --destination-kind inbox --verify --return-fields id,name,projectID
@@ -88,6 +94,19 @@ focusrelay edit-projects project-1 --operation move --destination-kind folder --
 ```
 
 ## MCP Examples
+
+Drop a non-repeating task without recording completion:
+
+```json
+{
+  "operation": "set_status",
+  "targetIDs": ["task-1"],
+  "taskStatus": { "status": "dropped" },
+  "previewOnly": true,
+  "verify": true,
+  "returnFields": ["id", "name", "taskStatus", "dropDate", "completionDate"]
+}
+```
 
 Complete tasks:
 

--- a/docs/omni-automation-write-contract.md
+++ b/docs/omni-automation-write-contract.md
@@ -29,16 +29,16 @@ Relevant reference pages:
   one matching payload.
 - `update` is for field patches only.
 - `set_completion` owns completion lifecycle transitions.
+- Task `set_status` owns active/dropped transitions and must never be translated
+  into completion.
 - Project `set_status` owns project status transitions.
 - `move` owns structural location changes.
-- Task status/drop changes are not supported until the task edit surface gains
-  a distinct status operation.
 - Successful mutations must invalidate cached `list_projects` and `list_tags` results before later reads.
 
 ## Locked V1 Public Surface
 
 ### Task tool
-- `edit_tasks`: `update`, `set_completion`, or `move`
+- `edit_tasks`: `update`, `set_status`, `set_completion`, or `move`
 
 ### Project tool
 - `edit_projects`: `update`, `set_status`, `set_completion`, or `move`
@@ -83,6 +83,8 @@ Relevant reference pages:
 ### Task lifecycle
 - `task.markComplete(date)`
 - `task.markIncomplete()`
+- `task.drop(allOccurrences)`
+- `task.active` for restoring a dropped task
 - `task.active`
 
 ### Task moves
@@ -126,6 +128,8 @@ Relevant reference pages:
 - Resolve task IDs to task objects and apply one homogeneous patch across all targets.
 - Resolve project IDs to project objects and apply one homogeneous patch across all targets.
 - Use `task.markComplete(...)` and `task.markIncomplete()` rather than synthesizing completion by direct date assignment.
+- Use `task.drop(...)` and `task.active` for drop/restore status changes; keep
+  occurrence-versus-series scope explicit for repeating tasks.
 - Use `project.markComplete(...)` and `project.markIncomplete()` rather than synthesizing completion by direct date assignment.
 - Use `project.status` for project active/on-hold/dropped transitions.
 - Use `moveTasks(...)` and `moveSections(...)` for structural moves instead of delete/recreate flows.

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -317,6 +317,7 @@ This document captures real-world use cases and questions users ask AI about the
 ### Current Write Capabilities
 ✅ **Working Today**:
 - Update existing task fields with `edit_tasks` operation `update`
+- Drop or restore tasks with `edit_tasks` operation `set_status`
 - Complete or uncomplete tasks with `edit_tasks` operation `set_completion`
 - Move tasks with `edit_tasks` operation `move`
 - Update existing project fields with `edit_projects` operation `update`


### PR DESCRIPTION
Closes #129

## Summary

- add edit_tasks set_status with active and dropped states
- require explicit occurrence or series scope for repeating drops
- preflight complete batches before writes and report already-satisfied targets as unchanged
- return normalized taskStatus, dropDate, and completionDate for verification
- add CLI parity, MCP wire coverage, deterministic JavaScriptCore contracts, live-test scaffolding, and user documentation

## Validation

- swift run focusrelay-dev validate --impact mutation
- 154 Swift Testing tests passed
- clean release build passed
- installed bridge health check passed after the required OmniFocus restart
- git diff --check

## Live UAT

Passed 2026-07-23 against the explicitly disposable active, non-repeating task `gLQq6L9uLDn`:

- non-writing drop preview passed
- invalid recurrence scope was rejected atomically for the non-repeating fixture
- drop with verification returned taskStatus=dropped, a non-null dropDate, and completionDate=null
- restore with verification returned taskStatus=active, dropDate=null, and completionDate=null
- formal `taskStatusDropVerifyRestoreLive` Swift Testing case passed

The fixture was restored to its original active lifecycle state.