### PR TITLE
Honor project status filters in Review queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP tool calls now reject unknown top-level and nested arguments before
   dispatch instead of silently turning malformed filters into plausible
   unfiltered queries.
+- Review perspective project queries now honor `statusFilter`, so active and
+  on-hold review batches are disjoint while `all` includes both reviewable
+  statuses and still excludes dropped/done projects.
 
 ## [0.10.1-beta] - 2026-07-19
 

--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -1595,9 +1595,21 @@
     }
 
     function shouldApplyListProjectsStatusFilter(statusFilter, reviewPerspective, isCompletionQuery) {
-      if (reviewPerspective) { return false; }
       if (isCompletionQuery) { return false; }
       if (!statusFilter || statusFilter === "all") { return false; }
+      return true;
+    }
+
+    function projectMatchesListStatus(status, statusFilter) {
+      if (statusFilter === "active") {
+        return status === Project.Status.Active;
+      } else if (statusFilter === "onhold" || statusFilter === "on_hold") {
+        return status === Project.Status.OnHold;
+      } else if (statusFilter === "dropped") {
+        return status === Project.Status.Dropped;
+      } else if (statusFilter === "done" || statusFilter === "completed") {
+        return status === Project.Status.Done;
+      }
       return true;
     }
     // END PROJECT COMPLETION QUERY MODULE
@@ -2434,23 +2446,14 @@
             projects = projects.filter(p => {
               const status = safe(() => p.status);
               if (!status) return false;
-              return status !== Project.Status.Dropped && status !== Project.Status.Done;
+              const isReviewable = status !== Project.Status.Dropped && status !== Project.Status.Done;
+              return isReviewable && projectMatchesListStatus(status, statusFilter);
             });
           } else if (shouldApplyListProjectsStatusFilter(statusFilter, false, isCompletionQuery)) {
             projects = projects.filter(p => {
               const status = safe(() => p.status);
               if (!status) return false;
-              
-              if (statusFilter === "active") {
-                return status === Project.Status.Active;
-              } else if (statusFilter === "onhold" || statusFilter === "on_hold") {
-                return status === Project.Status.OnHold;
-              } else if (statusFilter === "dropped") {
-                return status === Project.Status.Dropped;
-              } else if (statusFilter === "done" || statusFilter === "completed") {
-                return status === Project.Status.Done;
-              }
-              return true;
+              return projectMatchesListStatus(status, statusFilter);
             });
           }
 

