### PR TITLE
Install versioned plugin bundles for release UAT

### DIFF
--- a/docs/release-engineering-checklist.md
+++ b/docs/release-engineering-checklist.md
@@ -83,11 +83,16 @@ If the tap appears stale, untap and retap it before trusting the result.
 If plugin JavaScript changed:
 
 ```bash
-./scripts/install-plugin.sh
+FOCUSRELAY_PLUGIN_SRC=/opt/homebrew/opt/focusrelay/share/focusrelay/Plugin/FocusRelayBridge.omnijs \
+  ./scripts/install-plugin.sh
 osascript -e 'tell application "OmniFocus" to quit'
 sleep 2
 open -a "OmniFocus"
 ```
+
+Omit `FOCUSRELAY_PLUGIN_SRC` only for development validation that intentionally
+installs the source-tree `0.0.0-dev` plugin. Release verification must install
+the version-embedded plugin from the package being tested.
 
 Then verify the README flow: install binary, install plugin, configure MCP,
 restart OmniFocus, approve the first query, and receive real data.

--- a/scripts/install-plugin.sh
+++ b/scripts/install-plugin.sh
@@ -2,7 +2,12 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-PLUGIN_SRC="$ROOT_DIR/Plugin/FocusRelayBridge.omnijs"
+PLUGIN_SRC="${FOCUSRELAY_PLUGIN_SRC:-$ROOT_DIR/Plugin/FocusRelayBridge.omnijs}"
+
+if [[ ! -d "$PLUGIN_SRC" ]]; then
+    echo "❌ Plugin source not found: $PLUGIN_SRC" >&2
+    exit 1
+fi
 
 echo "🔍 Detecting OmniFocus plugin directories..."
 


### PR DESCRIPTION
Release follow-up for #152.

Validation impact: `package`

The installer now accepts `FOCUSRELAY_PLUGIN_SRC` while preserving the source-tree default. This lets release verification install the version-embedded plugin from Homebrew through the one approved installer instead of overwriting it with the `0.0.0-dev` source bundle.

Validation:
- missing override fails before mutation
- Homebrew-packaged plugin installed to both detected OmniFocus plugin locations
- installed binary and Bridge both report `0.11.0-beta`
- Bridge health, first task query, and `Drop test` project search passed
- `swift run focusrelay-dev validate --impact package` passed (175 tests plus release build)