### PR TITLE
Add deterministic project name search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Deterministic project-name search through `list_projects.search` and
+  `list-projects --search` for stable-ID discovery before project mutations.
 - Active and on-hold projects can be marked reviewed through
   `projectPatch.reviewedNow=true`; FocusRelay preflights the complete batch,
   preserves review intervals, uses one request-level timestamp, and verifies the

--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -1612,6 +1612,18 @@
       }
       return true;
     }
+
+    function normalizedProjectNameSearch(search) {
+      if (typeof search !== "string") { return null; }
+      const normalized = search.trim().toLocaleLowerCase();
+      return normalized.length > 0 ? normalized : null;
+    }
+
+    function projectMatchesNameSearch(project, normalizedSearch) {
+      if (!normalizedSearch) { return true; }
+      const name = String(safe(() => project.name) || "").toLocaleLowerCase();
+      return name.indexOf(normalizedSearch) !== -1;
+    }
     // END PROJECT COMPLETION QUERY MODULE
 
     // Normalize OmniFocus collections to plain arrays.
@@ -2424,6 +2436,7 @@
           // Check both projectFilter and filter (Swift sends projectFilter)
           const filter = request.projectFilter || request.filter || {};
           const statusFilter = (typeof filter.statusFilter === "string") ? filter.statusFilter.toLowerCase() : "active";
+          const projectNameSearch = normalizedProjectNameSearch(filter.search);
           const includeTaskCounts = filter.includeTaskCounts === true;
           const reviewPerspective = filter.reviewPerspective === true;
 
@@ -2455,6 +2468,12 @@
               if (!status) return false;
               return projectMatchesListStatus(status, statusFilter);
             });
