### PR TITLE
Fail benchmark suites on invalid evidence

### DIFF
--- a/Tests/FocusRelayDevCoreTests/BenchmarkSuiteResultScriptTests.swift
+++ b/Tests/FocusRelayDevCoreTests/BenchmarkSuiteResultScriptTests.swift
@@ -1,0 +1,155 @@
+import Foundation
+import Testing
+
+@Suite("Benchmark suite result script")
+struct BenchmarkSuiteResultScriptTests {
+    @Test("clean required scenarios pass")
+    func cleanSuitePasses() throws {
+        let fixture = try BenchmarkSuiteFixture()
+        try fixture.writeCleanSuite()
+
+        let result = try fixture.runValidator()
+
+        #expect(result.status == 0)
+        #expect(result.output.contains("Benchmark suite evidence passed"))
+    }
+
+    @Test(
+        "invalid evidence fails closed",
+        arguments: [
+            FailureFixture.timeout,
+            .error,
+            .incompleteCoverage,
+            .malformedJSON,
+            .missingRaw,
+            .missingSummary,
+        ]
+    )
+    func invalidEvidenceFailsClosed(failure: FailureFixture) throws {
+        let fixture = try BenchmarkSuiteFixture()
+        try fixture.writeCleanSuite()
+        try fixture.apply(failure)
+
+        let result = try fixture.runValidator()
+
+        #expect(result.status != 0)
+        #expect(result.output.contains(failure.expectedDiagnostic))
+        #expect(result.output.contains("Artifacts retained"))
+    }
+}
+
+enum FailureFixture: CaseIterable, Sendable {
+    case timeout
+    case error
+    case incompleteCoverage
+    case malformedJSON
+    case missingRaw
+    case missingSummary
+
+    var expectedDiagnostic: String {
+        switch self {
+        case .timeout: "timed out"
+        case .error: "reported an error"
+        case .incompleteCoverage: "missing measured scenario search_no_match"
+        case .malformedJSON: "malformed JSON"
+        case .missingRaw: "missing or empty raw.jsonl"
+        case .missingSummary: "missing or empty summary.md"
+        }
+    }
+}
+
+private struct BenchmarkSuiteFixture {
+    let root: URL
+    let validator: URL
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("focusrelay-benchmark-\(UUID().uuidString)", isDirectory: true)
+        validator = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent("scripts/check-benchmark-suite-results.sh")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    func writeCleanSuite() throws {
+        try writeTool("get_task_counts", scenarios: [
+            "default", "inbox_only", "available_only", "completed_after_anchor",
+            "flagged_only", "search_no_match",
+        ])
+        try writeTool("list_tasks", scenarios: [
+            "default", "default_no_total", "inbox_only", "inbox_only_no_total",
+            "available_only", "available_only_no_total", "completed_after_anchor",
+            "flagged_only", "flagged_only_no_total", "search_no_match",
+        ])
+        try writeTool("get_project_counts", scenarios: [
+            "project_view_remaining", "project_view_active", "project_view_available",
+            "project_view_everything", "completed_after_anchor",
+        ])
+    }
+
+    func apply(_ failure: FailureFixture) throws {
+        let tool = root.appendingPathComponent("get_task_counts", isDirectory: true)
+        let raw = tool.appendingPathComponent("raw.jsonl")
+        switch failure {
+        case .timeout:
+            try append(
+                #"{"phase":"measured","scenario":"default","ok":false,"timeout":true,"error":"timed out"}"#,
+                to: raw
+            )
+        case .error:
+            try append(
+                #"{"phase":"measured","scenario":"default","ok":false,"timeout":false,"error":"failed"}"#,
+                to: raw
+            )
+        case .incompleteCoverage:
+            let contents = try String(contentsOf: raw, encoding: .utf8)
+                .split(separator: "\n")
+                .filter { !$0.contains(#""scenario":"search_no_match""#) }
+                .joined(separator: "\n") + "\n"
+            try contents.write(to: raw, atomically: true, encoding: .utf8)
+        case .malformedJSON:
+            try append("{not-json}", to: raw)
+        case .missingRaw:
+            try FileManager.default.removeItem(at: raw)
+        case .missingSummary:
+            try FileManager.default.removeItem(at: tool.appendingPathComponent("summary.md"))
+        }
+    }
+
+    func runValidator() throws -> (status: Int32, output: String) {
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [validator.path, root.path]
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        process.waitUntilExit()
+        let output = String(decoding: pipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        return (process.terminationStatus, output)
+    }
+
+    private func writeTool(_ name: String, scenarios: [String]) throws {
+        let directory = root.appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let rows = scenarios.map {
+            #"{"phase":"measured","scenario":"\#($0)","ok":true,"timeout":false}"#
+        }.joined(separator: "\n") + "\n"
+        try rows.write(
+            to: directory.appendingPathComponent("raw.jsonl"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "# Summary\n".write(
+            to: directory.appendingPathComponent("summary.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
+    private func append(_ line: String, to file: URL) throws {
+        let handle = try FileHandle(forWritingTo: file)
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data("\(line)\n".utf8))
+    }
+}

--- a/docs/release-engineering-checklist.md
+++ b/docs/release-engineering-checklist.md
@@ -36,6 +36,12 @@ swift run focusrelay-dev benchmark --profile release
 
 The release profile is the realistic 1.5-hour suite. Use `smoke` during targeted
 performance work and `stress` only to answer a named diagnostic question.
+Every benchmark profile fails closed when a required measured scenario reports
+an error or timeout, has incomplete coverage, or produces malformed/missing
+artifacts. An environment-interrupted run is failed evidence even when the
+interruption is external. Diagnose it first, then permit at most one bounded
+retry with the cause removed; for sleep interruption, run the retry under
+`caffeinate`.
 
 ## 3. Tag The Certified Commit
 

--- a/scripts/benchmark-suite.sh
+++ b/scripts/benchmark-suite.sh
@@ -241,4 +241,5 @@ cat > "${SUITE_DIR}/summary.md" <<EOF_SUMMARY
 - get_project_counts: ${PROJECT_COUNTS_DIR}/summary.md
 EOF_SUMMARY
 
+./scripts/check-benchmark-suite-results.sh "$SUITE_DIR"
 log "Suite complete: ${SUITE_DIR}"

--- a/scripts/check-benchmark-suite-results.sh
+++ b/scripts/check-benchmark-suite-results.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 SUITE_DIR" >&2
+  exit 2
+fi
+
+SUITE_DIR="$1"
+FAILURES=()
+
+check_tool() {
+  local tool="$1"
+  shift
+  local raw="${SUITE_DIR}/${tool}/raw.jsonl"
+  local summary="${SUITE_DIR}/${tool}/summary.md"
+
+  if [[ ! -s "$raw" ]]; then
+    FAILURES+=("${tool}: missing or empty raw.jsonl")
+    return
+  fi
+  if [[ ! -s "$summary" ]]; then
+    FAILURES+=("${tool}: missing or empty summary.md")
+  fi
+  if ! jq -e -c . "$raw" >/dev/null 2>&1; then
+    FAILURES+=("${tool}: malformed JSON in raw.jsonl")
+    return
+  fi
+
+  local measured=0
+  local line_number=0
+  local line
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_number=$((line_number + 1))
+    if [[ "$line" == *'"phase":"measured"'* ]]; then
+      measured=$((measured + 1))
+      if [[ "$line" != *'"ok":true'* ]]; then
+        FAILURES+=("${tool}: measured call ${line_number} is not successful")
+      fi
+      if [[ "$line" == *'"timeout":true'* ]]; then
+        FAILURES+=("${tool}: measured call ${line_number} timed out")
+      fi
+      if [[ "$line" == *'"error":'* ]]; then
+        FAILURES+=("${tool}: measured call ${line_number} reported an error")
+      fi
+    fi
+  done < "$raw"
+
+  if (( measured == 0 )); then
+    FAILURES+=("${tool}: no measured calls")
+  fi
+
+  local scenario
+  for scenario in "$@"; do
+    if ! jq -e --arg scenario "$scenario" \
+      'select(.phase == "measured" and .scenario == $scenario)' \
+      "$raw" >/dev/null
+    then
+      FAILURES+=("${tool}: missing measured scenario ${scenario}")
+    fi
+  done
+}
+
+check_tool get_task_counts \
+  default inbox_only available_only completed_after_anchor flagged_only search_no_match
+check_tool list_tasks \
+  default default_no_total inbox_only inbox_only_no_total available_only \
+  available_only_no_total completed_after_anchor flagged_only flagged_only_no_total \
+  search_no_match
+check_tool get_project_counts \
+  project_view_remaining project_view_active project_view_available \
+  project_view_everything completed_after_anchor
+
+if (( ${#FAILURES[@]} > 0 )); then
+  echo "Benchmark suite failed closed: ${SUITE_DIR}" >&2
+  printf '  - %s\n' "${FAILURES[@]}" >&2
+  echo "Artifacts retained under ${SUITE_DIR}" >&2
+  exit 1
+fi
+
+echo "Benchmark suite evidence passed: ${SUITE_DIR}"


### PR DESCRIPTION
Closes #154

Validation impact: `performance`

Acceptance journey: a release operator running a benchmark profile now gets a nonzero exit when any required measured call fails, times out, loses scenario coverage, or produces malformed/missing artifacts; artifacts remain available for diagnosis.

Validation:
- `swift run focusrelay-dev validate --impact performance` (175 tests plus live semantic gates)
- clean no-sleep smoke artifacts pass the new validator
- the 2026-07-24 sleep-interrupted release artifacts fail closed on exactly four project-count timeout rows
- production fingerprint remains `e6de35f8912b6934449ad08774ed2417e9060463e0243b8053dbd4c9ae6da786`