### PR TITLE
Rewrite v0.11.0-beta release notes for users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,40 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.0-beta] - 2026-07-24
 
-### Added
+### What’s new
 
-- Deterministic project-name search through `list_projects.search` and
-  `list-projects --search` for stable-ID discovery before project mutations.
-- Active and on-hold projects can be marked reviewed through
-  `projectPatch.reviewedNow=true`; FocusRelay preflights the complete batch,
-  preserves review intervals, uses one request-level timestamp, and verifies the
-  OmniFocus-generated next review date.
-- Task dropping and restoration through `edit_tasks` / `edit-tasks` operation
-  `set_status`, including explicit repeating occurrence/series scope, preview,
-  verified `taskStatus` and `dropDate` readback, and all-or-nothing preflight.
+- Clean up your task list without losing history by dropping and restoring
+  tasks instead of marking them completed.
+- Finish weekly reviews faster by letting FocusRelay mark active or on-hold
+  projects as reviewed using OmniFocus’s normal review schedule.
+- Find the right project by name before changing it, even when it is on hold,
+  completed, or dropped.
+- Make bulk changes with confidence: if any requested task or project cannot be
+  updated, nothing in that batch is changed.
+- Get more trustworthy results from searches, Review queries, and multi-page
+  lists—invalid requests now fail clearly instead of returning misleading data.
 
-### Changed
+### Before upgrading
 
-- **Breaking:** Seven task and project mutation tools and CLI commands were
-  consolidated into `edit_tasks` / `edit-tasks` and
-  `edit_projects` / `edit-projects`. Each request now selects an explicit
-  operation and supplies exactly one matching payload; legacy aliases were
-  removed. See the
+- Task and project editing is now handled through the two clearer
+  `edit_tasks` and `edit_projects` tools. If you have saved automations using
+  older editing tools, update them using the
   [migration table](docs/mutation-workflows.md#breaking-migration).
-
-### Fixed
-
-- Bulk task and project mutations now preflight every target before applying or
-  saving, so one unknown target fails the whole request without changing valid
-  targets.
-- MCP tool calls now reject unknown top-level and nested arguments before
-  dispatch instead of silently turning malformed filters into plausible
-  unfiltered queries.
-- Review perspective project queries now honor `statusFilter`, so active and
-  on-hold review batches are disjoint while `all` includes both reviewable
-  statuses and still excludes dropped/done projects.
-- List cursors are now opaque and bound to the originating query; malformed,
-  stale-version, or filter-mismatched cursors fail before Bridge dispatch.
 
 ## [0.10.1-beta] - 2026-07-19
 

--- a/docs/release-notes-v0.11.0-beta.md
+++ b/docs/release-notes-v0.11.0-beta.md
@@ -1,72 +1,26 @@
 # FocusRelay 0.11.0-beta
 
-FocusRelay 0.11.0-beta makes bulk OmniFocus cleanup and review workflows safer,
-more discoverable, and harder for MCP clients to misuse.
+This release makes everyday OmniFocus cleanup and review work safer and easier.
 
-## Highlights
+## What’s new
 
-- Drop and restore tasks without creating false completion history, including
-  explicit occurrence/series handling for repeating tasks.
-- Mark active or on-hold projects reviewed with native OmniFocus review-date
-  behavior and verified readback.
-- Resolve project names to stable IDs with deterministic, case-insensitive
-  `list_projects` search before previewing a mutation.
-- Reject malformed MCP arguments instead of silently returning plausible
-  unfiltered data.
-- Keep bulk writes all-or-nothing when any requested target is unknown or
-  ineligible.
-- Keep Review perspective active and on-hold batches disjoint and correctly
-  counted.
-- Bind opaque pagination cursors to their originating query so changing filters
-  cannot silently skip or duplicate targets.
+- Clean up your task list without losing history by dropping and restoring
+  tasks instead of marking them completed.
+- Finish weekly reviews faster by letting FocusRelay mark active or on-hold
+  projects as reviewed using OmniFocus’s normal review schedule.
+- Find the right project by name before changing it, even when it is on hold,
+  completed, or dropped.
+- Make bulk changes with confidence: if any requested task or project cannot be
+  updated, nothing in that batch is changed.
+- Get more trustworthy results from searches, Review queries, and multi-page
+  lists—invalid requests now fail clearly instead of returning misleading data.
 
-## Breaking Tool Consolidation
+## Before upgrading
 
-The seven legacy task/project mutation tools have been replaced by two explicit
-operation-based tools:
+Task and project editing is now handled through the two clearer `edit_tasks` and
+`edit_projects` tools. If you have saved automations using older editing tools,
+update them using the
+[migration table](mutation-workflows.md#breaking-migration).
 
-- `edit_tasks` with `update`, `set_status`, `set_completion`, or `move`
-- `edit_projects` with `update`, `set_status`, `set_completion`, or `move`
-
-Each request supplies one operation, stable target IDs, and exactly one matching
-payload. CLI users use `edit-tasks` and `edit-projects`. See
-[Mutation Workflows](mutation-workflows.md) for the migration table and
-read-before-write examples.
-
-## Safer Agent Workflows
-
-FocusRelay now closes every public MCP argument object and validates the same
-schemas returned by `tools/list` before query or mutation dispatch. A misplaced
-task search receives a path-specific correction, unknown nested properties fail
-clearly, and malformed mutations never reach the Bridge.
-
-Project lookup no longer requires walking the complete catalog:
-
-```bash
-focusrelay list-projects --search "drop test" --status all --fields id,name,status
-focusrelay edit-projects PROJECT_ID --operation set_status --status dropped --preview-only --return-fields id,name,status
-```
-
-Search is a trimmed, literal, case-insensitive substring match against project
-names only. Follow `nextCursor` while it is present before concluding that no
-additional filtered matches exist.
-
-## Upgrade Notes
-
-The plugin JavaScript and binary must stay in sync. After upgrading:
-
-1. Reinstall `FocusRelayBridge.omnijs` using the packaged installer.
-2. Quit OmniFocus completely and reopen it.
-3. Run `focusrelay --version` and `focusrelay bridge-health-check`.
-4. Run a small query and approve the Omni Automation script if OmniFocus asks.
-
-Existing saved raw numeric pagination cursors are intentionally invalid. Restart
-pagination from page one to receive a query-bound cursor.
-
-## Validation
-
-The release candidate is certified through Swift Testing, direct MCP wire
-probes, deterministic JavaScriptCore contracts, Bridge semantic gates, live
-read-before-write and mutation UAT, a release build, and the frozen realistic
-release benchmark. Final benchmark and artifact evidence is recorded in release
-tracker [#152](https://github.com/deverman/FocusRelayMCP/issues/152).
+After upgrading, reinstall the packaged OmniFocus plugin and restart OmniFocus
+so the plugin and FocusRelay binary stay in sync.


### PR DESCRIPTION
Follow-up to #152

Validation impact: `docs`

Rewrites the v0.11.0-beta changelog and release notes as five concise, user-benefit bullets plus a short upgrade warning. Removes implementation and validation detail from the user-facing summary.

Validation: `swift run focusrelay-dev validate --impact docs`