+          }
+
+          if (projectNameSearch) {
+            projects = projects.filter(project =>
+              projectMatchesNameSearch(project, projectNameSearch)
+            );
           }
 
           if (reviewCutoff || reviewDueAfter) {

--- a/Sources/FocusRelayCLI/FocusRelayCLI.swift
+++ b/Sources/FocusRelayCLI/FocusRelayCLI.swift
@@ -119,6 +119,9 @@ struct ListProjects: AsyncParsableCommand {
     @Option(name: .customLong("status"), help: "Project status filter: active, onHold, dropped, done, all.")
     var statusFilter: String = "active"
 
+    @Option(help: "Search project names by trimmed, case-insensitive literal substring.")
+    var search: String?
+
     @Flag(name: .customLong("include-task-counts"), help: "Include task counts for each project.")
     var includeTaskCounts: Bool = false
 
@@ -161,6 +164,7 @@ struct ListProjects: AsyncParsableCommand {
             page: pageRequest,
             statusFilter: statusFilter,
             includeTaskCounts: includeTaskCounts,
+            search: search,
             reviewDueBefore: reviewBeforeDate,
             reviewDueAfter: reviewAfterDate,
             reviewPerspective: reviewPerspective,

--- a/Sources/FocusRelayServer/FocusRelayServer.swift
+++ b/Sources/FocusRelayServer/FocusRelayServer.swift
@@ -71,6 +71,11 @@ public enum FocusRelayServer {
     static let listProjectsToolDescription = """
     List OmniFocus projects with pagination and filtering. Projects have a status (active, onHold, dropped, done) and can optionally include child-task counts.
 
+    PROJECT NAME SEARCH:
+    - Use search for a trimmed, literal, case-insensitive substring match against project names only.
+    - Search is applied before pagination. Follow nextCursor while it is present before concluding that no additional filtered matches exist.
+    - Use statusFilter='all' when historical dropped/done projects may match.
+
     PROJECT MAINTENANCE AND HEALTH:
     - For completion, cleanup, or stalled-project recommendations, start with statusFilter='active'. Use 'all' only when historical done/dropped projects are relevant.
     - Always inspect project status before interpreting task counts. A project with remainingTasks=0 is not automatically a completion candidate.
@@ -295,6 +300,10 @@ public enum FocusRelayServer {
                                 "description": .string("Filter projects by status: 'active' (default), 'onHold', 'dropped', 'done', or 'all'. Use 'active' for current-project maintenance. 'all' includes historical done/dropped projects, so inspect each returned status before making recommendations."),
                                 "enum": .array([.string("active"), .string("onHold"), .string("dropped"), .string("done"), .string("all")]),
                                 "default": .string("active")
+                            ]),
+                            "search": .object([
+                                "type": .string("string"),
+                                "description": .string("Trimmed, literal, case-insensitive substring match against project names only. Empty or whitespace-only values are rejected.")
                             ]),
                             "completed": .object([
                                 "type": .string("boolean"),
@@ -696,6 +705,7 @@ public enum FocusRelayServer {
                     let page = try decodePageRequest(from: params)
                     let statusFilter = try decodeArgument(String.self, from: params.arguments, key: "statusFilter") ?? "active"
                     let includeTaskCounts = try decodeArgument(Bool.self, from: params.arguments, key: "includeTaskCounts") ?? false
+                    let search = try decodeArgument(String.self, from: params.arguments, key: "search")
                     let reviewDueBefore = try decodeArgument(Date.self, from: params.arguments, key: "reviewDueBefore")
                     let reviewDueAfter = try decodeArgument(Date.self, from: params.arguments, key: "reviewDueAfter")
                     let reviewPerspective = try decodeArgument(Bool.self, from: params.arguments, key: "reviewPerspective") ?? false
@@ -712,6 +722,7 @@ public enum FocusRelayServer {
                         page: page,
                         statusFilter: statusFilter,
                         includeTaskCounts: includeTaskCounts,
+                        search: search,
                         reviewDueBefore: reviewDueBefore,
                         reviewDueAfter: reviewDueAfter,
                         reviewPerspective: reviewPerspective,

--- a/Sources/OmniFocusAutomation/BridgeClient.swift
+++ b/Sources/OmniFocusAutomation/BridgeClient.swift
@@ -97,6 +97,7 @@ final class BridgeClient: @unchecked Sendable {
         page: PageRequest,
         statusFilter: String?,
         includeTaskCounts: Bool,
+        search: String? = nil,
         reviewDueBefore: Date?,
         reviewDueAfter: Date?,
         reviewPerspective: Bool,
@@ -109,6 +110,7 @@ final class BridgeClient: @unchecked Sendable {
         let projectFilter = ProjectFilter(
             statusFilter: statusFilter,
             includeTaskCounts: includeTaskCounts,
+            search: search,
             reviewDueBefore: reviewDueBefore,
             reviewDueAfter: reviewDueAfter,
             reviewPerspective: reviewPerspective,

--- a/Sources/OmniFocusAutomation/CatalogCache.swift
+++ b/Sources/OmniFocusAutomation/CatalogCache.swift
@@ -7,33 +7,38 @@ struct CacheKey: Hashable {
     let fieldsKey: String
     let statusFilter: String?
     let includeTaskCounts: Bool
+    let search: String?
 
     private init(
         limit: Int,
         cursor: String?,
         fieldsKey: String,
         statusFilter: String?,
-        includeTaskCounts: Bool
+        includeTaskCounts: Bool,
+        search: String?
     ) {
         self.limit = limit
         self.cursor = cursor
         self.fieldsKey = fieldsKey
         self.statusFilter = statusFilter
         self.includeTaskCounts = includeTaskCounts
+        self.search = search
     }
 
     static func projects(
         page: PageRequest,
         fields: [String]?,
         statusFilter: String?,
-        includeTaskCounts: Bool
+        includeTaskCounts: Bool,
+        search: String? = nil
     ) -> CacheKey {
         CacheKey(
             limit: page.limit,
             cursor: page.cursor,
             fieldsKey: (fields ?? []).joined(separator: ","),
             statusFilter: statusFilter,
-            includeTaskCounts: includeTaskCounts
+            includeTaskCounts: includeTaskCounts,
+            search: search
         )
     }
 
@@ -47,7 +52,8 @@ struct CacheKey: Hashable {
             cursor: page.cursor,
             fieldsKey: "",
             statusFilter: statusFilter,
-            includeTaskCounts: includeTaskCounts
+            includeTaskCounts: includeTaskCounts,
+            search: nil
         )
     }
 }

--- a/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
+++ b/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
@@ -31,6 +31,7 @@ public final class OmniFocusBridgeService: OmniFocusService {
         page: PageRequest,
         statusFilter: String?,
         includeTaskCounts: Bool,
+        search: String? = nil,
         reviewDueBefore: Date?,
         reviewDueAfter: Date?,
         reviewPerspective: Bool,
@@ -39,9 +40,11 @@ public final class OmniFocusBridgeService: OmniFocusService {
         completedAfter: Date?,
         fields: [String]?
     ) async throws -> Page<ProjectItem> {
+        let normalizedSearch = try Self.normalizeProjectSearch(search)
         let projectFilter = ProjectFilter(
             statusFilter: statusFilter,
             includeTaskCounts: includeTaskCounts,
+            search: normalizedSearch,
             reviewDueBefore: reviewDueBefore,
             reviewDueAfter: reviewDueAfter,
             reviewPerspective: reviewPerspective,
@@ -60,7 +63,8 @@ public final class OmniFocusBridgeService: OmniFocusService {
                 page: bridgePage,
                 fields: fields,
                 statusFilter: statusFilter,
-                includeTaskCounts: includeTaskCounts
+                includeTaskCounts: includeTaskCounts,
+                search: normalizedSearch
             )
             if let cached = await cache.getProjects(key: key) {
                 return try QueryBoundCursor.publicPage(from: cached, queryKey: queryKey)
@@ -70,6 +74,7 @@ public final class OmniFocusBridgeService: OmniFocusService {
                     page: bridgePage,
                     statusFilter: statusFilter,
                     includeTaskCounts: includeTaskCounts,
+                    search: normalizedSearch,
                     reviewDueBefore: reviewDueBefore,
                     reviewDueAfter: reviewDueAfter,
                     reviewPerspective: reviewPerspective,
@@ -88,6 +93,7 @@ public final class OmniFocusBridgeService: OmniFocusService {
                 page: bridgePage,
                 statusFilter: statusFilter,
                 includeTaskCounts: includeTaskCounts,
+                search: normalizedSearch,
                 reviewDueBefore: reviewDueBefore,
                 reviewDueAfter: reviewDueAfter,
                 reviewPerspective: reviewPerspective,
@@ -98,6 +104,17 @@ public final class OmniFocusBridgeService: OmniFocusService {
             )
         }.value
         return try QueryBoundCursor.publicPage(from: pageResult, queryKey: queryKey)
+    }
+
+    static func normalizeProjectSearch(_ search: String?) throws -> String? {
+        guard let search else { return nil }
+        let normalized = search.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else {
+            throw AutomationError.executionFailed(
+                "Project search must contain at least one non-whitespace character."
+            )
+        }
+        return normalized
     }
 
     public func listTags(page: PageRequest, statusFilter: String?, includeTaskCounts: Bool) async throws -> Page<TagItem> {

--- a/Sources/OmniFocusCore/OmniFocusCore.swift
+++ b/Sources/OmniFocusCore/OmniFocusCore.swift
@@ -242,6 +242,7 @@ public struct TagFilter: Codable, Sendable {
 public struct ProjectFilter: Codable, Sendable {
     public var statusFilter: String?
     public var includeTaskCounts: Bool?
+    public var search: String?
     public var reviewDueBefore: Date?
     public var reviewDueAfter: Date?
     public var reviewPerspective: Bool?
@@ -252,6 +253,7 @@ public struct ProjectFilter: Codable, Sendable {
     public init(
         statusFilter: String? = nil,
         includeTaskCounts: Bool? = nil,
+        search: String? = nil,
         reviewDueBefore: Date? = nil,
         reviewDueAfter: Date? = nil,
         reviewPerspective: Bool? = nil,
@@ -261,6 +263,7 @@ public struct ProjectFilter: Codable, Sendable {
     ) {
         self.statusFilter = statusFilter
         self.includeTaskCounts = includeTaskCounts
+        self.search = search
         self.reviewDueBefore = reviewDueBefore
         self.reviewDueAfter = reviewDueAfter
         self.reviewPerspective = reviewPerspective
@@ -354,6 +357,7 @@ public protocol OmniFocusService: Sendable {
         page: PageRequest,
         statusFilter: String?,
         includeTaskCounts: Bool,
+        search: String?,
         reviewDueBefore: Date?,
         reviewDueAfter: Date?,
         reviewPerspective: Bool,

--- a/Tests/FocusRelayCLITests/FocusRelayCLITests.swift
+++ b/Tests/FocusRelayCLITests/FocusRelayCLITests.swift
@@ -29,6 +29,19 @@ func fieldListParsesCommaSeparatedValues() {
 }
 
 @Test
+func listProjectsParsesProjectNameSearch() throws {
+    let command = try ListProjects.parse([
+        "--search", "drop test",
+        "--status", "all",
+        "--fields", "id,name,status"
+    ])
+
+    #expect(command.search == "drop test")
+    #expect(command.statusFilter == "all")
+    #expect(command.fields == "id,name,status")
+}
+
+@Test
 func iso8601DateParserAcceptsValidDates() throws {
     let date = try ISO8601DateParser.parse("2026-02-04T12:00:00Z", argumentName: "--due-before")
     #expect(date.timeIntervalSince1970 > 0)

--- a/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
+++ b/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
@@ -301,7 +301,7 @@ func mcpWireRejectsUnknownTopLevelAndNestedArgumentsBeforeDispatch() throws {
         #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"validation-test","version":"1"}}}"#,
         #"{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}"#,
         #"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_tasks","arguments":{"search":"drop test"}}}"#,
-        #"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_projects","arguments":{"search":"drop test","statusFilter":"all"}}}"#,
+        #"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_projects","arguments":{"query":"drop test","statusFilter":"all"}}}"#,
         #"{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"list_tasks","arguments":{"filter":{"unexpected":true}}}}"#,
         #"{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"list_tasks","arguments":{"page":{"offset":"50"}}}}"#,
         #"{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"edit_tasks","arguments":{"operation":"set_completion","targetIDs":["real-task"],"completion":{"state":"completed","unexpected":true}}}}"#,
@@ -331,7 +331,7 @@ func mcpWireRejectsUnknownTopLevelAndNestedArgumentsBeforeDispatch() throws {
     }
 
     #expect(toolErrorText(responses[2]).contains("list_tasks.search is unsupported; use list_tasks.filter.search"))
-    #expect(toolErrorText(responses[3]).contains("list_projects.search is unsupported"))
+    #expect(toolErrorText(responses[3]).contains("list_projects.query is unsupported"))
     #expect(toolErrorText(responses[4]).contains("list_tasks.filter.unexpected is unsupported"))
     #expect(toolErrorText(responses[5]).contains("list_tasks.page.offset is unsupported"))
     #expect(toolErrorText(responses[6]).contains("edit_tasks.completion.unexpected is unsupported"))
@@ -587,6 +587,8 @@ func projectToolDescriptionGuardsCompletionAndStalledRecommendations() {
     #expect(description.contains("availableTasks=0 does not mean a project is stalled"))
     #expect(description.contains("default statusFilter='active' is ignored"))
     #expect(description.contains("statusFilter remains active inside Review queries"))
+    #expect(description.contains("trimmed, literal, case-insensitive substring"))
+    #expect(description.contains("Follow nextCursor"))
     #expect(description.contains("inclusive"))
 }
 
@@ -758,5 +760,41 @@ func reviewPerspectiveAndStatusFilterDecodeTogetherAtMCPWireBoundary() throws {
             from: request.params.arguments,
             key: "reviewPerspective"
         ) == true
+    )
+}
+
+@Test
+func projectSearchDecodesAtMCPWireBoundary() throws {
+    let data = Data(
+        #"""
+        {
+          "jsonrpc": "2.0",
+          "id": 1,
+          "method": "tools/call",
+          "params": {
+            "name": "list_projects",
+            "arguments": {
+              "search": "drop test",
+              "statusFilter": "all"
+            }
+          }
+        }
+        """#.utf8
+    )
+    let request = try JSONDecoder().decode(Request<CallTool>.self, from: data)
+
+    #expect(
+        try FocusRelayServer.decodeArgument(
+            String.self,
+            from: request.params.arguments,
+            key: "search"
+        ) == "drop test"
+    )
+    #expect(
+        try FocusRelayServer.decodeArgument(
+            String.self,
+            from: request.params.arguments,
+            key: "statusFilter"
+        ) == "all"
     )
 }

--- a/Tests/OmniFocusIntegrationTests/CatalogCacheTests.swift
+++ b/Tests/OmniFocusIntegrationTests/CatalogCacheTests.swift
@@ -42,6 +42,26 @@ func projectCacheKeySeparatesStatusFilter() {
 }
 
 @Test
+func projectCacheKeySeparatesNameSearch() {
+    let page = PageRequest(limit: 10)
+    let first = CacheKey.projects(
+        page: page,
+        fields: ["id", "name"],
+        statusFilter: "all",
+        includeTaskCounts: false,
+        search: "drop test"
+    )
+    let second = CacheKey.projects(
+        page: page,
+        fields: ["id", "name"],
+        statusFilter: "all",
+        includeTaskCounts: false,
+        search: "another"
+    )
+    #expect(first != second)
+}
+
+@Test
 func projectCacheKeySeparatesIncludeTaskCounts() {
     let page = PageRequest(limit: 10, cursor: "cursor")
     let withoutCounts = CacheKey.projects(

--- a/Tests/OmniFocusIntegrationTests/ProjectNameSearchTests.swift
+++ b/Tests/OmniFocusIntegrationTests/ProjectNameSearchTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import JavaScriptCore
+@testable import OmniFocusAutomation
+import Testing
+
+@Test
+func projectNameSearchIsLiteralCaseInsensitiveAndPrecedesPagination() throws {
+    let module = try projectQueryHelperModule()
+    let context = JSContext()!
+    var exceptionMessage: String?
+    context.exceptionHandler = { _, exception in
+        exceptionMessage = exception?.toString()
+    }
+
+    let script = """
+    const Project = { Status: {
+      Active: "Active",
+      OnHold: "OnHold",
+      Dropped: "Dropped",
+      Done: "Done"
+    }};
+    function safe(fn) { try { return fn(); } catch (_) { return null; } }
+    \(module)
+    const projects = [
+      { id: "a", name: "Drop test", status: Project.Status.Active },
+      { id: "b", name: "Unrelated", status: Project.Status.Active },
+      { id: "c", name: "DROP TEST archive", status: Project.Status.Dropped },
+      { id: "d", name: "drop only", status: Project.Status.Active },
+      { id: "e", name: "test only", status: Project.Status.Active },
+      { id: "f", name: "Pre-drop test-post", status: Project.Status.OnHold }
+    ];
+    function search(query, statusFilter, limit) {
+      const normalized = normalizedProjectNameSearch(query);
+      const filtered = projects.filter(project =>
+        projectMatchesListStatus(project.status, statusFilter) &&
+        projectMatchesNameSearch(project, normalized)
+      );
+      return {
+        ids: filtered.slice(0, limit).map(project => project.id),
+        totalCount: filtered.length,
+        nextCursor: filtered.length > limit ? String(limit) : null
+      };
+    }
+    JSON.stringify({
+      all: search("  drop test  ", "all", 2),
+      active: search("DROP TEST", "active", 10),
+      partial: search("test-po", "all", 10)
+    });
+    """
+    let json = try #require(context.evaluateScript(script)?.toString())
+    #expect(exceptionMessage == nil)
+
+    struct Result: Decodable {
+        struct Page: Decodable {
+            let ids: [String]
+            let totalCount: Int
+            let nextCursor: String?
+        }
+        let all: Page
+        let active: Page
+        let partial: Page
+    }
+    let decoded = try JSONDecoder().decode(Result.self, from: Data(json.utf8))
+
+    #expect(decoded.all.ids == ["a", "c"])
+    #expect(decoded.all.totalCount == 3)
+    #expect(decoded.all.nextCursor == "2")
+    #expect(decoded.active.ids == ["a"])
+    #expect(decoded.active.totalCount == 1)
+    #expect(decoded.partial.ids == ["f"])
+}
+
+@Test
+func projectSearchNormalizationRejectsWhitespaceOnlyInput() throws {
+    #expect(try OmniFocusBridgeService.normalizeProjectSearch("  Drop test \n") == "Drop test")
+    #expect(try OmniFocusBridgeService.normalizeProjectSearch(nil) == nil)
+    #expect(throws: AutomationError.self) {
+        try OmniFocusBridgeService.normalizeProjectSearch(" \t\n ")
+    }
+}
+
+private func projectQueryHelperModule() throws -> String {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js")
+    let source = try String(contentsOf: sourceURL, encoding: .utf8)
+    let startMarker = "// PROJECT COMPLETION QUERY MODULE - list_projects completion vs statusFilter"
+    let endMarker = "// END PROJECT COMPLETION QUERY MODULE"
+    let start = try #require(source.range(of: startMarker))
+    let end = try #require(
+        source.range(of: endMarker, range: start.upperBound..<source.endIndex)
+    )
+    return String(source[start.lowerBound..<end.upperBound])
+}

--- a/docs/mutation-workflows.md
+++ b/docs/mutation-workflows.md
@@ -49,7 +49,15 @@ already known. Omit `destinationID` to move a project to the root library.
 focusrelay list-tasks --search "intro call" --fields id,name,projectName --limit 5
 focusrelay edit-tasks task-1 --operation update --flagged true --preview-only --return-fields id,name,flagged
 focusrelay edit-tasks task-1 --operation update --flagged true --verify --return-fields id,name,flagged
+
+focusrelay list-projects --search "drop test" --status all --fields id,name,status --limit 5
+focusrelay edit-projects project-1 --operation set_status --status dropped --preview-only --return-fields id,name,status
+focusrelay edit-projects project-1 --operation set_status --status dropped --verify --return-fields id,name,status
 ```
+
+Project search matches a trimmed, case-insensitive literal substring against
+project names only. Follow `nextCursor` while it is present, disambiguate
+multiple matches, and pass only the resolved stable IDs to `edit_projects`.
 
 Equivalent MCP call:
 

--- a/docs/omni-automation-contract.md
+++ b/docs/omni-automation-contract.md
@@ -106,6 +106,16 @@ compatibility; request `effectiveFlagged` for the visible OmniFocus flag state.
   and done projects are not reviewable.
 - Status and review-date filtering happen before total counts and pagination.
 
+## Project name search contract
+
+- `list_projects.search` trims surrounding whitespace and performs a literal,
+  case-insensitive substring match against `project.name` only.
+- Empty or whitespace-only searches fail before Bridge dispatch.
+- Status, Review, completion, and name filters are all applied before total
+  counts and pagination.
+- Native project order is preserved; no fuzzy matching or relevance ranking is
+  introduced.
+
 ## Pagination cursor contract
 
 - Cursors are opaque, versioned tokens bound to the originating list tool and


### PR DESCRIPTION
Closes #69

## Acceptance journey
`list_projects(search: "drop test", statusFilter: "all")` returns matching project names and stable IDs in the filtered page. The client then previews an explicit-ID mutation without scanning the full catalog or writing during lookup.

## Validation impact
`query`

## Changes
- add top-level MCP `search` and CLI `list-projects --search`
- trim and reject blank searches before Bridge dispatch
- apply literal case-insensitive project-name matching before counts/pagination
- include search in the project cache key and query-bound cursor fingerprint
- document safe project-name-to-ID read-before-write resolution

## Validation
- `swift test` — 173 tests passed
- `swift run focusrelay-dev validate --impact query` — 173 tests and semantic gates passed
- deterministic JavaScriptCore coverage verifies literal multi-word, partial, case-insensitive, status, count, and pagination behavior
- direct MCP decode and CLI parsing coverage
- live installed-Bridge UAT: `drop test` returned exactly `Drop test` (`buBqOONyCGB`, status dropped)
- preview-only explicit-ID status mutation succeeded with no write