### PR TITLE
Bind pagination cursors to their originating query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Review perspective project queries now honor `statusFilter`, so active and
   on-hold review batches are disjoint while `all` includes both reviewable
   statuses and still excludes dropped/done projects.
+- List cursors are now opaque and bound to the originating query; malformed,
+  stale-version, or filter-mismatched cursors fail before Bridge dispatch.
 
 ## [0.10.1-beta] - 2026-07-19
 

--- a/Package.swift
+++ b/Package.swift
@@ -96,6 +96,7 @@ let package = Package(
             name: "FocusRelayServerTests",
             dependencies: [
                 "FocusRelayServer",
+                "OmniFocusAutomation",
                 "FocusRelayVersion"
             ]
         ),

--- a/Sources/FocusRelayCLI/CLIHelpers.swift
+++ b/Sources/FocusRelayCLI/CLIHelpers.swift
@@ -50,7 +50,7 @@ struct PageOptions: ParsableArguments {
     @Option(help: "Page size limit.")
     var limit: Int? = nil
 
-    @Option(help: "Cursor for pagination.")
+    @Option(help: "Opaque cursor for the identical query; restart from page one after changing filters.")
     var cursor: String? = nil
 
     func makePageRequest(defaultLimit: Int) -> PageRequest {

--- a/Sources/FocusRelayServer/FocusRelayServer.swift
+++ b/Sources/FocusRelayServer/FocusRelayServer.swift
@@ -246,7 +246,7 @@ public enum FocusRelayServer {
                                 "type": .string("object"),
                                 "properties": .object([
                                     "limit": .object(["type": .string("integer"), "minimum": .int(1)]),
-                                    "cursor": .object(["type": .string("string")])
+                                    "cursor": paginationCursorSchema()
                                 ])
                             ]),
                             "fields": .object([
@@ -287,7 +287,7 @@ public enum FocusRelayServer {
                                 "type": .string("object"),
                                 "properties": .object([
                                     "limit": .object(["type": .string("integer"), "minimum": .int(1)]),
-                                    "cursor": .object(["type": .string("string")])
+                                    "cursor": paginationCursorSchema()
                                 ])
                             ]),
                             "statusFilter": .object([
@@ -354,7 +354,7 @@ public enum FocusRelayServer {
                                 "type": .string("object"),
                                 "properties": .object([
                                     "limit": .object(["type": .string("integer"), "minimum": .int(1)]),
-                                    "cursor": .object(["type": .string("string")])
+                                    "cursor": paginationCursorSchema()
                                 ])
                             ]),
                             "statusFilter": .object([
@@ -381,7 +381,7 @@ public enum FocusRelayServer {
                                 "type": .string("object"),
                                 "properties": .object([
                                     "limit": .object(["type": .string("integer"), "minimum": .int(1)]),
-                                    "cursor": .object(["type": .string("string")])
+                                    "cursor": paginationCursorSchema()
                                 ])
                             ]),
                             "fields": .object([
@@ -995,6 +995,13 @@ private func propertySchema(
         schema["default"] = defaultValue
     }
     return .object(schema)
+}
+
+private func paginationCursorSchema() -> Value {
+    propertySchema(
+        type: "string",
+        description: "Opaque cursor for the identical query. If membership filters change, omit the cursor and restart from page one."
+    )
 }
 
 private func dateFilterSchema(_ description: String, example: Value) -> Value {

--- a/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
+++ b/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
@@ -15,7 +15,12 @@ public final class OmniFocusBridgeService: OmniFocusService {
     }
 
     public func listTasks(filter: TaskFilter, page: PageRequest, fields: [String]?) async throws -> Page<TaskItem> {
-        return try await Task.detached { try self.client.listTasks(filter: filter, page: page, fields: fields) }.value
+        let queryKey = try QueryBoundCursor.queryKey(tool: "list_tasks", input: filter)
+        let bridgePage = try QueryBoundCursor.bridgePage(from: page, queryKey: queryKey)
+        let result = try await Task.detached {
+            try self.client.listTasks(filter: filter, page: bridgePage, fields: fields)
+        }.value
+        return try QueryBoundCursor.publicPage(from: result, queryKey: queryKey)
     }
 
     public func getTask(id: String, fields: [String]?) async throws -> TaskItem {
@@ -34,20 +39,35 @@ public final class OmniFocusBridgeService: OmniFocusService {
         completedAfter: Date?,
         fields: [String]?
     ) async throws -> Page<ProjectItem> {
+        let projectFilter = ProjectFilter(
+            statusFilter: statusFilter,
+            includeTaskCounts: includeTaskCounts,
+            reviewDueBefore: reviewDueBefore,
+            reviewDueAfter: reviewDueAfter,
+            reviewPerspective: reviewPerspective,
+            completed: completed,
+            completedBefore: completedBefore,
+            completedAfter: completedAfter
+        )
+        let queryKey = try QueryBoundCursor.queryKey(
+            tool: "list_projects",
+            input: projectFilter
+        )
+        let bridgePage = try QueryBoundCursor.bridgePage(from: page, queryKey: queryKey)
         let shouldBypassCache = reviewPerspective || reviewDueBefore != nil || reviewDueAfter != nil || completed != nil || completedBefore != nil || completedAfter != nil
         if !shouldBypassCache {
             let key = CacheKey.projects(
-                page: page,
+                page: bridgePage,
                 fields: fields,
                 statusFilter: statusFilter,
                 includeTaskCounts: includeTaskCounts
             )
             if let cached = await cache.getProjects(key: key) {
-                return cached
+                return try QueryBoundCursor.publicPage(from: cached, queryKey: queryKey)
             }
             let pageResult = try await Task.detached {
                 try self.client.listProjects(
-                    page: page,
+                    page: bridgePage,
                     statusFilter: statusFilter,
                     includeTaskCounts: includeTaskCounts,
                     reviewDueBefore: reviewDueBefore,
@@ -60,12 +80,12 @@ public final class OmniFocusBridgeService: OmniFocusService {
                 )
             }.value
             await cache.setProjects(pageResult, key: key, ttl: cacheTTL)
-            return pageResult
+            return try QueryBoundCursor.publicPage(from: pageResult, queryKey: queryKey)
         }
 
-        return try await Task.detached {
+        let pageResult = try await Task.detached {
             try self.client.listProjects(
-                page: page,
+                page: bridgePage,
                 statusFilter: statusFilter,
                 includeTaskCounts: includeTaskCounts,
                 reviewDueBefore: reviewDueBefore,
@@ -77,24 +97,45 @@ public final class OmniFocusBridgeService: OmniFocusService {
                 fields: fields
             )
         }.value
+        return try QueryBoundCursor.publicPage(from: pageResult, queryKey: queryKey)
     }
 
     public func listTags(page: PageRequest, statusFilter: String?, includeTaskCounts: Bool) async throws -> Page<TagItem> {
+        let filter = TagFilter(
+            statusFilter: statusFilter,
+            includeTaskCounts: includeTaskCounts
+        )
+        let queryKey = try QueryBoundCursor.queryKey(tool: "list_tags", input: filter)
+        let bridgePage = try QueryBoundCursor.bridgePage(from: page, queryKey: queryKey)
         let key = CacheKey.tags(
-            page: page,
+            page: bridgePage,
             statusFilter: statusFilter,
             includeTaskCounts: includeTaskCounts
         )
         if let cached = await cache.getTags(key: key) {
-            return cached
+            return try QueryBoundCursor.publicPage(from: cached, queryKey: queryKey)
         }
-        let pageResult = try await Task.detached { try self.client.listTags(page: page, statusFilter: statusFilter, includeTaskCounts: includeTaskCounts) }.value
+        let pageResult = try await Task.detached {
+            try self.client.listTags(
+                page: bridgePage,
+                statusFilter: statusFilter,
+                includeTaskCounts: includeTaskCounts
+            )
+        }.value
         await cache.setTags(pageResult, key: key, ttl: cacheTTL)
-        return pageResult
+        return try QueryBoundCursor.publicPage(from: pageResult, queryKey: queryKey)
     }
 
     public func listFolders(page: PageRequest, fields: [String]?) async throws -> Page<FolderItem> {
-        return try await Task.detached { try self.client.listFolders(page: page, fields: fields) }.value
+        let queryKey = try QueryBoundCursor.queryKey(
+            tool: "list_folders",
+            input: "stable-folder-order-v1"
+        )
+        let bridgePage = try QueryBoundCursor.bridgePage(from: page, queryKey: queryKey)
+        let result = try await Task.detached {
+            try self.client.listFolders(page: bridgePage, fields: fields)
+        }.value
+        return try QueryBoundCursor.publicPage(from: result, queryKey: queryKey)
     }
 
     public func getTaskCounts(filter: TaskFilter) async throws -> TaskCounts {

--- a/Sources/OmniFocusAutomation/QueryBoundCursor.swift
+++ b/Sources/OmniFocusAutomation/QueryBoundCursor.swift
@@ -1,0 +1,93 @@
+import Foundation
+import OmniFocusCore
+
+enum QueryBoundCursor {
+    private struct Envelope: Codable {
+        let version: Int
+        let offset: String
+        let queryKey: String
+    }
+
+    private static let version = 1
+
+    static func queryKey<Input: Encodable>(tool: String, input: Input) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let inputData = try encoder.encode(input)
+        return tool + ":" + inputData.base64EncodedString()
+    }
+
+    static func bridgePage(from page: PageRequest, queryKey: String) throws -> PageRequest {
+        guard let cursor = page.cursor else { return page }
+        let envelope: Envelope
+        do {
+            envelope = try decode(cursor)
+        } catch {
+            throw cursorError("malformed or unsupported")
+        }
+        guard envelope.version == version else {
+            throw cursorError("from an unsupported version")
+        }
+        guard envelope.queryKey == queryKey else {
+            throw cursorError("for a different query")
+        }
+        return PageRequest(limit: page.limit, cursor: envelope.offset)
+    }
+
+    static func publicPage<Item>(
+        from page: Page<Item>,
+        queryKey: String
+    ) throws -> Page<Item> where Item: Codable & Sendable {
+        let nextCursor = try page.nextCursor.map { offset in
+            try encode(Envelope(version: version, offset: offset, queryKey: queryKey))
+        }
+        return Page(
+            items: page.items,
+            nextCursor: nextCursor,
+            returnedCount: page.returnedCount,
+            totalCount: page.totalCount,
+            warnings: page.warnings
+        )
+    }
+
+    private static func encode(_ envelope: Envelope) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(envelope)
+        return data.base64URLEncodedString()
+    }
+
+    private static func decode(_ value: String) throws -> Envelope {
+        guard let data = Data(base64URLString: value) else {
+            throw cursorError("malformed")
+        }
+        return try JSONDecoder().decode(Envelope.self, from: data)
+    }
+
+    private static func cursorError(_ reason: String) -> AutomationError {
+        .executionFailed(
+            "Pagination cursor is \(reason). Restart pagination from the first page."
+        )
+    }
+}
+
+private extension Data {
+    func base64URLEncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    init?(base64URLString: String) {
+        var base64 = base64URLString
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = base64.count % 4
+        if remainder != 0 {
+            base64.append(String(repeating: "=", count: 4 - remainder))
+        }
+        self.init(base64Encoded: base64)
+    }
+}

--- a/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
+++ b/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
@@ -3,6 +3,7 @@ import Testing
 @testable import FocusRelayServer
 import FocusRelayVersion
 import MCP
+@testable import OmniFocusAutomation
 import OmniFocusCore
 
 @Test
@@ -281,6 +282,21 @@ func mcpWireRejectsUnknownTopLevelAndNestedArgumentsBeforeDispatch() throws {
         }
     }
 
+    let reviewQueryKey = try QueryBoundCursor.queryKey(
+        tool: "list_projects",
+        input: ProjectFilter(statusFilter: "active", reviewPerspective: true)
+    )
+    let reviewCursor = try #require(
+        QueryBoundCursor.publicPage(
+            from: Page<ProjectItem>(
+                items: [],
+                nextCursor: "100",
+                returnedCount: 100
+            ),
+            queryKey: reviewQueryKey
+        ).nextCursor
+    )
+
     let requests = [
         #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"validation-test","version":"1"}}}"#,
         #"{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}"#,
@@ -288,13 +304,15 @@ func mcpWireRejectsUnknownTopLevelAndNestedArgumentsBeforeDispatch() throws {
         #"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_projects","arguments":{"search":"drop test","statusFilter":"all"}}}"#,
         #"{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"list_tasks","arguments":{"filter":{"unexpected":true}}}}"#,
         #"{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"list_tasks","arguments":{"page":{"offset":"50"}}}}"#,
-        #"{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"edit_tasks","arguments":{"operation":"set_completion","targetIDs":["real-task"],"completion":{"state":"completed","unexpected":true}}}}"#
+        #"{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"edit_tasks","arguments":{"operation":"set_completion","targetIDs":["real-task"],"completion":{"state":"completed","unexpected":true}}}}"#,
+        #"{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"list_projects","arguments":{"statusFilter":"active","page":{"cursor":"100"}}}}"#,
+        #"{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"list_projects","arguments":{"statusFilter":"active","reviewPerspective":false,"page":{"cursor":"\#(reviewCursor)"}}}}"#
     ].joined(separator: "\n") + "\n"
     try standardInput.fileHandleForWriting.write(contentsOf: Data(requests.utf8))
 
     var responses: [Int: [String: Any]] = [:]
     var buffered = Data()
-    while responses.count < 6 {
+    while responses.count < 8 {
         let chunk = standardOutput.fileHandleForReading.availableData
         guard !chunk.isEmpty else {
             Issue.record("MCP server exited before returning argument-validation responses")
@@ -317,6 +335,8 @@ func mcpWireRejectsUnknownTopLevelAndNestedArgumentsBeforeDispatch() throws {
     #expect(toolErrorText(responses[4]).contains("list_tasks.filter.unexpected is unsupported"))
     #expect(toolErrorText(responses[5]).contains("list_tasks.page.offset is unsupported"))
     #expect(toolErrorText(responses[6]).contains("edit_tasks.completion.unexpected is unsupported"))
+    #expect(toolErrorText(responses[7]).contains("Pagination cursor is malformed or unsupported"))
+    #expect(toolErrorText(responses[8]).contains("Pagination cursor is for a different query"))
 }
 
 @Test

--- a/Tests/OmniFocusIntegrationTests/QueryBoundCursorTests.swift
+++ b/Tests/OmniFocusIntegrationTests/QueryBoundCursorTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import OmniFocusCore
+import Testing
+@testable import OmniFocusAutomation
+
+@Test
+func queryBoundCursorContinuesIdenticalQueryAndPreservesLimit() throws {
+    let key = try QueryBoundCursor.queryKey(
+        tool: "list_tasks",
+        input: TaskFilter(search: "drop test")
+    )
+    let publicPage = try QueryBoundCursor.publicPage(
+        from: Page<TaskItem>(
+            items: [],
+            nextCursor: "50",
+            returnedCount: 50,
+            totalCount: 120
+        ),
+        queryKey: key
+    )
+    let cursor = try #require(publicPage.nextCursor)
+    #expect(cursor != "50")
+
+    let bridgePage = try QueryBoundCursor.bridgePage(
+        from: PageRequest(limit: 75, cursor: cursor),
+        queryKey: key
+    )
+    #expect(bridgePage.limit == 75)
+    #expect(bridgePage.cursor == "50")
+}
+
+@Test
+func queryBoundCursorRejectsChangedQueryBeforeBridgePaging() throws {
+    let reviewKey = try QueryBoundCursor.queryKey(
+        tool: "list_projects",
+        input: ProjectFilter(statusFilter: "active", reviewPerspective: true)
+    )
+    let ordinaryKey = try QueryBoundCursor.queryKey(
+        tool: "list_projects",
+        input: ProjectFilter(statusFilter: "active", reviewPerspective: false)
+    )
+    let cursor = try #require(
+        QueryBoundCursor.publicPage(
+            from: Page<ProjectItem>(
+                items: [],
+                nextCursor: "100",
+                returnedCount: 100
+            ),
+            queryKey: reviewKey
+        ).nextCursor
+    )
+
+    #expect(throws: AutomationError.self) {
+        try QueryBoundCursor.bridgePage(
+            from: PageRequest(limit: 100, cursor: cursor),
+            queryKey: ordinaryKey
+        )
+    }
+}
+
+@Test(arguments: ["100", "not-a-cursor", versionTwoCursor()])
+func queryBoundCursorRejectsMalformedAndUnsupportedTokens(cursor: String) throws {
+    let key = try QueryBoundCursor.queryKey(
+        tool: "list_folders",
+        input: "stable-folder-order-v1"
+    )
+    #expect(throws: AutomationError.self) {
+        try QueryBoundCursor.bridgePage(
+            from: PageRequest(limit: 150, cursor: cursor),
+            queryKey: key
+        )
+    }
+}
+
+@Test
+func everyPublicListToolUsesASeparateQueryNamespace() throws {
+    let keys = try [
+        QueryBoundCursor.queryKey(tool: "list_tasks", input: TaskFilter()),
+        QueryBoundCursor.queryKey(tool: "list_projects", input: ProjectFilter()),
+        QueryBoundCursor.queryKey(tool: "list_tags", input: TagFilter()),
+        QueryBoundCursor.queryKey(tool: "list_folders", input: "stable-folder-order-v1")
+    ]
+    #expect(Set(keys).count == 4)
+}
+
+private func versionTwoCursor() -> String {
+    let data = try! JSONSerialization.data(
+        withJSONObject: [
+            "version": 2,
+            "offset": "50",
+            "queryKey": "list_tasks:any"
+        ],
+        options: [.sortedKeys]
+    )
+    return data.base64EncodedString()
+        .replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_")
+        .replacingOccurrences(of: "=", with: "")
+}

--- a/docs/omni-automation-contract.md
+++ b/docs/omni-automation-contract.md
@@ -106,6 +106,18 @@ compatibility; request `effectiveFlagged` for the visible OmniFocus flag state.
   and done projects are not reviewable.
 - Status and review-date filtering happen before total counts and pagination.
 
+## Pagination cursor contract
+
+- Cursors are opaque, versioned tokens bound to the originating list tool and
+  every input that affects membership or ordering.
+- Reusing a cursor after changing filters fails before Bridge dispatch and
+  directs the client to restart from page one.
+- Requested output fields may change between pages because they do not change
+  membership or ordering.
+- Cursor-only requests retain each list tool's documented default page limit.
+- This contract does not promise snapshot isolation when OmniFocus data changes
+  between requests.
+
 ## Banned undocumented core-query patterns
 Do not use these as the primary production query path unless the official docs explicitly document them in the future.
 


### PR DESCRIPTION
Closes #146

## Acceptance journey
An opaque cursor continues the identical list query, including after output fields change. Reusing it after changing Review, status, search, dates, project, tags, completion, or another encoded filter fails before Bridge dispatch and tells the client to restart pagination.

## Validation impact
`query`

## Changes
- wrap Bridge offsets in versioned query-bound public cursor tokens
- validate and unwrap at the shared service boundary before Bridge dispatch
- apply separate cursor namespaces to tasks, projects, tags, and folders
- keep output fields outside the query key and preserve caller/default page limits
- document opaque cursor behavior in MCP schemas, CLI help, and query contract

## Validation
- `swift run focusrelay-dev validate --impact query` — 168 tests and semantic gates passed
- direct MCP probes reject raw numeric and Review-to-non-Review cursor reuse
- unit coverage: valid continuation, malformed token, unsupported version, query mismatch, preserved limit, four tool namespaces
- live CLI pagination returned distinct page-two data for tasks, projects, tags, and folders; project/task/folder field changes remained valid
- live Review cursor reused without Review failed with `Pagination cursor is for a different query. Restart pagination from the first page.`