### PR TITLE
Prototype project reviewed-now mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Active and on-hold projects can be marked reviewed through
+  `projectPatch.reviewedNow=true`; FocusRelay preflights the complete batch,
+  preserves review intervals, uses one local-day timestamp, and verifies the
+  OmniFocus-generated next review date.
+
 ### Changed
 
 - **Breaking:** Seven task and project mutation tools and CLI commands were

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Active and on-hold projects can be marked reviewed through
   `projectPatch.reviewedNow=true`; FocusRelay preflights the complete batch,
-  preserves review intervals, uses one local-day timestamp, and verifies the
+  preserves review intervals, uses one request-level timestamp, and verifies the
   OmniFocus-generated next review date.
 
 ### Changed

--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -604,10 +604,6 @@
       return { steps: steps, unit: unit };
     }
 
-    function reviewTimestampForNow(now) {
-      return Calendar.current.startOfDay(now);
-    }
-
     function preflightReviewedNow(ids, projectByID) {
       const failures = [];
       ids.forEach(id => {
@@ -1635,7 +1631,7 @@
               if (preflightError) {
                 response.data = failedMutationEnvelope(targetType, operation.kind, mutation, ids, preflightError);
               } else {
-                const reviewedAt = reviewTimestampForNow(new Date());
+                const reviewedAt = new Date();
                 const results = executeTargetMutation(ids, projectByID, mutation, {
                   saveMode: "batch",
                   previewMessage: () => "Validated eligible project for reviewedNow preview.",

--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -604,6 +604,10 @@
       return { steps: steps, unit: unit };
     }
 
+    function reviewTimestampForNow(now) {
+      return Calendar.current.startOfDay(now);
+    }
+
     function preflightReviewedNow(ids, projectByID) {
       const failures = [];
       ids.forEach(id => {
@@ -1631,7 +1635,7 @@
               if (preflightError) {
                 response.data = failedMutationEnvelope(targetType, operation.kind, mutation, ids, preflightError);
               } else {
-                const reviewedAt = new Date();
+                const reviewedAt = reviewTimestampForNow(new Date());
                 const results = executeTargetMutation(ids, projectByID, mutation, {
                   saveMode: "batch",
                   previewMessage: () => "Validated eligible project for reviewedNow preview.",

--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -296,11 +296,17 @@
 
         if (mutation.previewOnly) {
           try {
-            results.push({
+            const previewResult = {
               id: id,
               status: "previewed",
               message: options.previewMessage(target, id)
-            });
+            };
+            if (options.returnedFields) {
+              previewResult.returnedFields = options.previewReturnedFields
+                ? options.previewReturnedFields(target, id)
+                : options.returnedFields(target, {}, id);
+            }
+            results.push(previewResult);
           } catch (error) {
             results.push(stageFailure(id, "preview validation", error));
           }
@@ -561,6 +567,15 @@
 
     function validateProjectPatch(projectPatch) {
       if (!projectPatch) { return "update_projects requires a projectPatch payload."; }
+      if (projectPatch.reviewedNow !== undefined && projectPatch.reviewedNow !== null) {
+        if (projectPatch.reviewedNow !== true) {
+          return "reviewedNow only accepts true.";
+        }
+        const otherKeys = Object.keys(projectPatch).filter(key => key !== "reviewedNow" && projectPatch[key] !== undefined && projectPatch[key] !== null && projectPatch[key] !== false);
+        if (otherKeys.length > 0) {
+          return "reviewedNow must be the only projectPatch field.";
+        }
+      }
       if (projectPatch.dueDate && projectPatch.clearDueDate) {
         return "Project patches cannot set and clear dueDate in the same request.";
       }
@@ -578,6 +593,62 @@
         }
       }
       return null;
+    }
+
+    function reviewIntervalSnapshot(project) {
+      const interval = safe(() => project.reviewInterval);
+      if (!interval) { return null; }
+      const steps = Number(safe(() => interval.steps));
+      const unit = String(safe(() => interval.unit) || "");
+      if (!isFinite(steps) || steps <= 0 || unit.length === 0) { return null; }
+      return { steps: steps, unit: unit };
+    }
+
+    function preflightReviewedNow(ids, projectByID) {
+      const failures = [];
+      ids.forEach(id => {
+        const project = projectByID[id];
+        if (!project) {
+          failures.push(id + ": target ID not found");
+          return;
+        }
+        const status = projectStatusString(project);
+        if (status !== "active" && status !== "onHold") {
+          failures.push(id + ": project status " + status + " is not eligible for review");
+        }
+        if (!reviewIntervalSnapshot(project)) {
+          failures.push(id + ": project has no usable review interval");
+        }
+      });
+      return failures.length === 0
+        ? null
+        : "Project review preflight failed: " + failures.join("; ") + ". No projects were changed.";
+    }
+
+    function applyReviewedNow(project, reviewedAt) {
+      const reviewInterval = reviewIntervalSnapshot(project);
+      project.lastReviewDate = reviewedAt;
+      return { reviewedAt: reviewedAt, reviewInterval: reviewInterval };
+    }
+
+    function verifyReviewedNow(project, context) {
+      const lastReviewDate = safe(() => project.lastReviewDate);
+      if (!lastReviewDate || lastReviewDate.getTime() !== context.reviewedAt.getTime()) {
+        return "lastReviewDate did not match the request-level review timestamp.";
+      }
+      const currentInterval = reviewIntervalSnapshot(project);
+      if (!currentInterval || currentInterval.steps !== context.reviewInterval.steps || currentInterval.unit !== context.reviewInterval.unit) {
+        return "reviewInterval changed while marking the project reviewed.";
+      }
+      const nextReviewDate = safe(() => project.nextReviewDate);
+      if (!nextReviewDate || typeof nextReviewDate.getTime !== "function" || isNaN(nextReviewDate.getTime())) {
+        return "OmniFocus did not produce a usable nextReviewDate.";
+      }
+      return null;
+    }
+
+    function reviewedNowPreviewFields(project) {
+      return projectReturnedFields(project, ["id", "name", "status", "lastReviewDate", "nextReviewDate", "reviewInterval"]);
     }
 
     function applyProjectPatch(project, projectPatch) {
@@ -1554,6 +1625,24 @@
             const patchError = validateProjectPatch(operation.projectPatch);
             if (patchError) {
               response.data = failedMutationEnvelope(targetType, operation.kind, mutation, ids, patchError);
+            } else if (operation.projectPatch.reviewedNow === true) {
+              const projectByID = projectByIDIndex();
+              const preflightError = preflightReviewedNow(ids, projectByID);
+              if (preflightError) {
+                response.data = failedMutationEnvelope(targetType, operation.kind, mutation, ids, preflightError);
+              } else {
+                const reviewedAt = new Date();
+                const results = executeTargetMutation(ids, projectByID, mutation, {
+                  saveMode: "batch",
+                  previewMessage: () => "Validated eligible project for reviewedNow preview.",
+                  previewReturnedFields: project => reviewedNowPreviewFields(project),
+                  apply: project => applyReviewedNow(project, reviewedAt),
+                  verify: (project, context) => verifyReviewedNow(project, context),
+                  returnedFields: project => projectReturnedFields(project, mutation.returnFields),
+                  mutatedMessage: () => verifiedMessage("Project marked reviewed.", mutation.verify)
+                });
+                response.data = mutationEnvelope(targetType, operation.kind, mutation, ids, results);
+              }
             } else {
               const results = executeTargetMutation(ids, projectByIDIndex(), mutation, {
                 saveMode: "perItem",

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ The current source build can:
 - review projects, folders, tags, task counts, and stalled work;
 - update names, notes, flags, dates, estimates, tags, project settings, and
   review intervals;
+- mark active and on-hold projects reviewed using OmniFocus's native review-day
+  and next-review semantics;
 - complete, reactivate, and move existing tasks;
 - complete, reactivate, change status, and move existing projects;
 - preview a proposed change and verify the saved result.

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ The current source build can:
 - review projects, folders, tags, task counts, and stalled work;
 - update names, notes, flags, dates, estimates, tags, project settings, and
   review intervals;
-- mark active and on-hold projects reviewed using OmniFocus's native review-day
-  and next-review semantics;
+- mark active and on-hold projects reviewed using OmniFocus's native review
+  timestamp and next-review semantics;
 - complete, reactivate, and move existing tasks;
 - complete, reactivate, change status, and move existing projects;
 - preview a proposed change and verify the saved result.

--- a/Sources/FocusRelayCLI/CLIHelpers.swift
+++ b/Sources/FocusRelayCLI/CLIHelpers.swift
@@ -248,6 +248,9 @@ struct ProjectPatchOptions: ParsableArguments {
     @Option(name: .customLong("review-unit"), help: "Set review interval unit: days, weeks, months, years.")
     var reviewUnit: String? = nil
 
+    @Flag(name: .customLong("reviewed-now"), help: "Mark active or on-hold projects reviewed now. Must be the only update field.")
+    var reviewedNow: Bool = false
+
     func makeProjectPatchMutation() throws -> ProjectPatchMutation {
         let reviewInterval: ReviewInterval?
         switch (reviewSteps, reviewUnit) {
@@ -269,7 +272,8 @@ struct ProjectPatchOptions: ParsableArguments {
             deferDate: try ISO8601DateParser.parseOptional(deferDate, argumentName: "--defer-date"),
             clearDeferDate: clearDeferDate,
             sequential: sequential,
-            reviewInterval: reviewInterval
+            reviewInterval: reviewInterval,
+            reviewedNow: reviewedNow ? true : nil
         )
         try patch.validate()
         return patch

--- a/Sources/FocusRelayServer/FocusRelayServer.swift
+++ b/Sources/FocusRelayServer/FocusRelayServer.swift
@@ -505,7 +505,11 @@ public enum FocusRelayServer {
                                             "steps": propertySchema(type: "integer", description: "Review interval step count."),
                                             "unit": propertySchema(type: "string", description: "Review interval unit, such as days, weeks, months, or years.")
                                         ])
-                                    ])
+                                    ]),
+                                    "reviewedNow": propertySchema(
+                                        type: "boolean",
+                                        description: "Mark active or on-hold projects reviewed now. Only true is accepted, and it must be the only projectPatch field."
+                                    )
                                 ])
                             ]),
                             "projectStatus": .object([

--- a/Sources/OmniFocusCore/MutationModels.swift
+++ b/Sources/OmniFocusCore/MutationModels.swift
@@ -267,6 +267,7 @@ public struct ProjectPatchMutation: Codable, Sendable, Equatable {
     public let containsSingletonActions: Bool?
     public let completedByChildren: Bool?
     public let reviewInterval: ReviewInterval?
+    public let reviewedNow: Bool?
     public let tags: TagMutation?
 
     public init(
@@ -282,6 +283,7 @@ public struct ProjectPatchMutation: Codable, Sendable, Equatable {
         containsSingletonActions: Bool? = nil,
         completedByChildren: Bool? = nil,
         reviewInterval: ReviewInterval? = nil,
+        reviewedNow: Bool? = nil,
         tags: TagMutation? = nil
     ) {
         self.name = name
@@ -296,6 +298,7 @@ public struct ProjectPatchMutation: Codable, Sendable, Equatable {
         self.containsSingletonActions = containsSingletonActions
         self.completedByChildren = completedByChildren
         self.reviewInterval = reviewInterval
+        self.reviewedNow = reviewedNow
         self.tags = tags
     }
 
@@ -312,6 +315,7 @@ public struct ProjectPatchMutation: Codable, Sendable, Equatable {
         case containsSingletonActions
         case completedByChildren
         case reviewInterval
+        case reviewedNow
         case tags
     }
 
@@ -329,6 +333,7 @@ public struct ProjectPatchMutation: Codable, Sendable, Equatable {
         containsSingletonActions = try container.decodeIfPresent(Bool.self, forKey: .containsSingletonActions)
         completedByChildren = try container.decodeIfPresent(Bool.self, forKey: .completedByChildren)
         reviewInterval = try container.decodeIfPresent(ReviewInterval.self, forKey: .reviewInterval)
+        reviewedNow = try container.decodeIfPresent(Bool.self, forKey: .reviewedNow)
         tags = try container.decodeIfPresent(TagMutation.self, forKey: .tags)
     }
 
@@ -345,10 +350,23 @@ public struct ProjectPatchMutation: Codable, Sendable, Equatable {
         containsSingletonActions == nil &&
         completedByChildren == nil &&
         reviewInterval == nil &&
+        reviewedNow == nil &&
         tags == nil
     }
 
     public func validate() throws {
+        if let reviewedNow {
+            guard reviewedNow else {
+                throw MutationValidationError("reviewedNow only accepts true.")
+            }
+            let hasOtherField = name != nil || note != nil || noteAppend != nil || flagged != nil ||
+                dueDate != nil || clearDueDate || deferDate != nil || clearDeferDate ||
+                sequential != nil || containsSingletonActions != nil || completedByChildren != nil ||
+                reviewInterval != nil || tags != nil
+            if hasOtherField {
+                throw MutationValidationError("reviewedNow must be the only projectPatch field.")
+            }
+        }
         if containsSingletonActions != nil {
             throw MutationValidationError("containsSingletonActions updates are not supported yet; see the edit-surface consolidation roadmap item.")
         }

--- a/Tests/FocusRelayCLITests/FocusRelayCLITests.swift
+++ b/Tests/FocusRelayCLITests/FocusRelayCLITests.swift
@@ -140,6 +140,38 @@ func projectPatchOptionsBuildSharedProjectPatch() throws {
 }
 
 @Test
+func editProjectsParsesReviewedNowUpdate() throws {
+    let command = try EditProjects.parse([
+        "project-1", "project-2",
+        "--operation", "update",
+        "--reviewed-now",
+        "--preview-only",
+        "--verify",
+        "--return-fields", "id,name,status,lastReviewDate,nextReviewDate,reviewInterval"
+    ])
+
+    let request = try command.makeRequest()
+    #expect(request.operation.kind == .updateProjects)
+    #expect(request.operation.projectPatch?.reviewedNow == true)
+    #expect(request.previewOnly)
+    #expect(request.verify)
+}
+
+@Test
+func editProjectsRejectsReviewedNowWithOtherPatchFields() throws {
+    let command = try EditProjects.parse([
+        "project-1",
+        "--operation", "update",
+        "--reviewed-now",
+        "--flagged", "true"
+    ])
+
+    #expect(throws: MutationValidationError.self) {
+        _ = try command.makeRequest()
+    }
+}
+
+@Test
 func editProjectsParsesAndBuildsStatusRequest() throws {
     let command = try EditProjects.parse([
         "project-1",

--- a/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
+++ b/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
@@ -116,7 +116,8 @@ func everyPublicSparseProjectPatchSurvivesMCPValueDecoding() throws {
         ["deferDate": .string("2026-07-16T08:00:00Z")],
         ["clearDeferDate": .bool(true)],
         ["sequential": .bool(true)],
-        ["reviewInterval": .object(["steps": .int(2), "unit": .string("weeks")])]
+        ["reviewInterval": .object(["steps": .int(2), "unit": .string("weeks")])],
+        ["reviewedNow": .bool(true)]
     ]
 
     for value in cases {
@@ -330,6 +331,22 @@ func projectEditWireArgumentsDispatchEveryOperation() throws {
         ])
         #expect(request.operation.kind == expectedKind)
     }
+}
+
+@Test
+func projectReviewedNowWireArgumentsUseUpdatePatch() throws {
+    let request = try FocusRelayServer.decodeProjectEditRequest(from: [
+        "operation": .string("update"),
+        "targetIDs": .array([.string("project-1"), .string("project-2")]),
+        "projectPatch": .object(["reviewedNow": .bool(true)]),
+        "previewOnly": .bool(true),
+        "verify": .bool(true),
+        "returnFields": .array([.string("id"), .string("lastReviewDate"), .string("nextReviewDate")])
+    ])
+
+    #expect(request.operation.projectPatch?.reviewedNow == true)
+    #expect(request.previewOnly)
+    #expect(request.verify)
 }
 
 @Test

--- a/Tests/OmniFocusCoreTests/MutationModelsTests.swift
+++ b/Tests/OmniFocusCoreTests/MutationModelsTests.swift
@@ -45,13 +45,29 @@ func everySupportedSparseProjectFieldDecodes() throws {
         #"{"deferDate":"2026-07-15T09:00:00Z"}"#,
         #"{"clearDeferDate":true}"#,
         #"{"sequential":true}"#,
-        #"{"reviewInterval":{"steps":1,"unit":"weeks"}}"#
+        #"{"reviewInterval":{"steps":1,"unit":"weeks"}}"#,
+        #"{"reviewedNow":true}"#
     ]
 
     for patch in patches {
         let decoded = try decodeMutation(ProjectPatchMutation.self, from: patch)
         #expect(!decoded.isEmpty)
         try decoded.validate()
+    }
+}
+
+@Test
+func reviewedNowRejectsFalseAndMixedProjectPatches() {
+    let patches = [
+        ProjectPatchMutation(reviewedNow: false),
+        ProjectPatchMutation(flagged: true, reviewedNow: true),
+        ProjectPatchMutation(reviewInterval: ReviewInterval(steps: 1, unit: "weeks"), reviewedNow: true)
+    ]
+
+    for patch in patches {
+        #expect(throws: MutationValidationError.self) {
+            try patch.validate()
+        }
     }
 }
 

--- a/Tests/OmniFocusIntegrationTests/BridgeMutationExecutionTests.swift
+++ b/Tests/OmniFocusIntegrationTests/BridgeMutationExecutionTests.swift
@@ -165,15 +165,23 @@ func reviewedNowPreflightRejectsIneligibleAndMissingProjectsTogether() throws {
 func reviewedNowUsesOneTimestampAndPreservesIntervals() throws {
     let source = try String(contentsOf: bridgeLibraryURL, encoding: .utf8)
     let intervalSnapshot = try extractJavaScriptFunction(named: "reviewIntervalSnapshot", from: source)
+    let timestamp = try extractJavaScriptFunction(named: "reviewTimestampForNow", from: source)
     let apply = try extractJavaScriptFunction(named: "applyReviewedNow", from: source)
     let verify = try extractJavaScriptFunction(named: "verifyReviewedNow", from: source)
     let context = try #require(JSContext())
     let script = """
     const safe = fn => { try { return fn(); } catch (_) { return null; } };
+    const Calendar = {
+      current: {
+        startOfDay: date => new Date(date.getFullYear(), date.getMonth(), date.getDate())
+      }
+    };
     \(intervalSnapshot)
+    \(timestamp)
     \(apply)
     \(verify)
-    const reviewedAt = new Date("2026-07-23T01:02:03.456Z");
+    const now = new Date(2026, 6, 23, 9, 2, 3, 456);
+    const reviewedAt = reviewTimestampForNow(now);
     const first = { reviewInterval: { steps: 1, unit: "weeks" }, lastReviewDate: null, nextReviewDate: null };
     const second = { reviewInterval: { steps: 2, unit: "months" }, lastReviewDate: null, nextReviewDate: null };
     const firstContext = applyReviewedNow(first, reviewedAt);
@@ -182,6 +190,10 @@ func reviewedNowUsesOneTimestampAndPreservesIntervals() throws {
     second.nextReviewDate = new Date("2026-09-23T01:02:03.456Z");
     JSON.stringify({
       sameTimestamp: first.lastReviewDate.getTime() === second.lastReviewDate.getTime(),
+      localMidnight: first.lastReviewDate.getHours() === 0 &&
+        first.lastReviewDate.getMinutes() === 0 &&
+        first.lastReviewDate.getSeconds() === 0 &&
+        first.lastReviewDate.getMilliseconds() === 0,
       firstVerified: verifyReviewedNow(first, firstContext),
       secondVerified: verifyReviewedNow(second, secondContext),
       firstInterval: first.reviewInterval,
@@ -192,6 +204,7 @@ func reviewedNowUsesOneTimestampAndPreservesIntervals() throws {
     let json = try #require(context.evaluateScript(script)?.toString())
     let result = try #require(JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
     #expect(result["sameTimestamp"] as? Bool == true)
+    #expect(result["localMidnight"] as? Bool == true)
     #expect(result["firstVerified"] is NSNull)
     #expect(result["secondVerified"] is NSNull)
     #expect((result["firstInterval"] as? [String: Any])?["steps"] as? Int == 1)

--- a/Tests/OmniFocusIntegrationTests/BridgeMutationExecutionTests.swift
+++ b/Tests/OmniFocusIntegrationTests/BridgeMutationExecutionTests.swift
@@ -165,23 +165,15 @@ func reviewedNowPreflightRejectsIneligibleAndMissingProjectsTogether() throws {
 func reviewedNowUsesOneTimestampAndPreservesIntervals() throws {
     let source = try String(contentsOf: bridgeLibraryURL, encoding: .utf8)
     let intervalSnapshot = try extractJavaScriptFunction(named: "reviewIntervalSnapshot", from: source)
-    let timestamp = try extractJavaScriptFunction(named: "reviewTimestampForNow", from: source)
     let apply = try extractJavaScriptFunction(named: "applyReviewedNow", from: source)
     let verify = try extractJavaScriptFunction(named: "verifyReviewedNow", from: source)
     let context = try #require(JSContext())
     let script = """
     const safe = fn => { try { return fn(); } catch (_) { return null; } };
-    const Calendar = {
-      current: {
-        startOfDay: date => new Date(date.getFullYear(), date.getMonth(), date.getDate())
-      }
-    };
     \(intervalSnapshot)
-    \(timestamp)
     \(apply)
     \(verify)
-    const now = new Date(2026, 6, 23, 9, 2, 3, 456);
-    const reviewedAt = reviewTimestampForNow(now);
+    const reviewedAt = new Date("2026-07-23T01:02:03.456Z");
     const first = { reviewInterval: { steps: 1, unit: "weeks" }, lastReviewDate: null, nextReviewDate: null };
     const second = { reviewInterval: { steps: 2, unit: "months" }, lastReviewDate: null, nextReviewDate: null };
     const firstContext = applyReviewedNow(first, reviewedAt);
@@ -190,10 +182,6 @@ func reviewedNowUsesOneTimestampAndPreservesIntervals() throws {
     second.nextReviewDate = new Date("2026-09-23T01:02:03.456Z");
     JSON.stringify({
       sameTimestamp: first.lastReviewDate.getTime() === second.lastReviewDate.getTime(),
-      localMidnight: first.lastReviewDate.getHours() === 0 &&
-        first.lastReviewDate.getMinutes() === 0 &&
-        first.lastReviewDate.getSeconds() === 0 &&
-        first.lastReviewDate.getMilliseconds() === 0,
       firstVerified: verifyReviewedNow(first, firstContext),
       secondVerified: verifyReviewedNow(second, secondContext),
       firstInterval: first.reviewInterval,
@@ -204,7 +192,6 @@ func reviewedNowUsesOneTimestampAndPreservesIntervals() throws {
     let json = try #require(context.evaluateScript(script)?.toString())
     let result = try #require(JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
     #expect(result["sameTimestamp"] as? Bool == true)
-    #expect(result["localMidnight"] as? Bool == true)
     #expect(result["firstVerified"] is NSNull)
     #expect(result["secondVerified"] is NSNull)
     #expect((result["firstInterval"] as? [String: Any])?["steps"] as? Int == 1)

--- a/Tests/OmniFocusIntegrationTests/BridgeMutationExecutionTests.swift
+++ b/Tests/OmniFocusIntegrationTests/BridgeMutationExecutionTests.swift
@@ -135,6 +135,69 @@ func successMessageFailurePreservesSavedMutationStatus() throws {
     #expect((results[0]["returnedFields"] as? [String: Any])?["value"] as? Int == 1)
 }
 
+@Test
+func reviewedNowPreflightRejectsIneligibleAndMissingProjectsTogether() throws {
+    let source = try String(contentsOf: bridgeLibraryURL, encoding: .utf8)
+    let preflight = try extractJavaScriptFunction(named: "preflightReviewedNow", from: source)
+    let context = try #require(JSContext())
+    let script = """
+    const projectStatusString = project => project.status;
+    const reviewIntervalSnapshot = project => project.reviewInterval || null;
+    \(preflight)
+    preflightReviewedNow(
+      ["active", "done", "missing", "no-interval"],
+      {
+        active: { status: "active", reviewInterval: { steps: 1, unit: "weeks" } },
+        done: { status: "done", reviewInterval: { steps: 1, unit: "weeks" } },
+        "no-interval": { status: "onHold", reviewInterval: null }
+      }
+    );
+    """
+
+    let message = context.evaluateScript(script)?.toString()
+    #expect(message?.contains("done: project status done is not eligible") == true)
+    #expect(message?.contains("missing: target ID not found") == true)
+    #expect(message?.contains("no-interval: project has no usable review interval") == true)
+    #expect(message?.contains("No projects were changed") == true)
+}
+
+@Test
+func reviewedNowUsesOneTimestampAndPreservesIntervals() throws {
+    let source = try String(contentsOf: bridgeLibraryURL, encoding: .utf8)
+    let intervalSnapshot = try extractJavaScriptFunction(named: "reviewIntervalSnapshot", from: source)
+    let apply = try extractJavaScriptFunction(named: "applyReviewedNow", from: source)
+    let verify = try extractJavaScriptFunction(named: "verifyReviewedNow", from: source)
+    let context = try #require(JSContext())
+    let script = """
+    const safe = fn => { try { return fn(); } catch (_) { return null; } };
+    \(intervalSnapshot)
+    \(apply)
+    \(verify)
+    const reviewedAt = new Date("2026-07-23T01:02:03.456Z");
+    const first = { reviewInterval: { steps: 1, unit: "weeks" }, lastReviewDate: null, nextReviewDate: null };
+    const second = { reviewInterval: { steps: 2, unit: "months" }, lastReviewDate: null, nextReviewDate: null };
+    const firstContext = applyReviewedNow(first, reviewedAt);
+    const secondContext = applyReviewedNow(second, reviewedAt);
+    first.nextReviewDate = new Date("2026-07-30T01:02:03.456Z");
+    second.nextReviewDate = new Date("2026-09-23T01:02:03.456Z");
+    JSON.stringify({
+      sameTimestamp: first.lastReviewDate.getTime() === second.lastReviewDate.getTime(),
+      firstVerified: verifyReviewedNow(first, firstContext),
+      secondVerified: verifyReviewedNow(second, secondContext),
+      firstInterval: first.reviewInterval,
+      secondInterval: second.reviewInterval
+    });
+    """
+
+    let json = try #require(context.evaluateScript(script)?.toString())
+    let result = try #require(JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+    #expect(result["sameTimestamp"] as? Bool == true)
+    #expect(result["firstVerified"] is NSNull)
+    #expect(result["secondVerified"] is NSNull)
+    #expect((result["firstInterval"] as? [String: Any])?["steps"] as? Int == 1)
+    #expect((result["secondInterval"] as? [String: Any])?["steps"] as? Int == 2)
+}
+
 private func evaluateMutationExecutor(body: String) throws -> [[String: Any]] {
     let source = try String(contentsOf: bridgeLibraryURL, encoding: .utf8)
     let safe = try extractJavaScriptFunction(named: "safe", from: source)

--- a/docs/mutation-workflows.md
+++ b/docs/mutation-workflows.md
@@ -27,6 +27,7 @@ and payload to every target ID.
 | Complete or reopen tasks | `edit_tasks` | `set_completion` | `completion` |
 | Move tasks | `edit_tasks` | `move` | `move` |
 | Change project fields | `edit_projects` | `update` | `projectPatch` |
+| Mark active or on-hold projects reviewed | `edit_projects` | `update` | `projectPatch.reviewedNow=true` |
 | Activate, hold, or drop projects | `edit_projects` | `set_status` | `projectStatus` |
 | Complete or reopen projects | `edit_projects` | `set_completion` | `completion` |
 | Move projects | `edit_projects` | `move` | `move` |
@@ -79,6 +80,8 @@ focusrelay edit-tasks task-1 --operation move --destination-kind project --desti
 
 ```bash
 focusrelay edit-projects project-1 --operation update --sequential true --verify --return-fields id,name
+focusrelay edit-projects project-1 --operation update --reviewed-now --preview-only --return-fields id,name,status,lastReviewDate,nextReviewDate,reviewInterval
+focusrelay edit-projects project-1 --operation update --reviewed-now --verify --return-fields id,name,status,lastReviewDate,nextReviewDate,reviewInterval
 focusrelay edit-projects project-1 --operation set_status --status on_hold --verify --return-fields id,name,status
 focusrelay edit-projects project-1 --operation set_status --status dropped --verify --return-fields id,name,status
 focusrelay edit-projects project-1 --operation set_completion --state completed --verify --return-fields id,name,status,completionDate
@@ -127,6 +130,22 @@ Put a project on hold:
   "returnFields": ["id", "name", "status"]
 }
 ```
+
+Mark an active or on-hold project reviewed:
+
+```json
+{
+  "operation": "update",
+  "targetIDs": ["project-1"],
+  "projectPatch": { "reviewedNow": true },
+  "verify": true,
+  "returnFields": ["id", "name", "status", "lastReviewDate", "nextReviewDate", "reviewInterval"]
+}
+```
+
+`reviewedNow` must be the only project patch field. FocusRelay preflights the
+whole batch, uses one local-day review timestamp, preserves each review
+interval, and lets OmniFocus calculate each next review date.
 
 Move a project to a folder:
 

--- a/docs/mutation-workflows.md
+++ b/docs/mutation-workflows.md
@@ -144,7 +144,7 @@ Mark an active or on-hold project reviewed:
 ```
 
 `reviewedNow` must be the only project patch field. FocusRelay preflights the
-whole batch, uses one local-day review timestamp, preserves each review
+whole batch, uses one request-level review timestamp, preserves each review
 interval, and lets OmniFocus calculate each next review date.
 
 Move a project to a folder:

--- a/docs/omni-automation-write-contract.md
+++ b/docs/omni-automation-write-contract.md
@@ -112,7 +112,7 @@ Relevant reference pages:
 - `project.status`
 - `project.markComplete(date)`
 - `project.markIncomplete()`
-- `project.lastReviewDate`, assigned to `Calendar.current.startOfDay(now)` for
+- `project.lastReviewDate`, assigned one request-level current timestamp for
   active or on-hold projects after complete-batch eligibility preflight
 
 ### Project moves
@@ -130,7 +130,7 @@ Relevant reference pages:
 - Use `task.markComplete(...)` and `task.markIncomplete()` rather than synthesizing completion by direct date assignment.
 - Use `project.markComplete(...)` and `project.markIncomplete()` rather than synthesizing completion by direct date assignment.
 - Use `project.status` for project active/on-hold/dropped transitions.
-- Mark projects reviewed by assigning one request-level local-day timestamp to
+- Mark projects reviewed by assigning one request-level current timestamp to
   `project.lastReviewDate`; preserve `reviewInterval` and verify OmniFocus's
   resulting `nextReviewDate` rather than calculating it independently.
 - Use `moveTasks(...)` and `moveSections(...)` for structural moves instead of delete/recreate flows.
@@ -164,8 +164,8 @@ Relevant reference pages:
   for active or on-hold projects with a usable review interval.
 - Every target is preflighted before any write so mixed eligible/ineligible
   batches fail without partial mutation.
-- Use `Calendar.current.startOfDay(new Date())`, matching OmniFocus's native
-  day-based Mark Reviewed behavior; do not persist an arbitrary clock time.
+- Use one `new Date()` value for the complete request, matching the timestamp
+  recorded by OmniFocus's native Mark Reviewed action.
 - One request timestamp applies to the whole batch. Verification requires the
   saved date, unchanged interval, and an OmniFocus-generated next review date.
 

--- a/docs/omni-automation-write-contract.md
+++ b/docs/omni-automation-write-contract.md
@@ -112,6 +112,8 @@ Relevant reference pages:
 - `project.status`
 - `project.markComplete(date)`
 - `project.markIncomplete()`
+- `project.lastReviewDate`, assigned to `Calendar.current.startOfDay(now)` for
+  active or on-hold projects after complete-batch eligibility preflight
 
 ### Project moves
 - `moveSections(sections, position)`
@@ -128,6 +130,9 @@ Relevant reference pages:
 - Use `task.markComplete(...)` and `task.markIncomplete()` rather than synthesizing completion by direct date assignment.
 - Use `project.markComplete(...)` and `project.markIncomplete()` rather than synthesizing completion by direct date assignment.
 - Use `project.status` for project active/on-hold/dropped transitions.
+- Mark projects reviewed by assigning one request-level local-day timestamp to
+  `project.lastReviewDate`; preserve `reviewInterval` and verify OmniFocus's
+  resulting `nextReviewDate` rather than calculating it independently.
 - Use `moveTasks(...)` and `moveSections(...)` for structural moves instead of delete/recreate flows.
 - Hide project root-task implementation details behind project-oriented public inputs and outputs.
 
@@ -139,7 +144,6 @@ Relevant reference pages:
 - Attachment or file-link mutation
 - Notification mutation
 - Repetition-rule mutation
-- Project review date direct mutation using undocumented surfaces
 - Tag reordering as part of the `update` operation
 - Placement controls beyond documented move destinations unless a later issue validates a concrete use case
 - `plannedDate` writes
@@ -154,6 +158,16 @@ Relevant reference pages:
 ### Project root-task details
 - Omni Automation documents that many “task-like” project properties are ultimately held on the project’s root task.
 - FocusRelay may use that documented implementation detail internally, but the public tool surface should remain project-shaped.
+
+### Project review semantics
+- `reviewedNow=true` is accepted only as the sole project patch field and only
+  for active or on-hold projects with a usable review interval.
+- Every target is preflighted before any write so mixed eligible/ineligible
+  batches fail without partial mutation.
+- Use `Calendar.current.startOfDay(new Date())`, matching OmniFocus's native
+  day-based Mark Reviewed behavior; do not persist an arbitrary clock time.
+- One request timestamp applies to the whole batch. Verification requires the
+  saved date, unchanged interval, and an OmniFocus-generated next review date.
 
 ### Planned date writes
 - The task docs currently describe `plannedDate` with mixed signals about setter support and migration requirements.


### PR DESCRIPTION
Closes #138

## Impact

`mutation`

## Acceptance journey

A user selects active or on-hold project IDs, previews one `reviewedNow=true` update, then applies it with verification. FocusRelay preflights every target before any write, uses one request-level timestamp, preserves each review interval, and returns OmniFocus-native next-review state.

## Implementation

- Adds `projectPatch.reviewedNow=true` to MCP and `--reviewed-now` to the CLI.
- Rejects false and mixed-field review patches.
- Preflights every target and makes no writes when any target is missing, ineligible, or lacks a usable interval.
- Uses one `new Date()` timestamp for the complete request, matching native Mark Reviewed behavior.
- Verifies the saved review date, unchanged interval, and OmniFocus-generated next review date.
- Adds direct MCP argument coverage and deterministic JavaScriptCore execution tests.
- Documents the proven write contract and CLI/MCP workflows.

## Validation

- `swift test` — passed, 154 Swift Testing tests.
- `swift run focusrelay-dev validate --impact mutation` — passed tests and clean release build.
- `git diff --check` — passed.

## Live UAT

Passed 2026-07-23 using explicitly disposable project `buBqOONyCGB` (`Drop test`):

- [x] Active-project preview and verified write.
- [x] On-hold-project verified write after a reversible status transition.
- [x] Restored the fixture to its original active status.
- [x] Preserved the one-month review interval.
- [x] Verified review state persisted after a full OmniFocus restart.
- [x] Observed a user-invoked native Mark Reviewed action.
- [x] Compared native and direct results through the same Bridge read boundary.

Native Mark Reviewed recorded Last Reviewed `2026-07-23T03:06:19.156Z` and Next Review `2026-08-22T16:00:00.000Z`. The final direct implementation recorded Last Reviewed `2026-07-23T03:07:43.801Z` and the identical Next Review `2026-08-22T16:00:00.000Z`. Both recorded their invocation timestamp, preserved the one-month interval, and let OmniFocus calculate Next Review at local midnight.

An intermediate local-midnight normalization hypothesis was rejected by the native UI evidence and removed in commit `d5d1928`. No ordinary project was mutated; the supplied fixture remains active.