--- a/Sources/FocusRelayCLI/FocusRelayCLI.swift
+++ b/Sources/FocusRelayCLI/FocusRelayCLI.swift
@@ -122,7 +122,7 @@ struct ListProjects: AsyncParsableCommand {
     @Flag(name: .customLong("include-task-counts"), help: "Include task counts for each project.")
     var includeTaskCounts: Bool = false
 
-    @Flag(name: .customLong("review-perspective"), help: "Apply review perspective defaults.")
+    @Flag(name: .customLong("review-perspective"), help: "Apply Review due-date defaults while honoring --status (active, onHold, or all reviewable projects).")
     var reviewPerspective: Bool = false
 
     @Option(name: .customLong("review-due-before"), help: "ISO8601 datetime. Next review due before this time.")

--- a/Sources/FocusRelayServer/FocusRelayServer.swift
+++ b/Sources/FocusRelayServer/FocusRelayServer.swift
@@ -89,6 +89,7 @@ public enum FocusRelayServer {
 
     REVIEW PERSPECTIVE:
     - Use reviewPerspective=true to return projects pending review (excludes dropped/done and applies nextReviewDate <= now when reviewDueBefore is omitted).
+    - statusFilter remains active inside Review queries: use 'active' or 'onHold' for disjoint groups, or 'all' for every reviewable active/on-hold project.
     - Optionally set reviewDueBefore/reviewDueAfter (ISO8601 UTC) to bound nextReviewDate.
     """
 
@@ -317,7 +318,7 @@ public enum FocusRelayServer {
                             ]),
                             "reviewPerspective": .object([
                                 "type": .string("boolean"),
-                                "description": .string("If true, apply OmniFocus Review perspective defaults: exclude dropped/done and require nextReviewDate <= now when reviewDueBefore is omitted"),
+                                "description": .string("If true, apply OmniFocus Review perspective defaults: exclude dropped/done, honor statusFilter for active/onHold grouping, and require nextReviewDate <= now when reviewDueBefore is omitted"),
                                 "default": .bool(false)
                             ]),
                             "reviewDueBefore": propertySchema(

--- a/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
+++ b/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
@@ -566,6 +566,7 @@ func projectToolDescriptionGuardsCompletionAndStalledRecommendations() {
     #expect(description.contains("If all child tasks are dropped, treat it as a drop/review candidate"))
     #expect(description.contains("availableTasks=0 does not mean a project is stalled"))
     #expect(description.contains("default statusFilter='active' is ignored"))
+    #expect(description.contains("statusFilter remains active inside Review queries"))
     #expect(description.contains("inclusive"))
 }
 
@@ -702,4 +703,40 @@ func cursorOnlyPagesApplyDefaultsAtMCPWireBoundary() throws {
         #expect(page.limit == testCase.expectedLimit)
         #expect(page.cursor == testCase.cursor)
     }
+}
+
+@Test
+func reviewPerspectiveAndStatusFilterDecodeTogetherAtMCPWireBoundary() throws {
+    let data = Data(
+        #"""
+        {
+          "jsonrpc": "2.0",
+          "id": 1,
+          "method": "tools/call",
+          "params": {
+            "name": "list_projects",
+            "arguments": {
+              "statusFilter": "onHold",
+              "reviewPerspective": true
+            }
+          }
+        }
+        """#.utf8
+    )
+    let request = try JSONDecoder().decode(Request<CallTool>.self, from: data)
+
+    #expect(
+        try FocusRelayServer.decodeArgument(
+            String.self,
+            from: request.params.arguments,
+            key: "statusFilter"
+        ) == "onHold"
+    )
+    #expect(
+        try FocusRelayServer.decodeArgument(
+            Bool.self,
+            from: request.params.arguments,
+            key: "reviewPerspective"
+        ) == true
+    )
 }

--- a/Tests/OmniFocusIntegrationTests/ListProjectsCompletionFilterTests.swift
+++ b/Tests/OmniFocusIntegrationTests/ListProjectsCompletionFilterTests.swift
@@ -123,5 +123,80 @@ func projectCompletionQueryHelpersIgnoreNonCompletionFilters() throws {
     #expect(decoded.afterOnly)
     #expect(decoded.applyActive)
     #expect(!decoded.applyAll)
-    #expect(!decoded.applyReview)
+    #expect(decoded.applyReview)
+}
+
+@Test
+func reviewPerspectiveHonorsStatusFilterBeforeCountAndPagination() throws {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js")
+    let librarySource = try String(contentsOf: sourceURL, encoding: .utf8)
+    let startMarker = "// PROJECT COMPLETION QUERY MODULE - list_projects completion vs statusFilter"
+    let endMarker = "// END PROJECT COMPLETION QUERY MODULE"
+    let start = try #require(librarySource.range(of: startMarker))
+    let end = try #require(
+        librarySource.range(of: endMarker, range: start.upperBound..<librarySource.endIndex)
+    )
+    let module = String(librarySource[start.lowerBound..<end.upperBound])
+
+    let context = JSContext()!
+    let script = """
+    const Project = { Status: {
+      Active: "Active",
+      OnHold: "OnHold",
+      Dropped: "Dropped",
+      Done: "Done"
+    }};
+    \(module)
+    const projects = [
+      { id: "active-1", status: Project.Status.Active },
+      { id: "hold-1", status: Project.Status.OnHold },
+      { id: "active-2", status: Project.Status.Active },
+      { id: "dropped-1", status: Project.Status.Dropped },
+      { id: "done-1", status: Project.Status.Done }
+    ];
+    function reviewPage(statusFilter, limit) {
+      const filtered = projects.filter(project => {
+        const reviewable =
+          project.status !== Project.Status.Dropped &&
+          project.status !== Project.Status.Done;
+        return reviewable && projectMatchesListStatus(project.status, statusFilter);
+      });
+      return {
+        ids: filtered.slice(0, limit).map(project => project.id),
+        totalCount: filtered.length,
+        nextCursor: filtered.length > limit ? String(limit) : null
+      };
+    }
+    JSON.stringify({
+      active: reviewPage("active", 1),
+      onHold: reviewPage("onhold", 10),
+      all: reviewPage("all", 10)
+    });
+    """
+    let json = try #require(context.evaluateScript(script)?.toString())
+    struct Result: Decodable {
+        struct Page: Decodable {
+            let ids: [String]
+            let totalCount: Int
+            let nextCursor: String?
+        }
+        let active: Page
+        let onHold: Page
+        let all: Page
+    }
+    let decoded = try JSONDecoder().decode(Result.self, from: Data(json.utf8))
+
+    #expect(decoded.active.ids == ["active-1"])
+    #expect(decoded.active.totalCount == 2)
+    #expect(decoded.active.nextCursor == "1")
+    #expect(decoded.onHold.ids == ["hold-1"])
+    #expect(decoded.onHold.totalCount == 1)
+    #expect(decoded.onHold.nextCursor == nil)
+    #expect(decoded.all.ids == ["active-1", "hold-1", "active-2"])
+    #expect(decoded.all.totalCount == 3)
+    #expect(Set(decoded.active.ids).isDisjoint(with: decoded.onHold.ids))
 }

--- a/docs/omni-automation-contract.md
+++ b/docs/omni-automation-contract.md
@@ -96,6 +96,16 @@ The `flagged` filter and aggregate flagged count use documented
 The returned `flagged` field remains the task's local writable flag for backward
 compatibility; request `effectiveFlagged` for the visible OmniFocus flag state.
 
+## Project Review query contract
+
+- `reviewPerspective=true` adds Review eligibility and due-date constraints; it
+  does not replace the caller's project status scope.
+- `statusFilter=active` and `statusFilter=onHold` return disjoint pending-review
+  groups.
+- `statusFilter=all` includes active and on-hold projects only because dropped
+  and done projects are not reviewable.
+- Status and review-date filtering happen before total counts and pagination.
+
 ## Banned undocumented core-query patterns
 Do not use these as the primary production query path unless the official docs explicitly document them in the future.
 


### PR DESCRIPTION
Closes #145

## Acceptance journey
Review queries apply pending-review eligibility and the caller's status scope before count and pagination. Active and on-hold batches are disjoint; `all` contains both reviewable statuses and excludes dropped/done projects.

## Validation impact
`query`

## Changes
- apply status matching inside the Review eligibility pass
- share the status matcher with ordinary project queries
- document MCP and CLI Review/status interaction
- add deterministic status/count/pagination and direct MCP decoding tests

## Validation
- `swift run focusrelay-dev validate --impact query` — 164 tests and semantic gates passed
- `swift test` — 164 tests passed
- live installed-Bridge UAT with `reviewDueBefore=2030-01-01`:
  - active: 271, sampled results all `active`
  - onHold: 53, sampled results all `onHold`
  - all: 324 = 271 + 53, sampled results contain both statuses
- due-now native Review remains empty after the completed review-bankruptcy UAT