### PR TITLE
Reject unknown MCP tool arguments before dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bulk task and project mutations now preflight every target before applying or
   saving, so one unknown target fails the whole request without changing valid
   targets.
+- MCP tool calls now reject unknown top-level and nested arguments before
+  dispatch instead of silently turning malformed filters into plausible
+  unfiltered queries.
 
 ## [0.10.1-beta] - 2026-07-19
 

--- a/Sources/FocusRelayServer/FocusRelayServer.swift
+++ b/Sources/FocusRelayServer/FocusRelayServer.swift
@@ -233,7 +233,7 @@ public enum FocusRelayServer {
         }
         let service: OmniFocusService = bridgeService
 
-        await server.withMethodHandler(ListTools.self) { _ in
+        func makeTools() -> [Tool] {
             let tools = [
                 Tool(
                     name: "list_tasks",
@@ -636,7 +636,12 @@ public enum FocusRelayServer {
                 "Mutation tool annotations must truthfully describe write risk."
             )
 
-            return .init(tools: tools)
+            return tools
+        }
+
+        let tools = makeTools()
+        await server.withMethodHandler(ListTools.self) { _ in
+            .init(tools: tools)
         }
 
         await server.withMethodHandler(CallTool.self) { params in
@@ -647,9 +652,14 @@ public enum FocusRelayServer {
                     logger.info("Tool \(params.name) completed in \(String(format: "%.3f", elapsed))s")
                 }
 
-                guard publicToolNames.contains(params.name) else {
+                guard let tool = tools.first(where: { $0.name == params.name }) else {
                     return .init(content: [.text(text: "Unknown tool: \(params.name)", annotations: nil, _meta: nil)], isError: true)
                 }
+                try validateToolArguments(
+                    toolName: params.name,
+                    arguments: params.arguments ?? [:],
+                    schema: tool.inputSchema
+                )
 
                 switch params.name {
                 case "list_tasks":
@@ -771,6 +781,63 @@ public enum FocusRelayServer {
         return try decoder.decode(T.self, from: data)
     }
 
+    static func validateToolArguments(
+        toolName: String,
+        arguments: [String: Value],
+        schema: Value
+    ) throws {
+        try validateClosedProperties(
+            value: .object(arguments),
+            schema: schema,
+            path: toolName
+        )
+    }
+
+    private static func validateClosedProperties(
+        value: Value,
+        schema: Value,
+        path: String
+    ) throws {
+        guard case let .object(schemaObject) = schema else { return }
+
+        if case let .object(properties)? = schemaObject["properties"],
+           case let .object(arguments) = value {
+            if schemaObject["additionalProperties"] == .bool(false),
+               let unknownKey = arguments.keys
+                .filter({ properties[$0] == nil })
+                .sorted()
+                .first {
+                let argumentPath = "\(path).\(unknownKey)"
+                if path == "list_tasks", unknownKey == "search" {
+                    throw MutationValidationError(
+                        "\(argumentPath) is unsupported; use list_tasks.filter.search."
+                    )
+                }
+                throw MutationValidationError("\(argumentPath) is unsupported.")
+            }
+
+            for (key, argument) in arguments {
+                guard let propertySchema = properties[key] else { continue }
+                try validateClosedProperties(
+                    value: argument,
+                    schema: propertySchema,
+                    path: "\(path).\(key)"
+                )
+            }
+        }
+
+        if case let .array(items) = value,
+           let itemSchema = schemaObject["items"] {
+            for (index, item) in items.enumerated() {
+                try validateClosedProperties(
+                    value: item,
+                    schema: itemSchema,
+                    path: "\(path)[\(index)]"
+                )
+            }
+        }
+    }
+
     static func decodeTaskEditRequest(from args: [String: Value]?) throws -> MutationRequest {
         let operationName = try decodeArgument(String.self, from: args, key: "operation")
         guard let operationName else {
@@ -855,7 +922,7 @@ private func toolSchema(properties: [String: Value], required: [String] = []) ->
         schema["required"] = .array(required.map { .string($0) })
     }
 
-    return .object(schema)
+    return closingObjectSchemas(.object(schema))
 }
 
 func discriminatedToolSchema(
@@ -884,13 +951,30 @@ func discriminatedToolSchema(
         ])
     }
 
-    return .object([
+    return closingObjectSchemas(.object([
         "type": .string("object"),
         "properties": .object(properties),
         "required": .array([.string("operation"), .string("targetIDs")]),
         "additionalProperties": .bool(false),
         "oneOf": .array(alternatives)
-    ])
+    ]))
+}
+
+private func closingObjectSchemas(_ value: Value) -> Value {
+    switch value {
+    case .object(var object):
+        for (key, child) in object {
+            object[key] = closingObjectSchemas(child)
+        }
+        if object["type"] == .string("object"), object["properties"] != nil {
+            object["additionalProperties"] = .bool(false)
+        }
+        return .object(object)
+    case .array(let values):
+        return .array(values.map(closingObjectSchemas))
+    default:
+        return value
+    }
 }
 
 private func propertySchema(

--- a/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
+++ b/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
@@ -238,6 +238,11 @@ func productionToolsListMatchesGoldenPublicCatalog() throws {
     let tools = try #require(result["tools"] as? [[String: Any]])
     #expect(tools.compactMap { $0["name"] as? String } == FocusRelayServer.publicToolNames)
 
+    for tool in tools {
+        let schema = try #require(tool["inputSchema"] as? [String: Any])
+        expectClosedObjectSchemas(schema)
+    }
+
     for name in FocusRelayServer.mutationToolNames {
         let tool = try #require(tools.first { $0["name"] as? String == name })
         let annotations = try #require(tool["annotations"] as? [String: Any])
@@ -250,6 +255,68 @@ func productionToolsListMatchesGoldenPublicCatalog() throws {
         #expect(schema["additionalProperties"] as? Bool == false)
         #expect((schema["oneOf"] as? [[String: Any]])?.isEmpty == false)
     }
+}
+
+@Test
+func mcpWireRejectsUnknownTopLevelAndNestedArgumentsBeforeDispatch() throws {
+    let packageRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    let executable = packageRoot.appendingPathComponent(".build/debug/focusrelay")
+
+    let process = Process()
+    let standardInput = Pipe()
+    let standardOutput = Pipe()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/perl")
+    process.arguments = ["-e", "alarm 10; exec @ARGV", executable.path, "serve"]
+    process.currentDirectoryURL = packageRoot
+    process.standardInput = standardInput
+    process.standardOutput = standardOutput
+    process.standardError = Pipe()
+    try process.run()
+    defer {
+        if process.isRunning {
+            process.terminate()
+        }
+    }
+
+    let requests = [
+        #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"validation-test","version":"1"}}}"#,
+        #"{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}"#,
+        #"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_tasks","arguments":{"search":"drop test"}}}"#,
+        #"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_projects","arguments":{"search":"drop test","statusFilter":"all"}}}"#,
+        #"{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"list_tasks","arguments":{"filter":{"unexpected":true}}}}"#,
+        #"{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"list_tasks","arguments":{"page":{"offset":"50"}}}}"#,
+        #"{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"edit_tasks","arguments":{"operation":"set_completion","targetIDs":["real-task"],"completion":{"state":"completed","unexpected":true}}}}"#
+    ].joined(separator: "\n") + "\n"
+    try standardInput.fileHandleForWriting.write(contentsOf: Data(requests.utf8))
+
+    var responses: [Int: [String: Any]] = [:]
+    var buffered = Data()
+    while responses.count < 6 {
+        let chunk = standardOutput.fileHandleForReading.availableData
+        guard !chunk.isEmpty else {
+            Issue.record("MCP server exited before returning argument-validation responses")
+            break
+        }
+        buffered.append(chunk)
+        while let newline = buffered.firstIndex(of: 0x0A) {
+            let line = buffered[..<newline]
+            buffered.removeSubrange(...newline)
+            guard let object = try JSONSerialization.jsonObject(with: line) as? [String: Any],
+                  let id = object["id"] as? Int else {
+                continue
+            }
+            responses[id] = object
+        }
+    }
+
+    #expect(toolErrorText(responses[2]).contains("list_tasks.search is unsupported; use list_tasks.filter.search"))
+    #expect(toolErrorText(responses[3]).contains("list_projects.search is unsupported"))
+    #expect(toolErrorText(responses[4]).contains("list_tasks.filter.unexpected is unsupported"))
+    #expect(toolErrorText(responses[5]).contains("list_tasks.page.offset is unsupported"))
+    #expect(toolErrorText(responses[6]).contains("edit_tasks.completion.unexpected is unsupported"))
 }
 
 @Test
@@ -289,6 +356,32 @@ func editToolSchemasRequireExactlyOneMatchingPayload() throws {
             "move": "move"
         ]
     )
+}
+
+private func expectClosedObjectSchemas(_ schema: [String: Any]) {
+    if schema["type"] as? String == "object", schema["properties"] != nil {
+        #expect(schema["additionalProperties"] as? Bool == false)
+    }
+    if let properties = schema["properties"] as? [String: Any] {
+        for child in properties.values {
+            if let childSchema = child as? [String: Any] {
+                expectClosedObjectSchemas(childSchema)
+            }
+        }
+    }
+    if let items = schema["items"] as? [String: Any] {
+        expectClosedObjectSchemas(items)
+    }
+}
+
+private func toolErrorText(_ response: [String: Any]?) -> String {
+    guard let result = response?["result"] as? [String: Any],
+          result["isError"] as? Bool == true,
+          let content = result["content"] as? [[String: Any]],
+          let text = content.first?["text"] as? String else {
+        return ""
+    }
+    return text
 }
 
 @Test

--- a/docs/omni-automation-contract.md
+++ b/docs/omni-automation-contract.md
@@ -113,3 +113,12 @@ Before merging query-engine changes, verify:
 - `project.status` is the source of truth for project state.
 - Boundary semantics are covered by tests before benchmarking.
 - Benchmarks are not run unless parity and count-contract gates pass.
+## MCP Argument Boundary
+
+- Public MCP input schemas close every object with
+  `additionalProperties: false`.
+- Runtime validation uses those same schemas before query or mutation dispatch;
+  unknown top-level or nested properties fail with the full argument path.
+- A malformed query must never degrade into a plausible unfiltered query.
+- A malformed mutation must fail before target resolution, Bridge dispatch, or
+  any write.


### PR DESCRIPTION
Closes #143

## Acceptance journey
A client that sends top-level `list_tasks.search` receives `list_tasks.search is unsupported; use list_tasks.filter.search` before FocusRelay queries OmniFocus. Unknown nested query and mutation properties likewise fail with their complete argument path.

## Validation impact
`server-wire`

## Changes
- derive runtime unknown-property validation from the same schemas returned by `tools/list`
- recursively close every object schema with `additionalProperties: false`
- validate before query or mutation dispatch
- add direct JSON-RPC wire coverage for both observed OpenCode payloads plus nested filter, page, and mutation properties
- document the fail-closed MCP boundary

## Validation
- `swift run focusrelay-dev validate --impact server-wire` — 162 tests passed and production build succeeded
- direct wire regression confirms malformed mutation arguments return before `performMutation` / Bridge dispatch