### PR TITLE
Reject unsupported output fields before dispatch

### DIFF
--- a/Sources/FocusRelayCLI/CLIHelpers.swift
+++ b/Sources/FocusRelayCLI/CLIHelpers.swift
@@ -1,5 +1,6 @@
 import ArgumentParser
 import Foundation
+import FocusRelayOutput
 import OmniFocusCore
 
 extension MutationCompletionState: ExpressibleByArgument {}
@@ -17,6 +18,12 @@ enum FieldList {
             .split(separator: ",")
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
+    }
+
+    static func parseOutputFields(_ raw: String?, for toolName: String) throws -> [String] {
+        let fields = parse(raw)
+        try OutputFieldCatalog.validate(fields, for: toolName)
+        return fields
     }
 }
 

--- a/Sources/FocusRelayCLI/FocusRelayCLI.swift
+++ b/Sources/FocusRelayCLI/FocusRelayCLI.swift
@@ -72,7 +72,7 @@ struct ListTasks: AsyncParsableCommand {
         let service = OmniFocusBridgeService()
         let taskFilter = try filter.makeTaskFilter()
         let pageRequest = page.makePageRequest(defaultLimit: 50)
-        let fieldList = FieldList.parse(fields)
+        let fieldList = try FieldList.parseOutputFields(fields, for: "list_tasks")
         let selectedFields = fieldList.isEmpty ? ["id", "name"] : fieldList
 
         let result = try await service.listTasks(filter: taskFilter, page: pageRequest, fields: selectedFields)
@@ -98,7 +98,7 @@ struct GetTask: AsyncParsableCommand {
 
     func run() async throws {
         let service = OmniFocusBridgeService()
-        let fieldList = FieldList.parse(fields)
+        let fieldList = try FieldList.parseOutputFields(fields, for: "get_task")
         let selectedFields = fieldList.isEmpty ? ["id", "name"] : fieldList
 
         let result = try await service.getTask(id: id, fields: selectedFields)
@@ -149,7 +149,7 @@ struct ListProjects: AsyncParsableCommand {
     func run() async throws {
         let service = OmniFocusBridgeService()
         let pageRequest = page.makePageRequest(defaultLimit: 150)
-        let fieldList = FieldList.parse(fields)
+        let fieldList = try FieldList.parseOutputFields(fields, for: "list_projects")
         let selectedFields = FocusRelayServer.resolvedProjectFields(
             requestedFields: fieldList,
             statusFilter: statusFilter,
@@ -222,7 +222,7 @@ struct ListFolders: AsyncParsableCommand {
     func run() async throws {
         let service = OmniFocusBridgeService()
         let pageRequest = page.makePageRequest(defaultLimit: 150)
-        let fieldList = FieldList.parse(fields)
+        let fieldList = try FieldList.parseOutputFields(fields, for: "list_folders")
         let selectedFields = fieldList.isEmpty ? ["id", "name"] : fieldList
 
         let result = try await service.listFolders(page: pageRequest, fields: selectedFields)

--- a/Sources/FocusRelayOutput/OutputModels.swift
+++ b/Sources/FocusRelayOutput/OutputModels.swift
@@ -1,6 +1,68 @@
 import Foundation
 import OmniFocusCore
 
+public enum OutputFieldCatalog {
+    public static let task = [
+        "id", "name", "note", "projectID", "projectName", "tagIDs", "tagNames",
+        "dueDate", "plannedDate", "deferDate", "completionDate", "completed",
+        "flagged", "effectiveFlagged", "estimatedMinutes", "available"
+    ]
+
+    public static let project = [
+        "id", "name", "note", "status", "flagged", "lastReviewDate",
+        "nextReviewDate", "reviewInterval", "hasChildren", "nextTask",
+        "containsSingletonActions", "isStalled", "completionDate"
+    ]
+
+    public static let folder = [
+        "id", "name", "parentID", "parentName", "projectCount", "childFolderCount"
+    ]
+
+    public static func fields(for toolName: String) -> [String]? {
+        switch toolName {
+        case "list_tasks", "get_task":
+            task
+        case "list_projects":
+            project
+        case "list_folders":
+            folder
+        default:
+            nil
+        }
+    }
+
+    public static func validate(_ requestedFields: [String], for toolName: String) throws {
+        guard let supportedFields = fields(for: toolName) else {
+            throw OutputFieldValidationError("\(toolName) does not accept output fields.")
+        }
+
+        let supported = Set(supportedFields)
+        var seen: Set<String> = []
+        let unsupported = requestedFields.filter {
+            !supported.contains($0) && seen.insert($0).inserted
+        }
+        guard !unsupported.isEmpty else { return }
+
+        throw OutputFieldValidationError(
+            "\(toolName).fields contains unsupported field(s): "
+                + unsupported.joined(separator: ", ")
+                + ". Supported fields: "
+                + supportedFields.joined(separator: ", ")
+                + "."
+        )
+    }
+}
+
+public struct OutputFieldValidationError: Error, LocalizedError, Sendable {
+    public let message: String
+
+    public init(_ message: String) {
+        self.message = message
+    }
+
+    public var errorDescription: String? { message }
+}
+
 public struct TaskOutput: Encodable {
     public let id: String?
     public let name: String?

--- a/Sources/FocusRelayServer/FocusRelayServer.swift
+++ b/Sources/FocusRelayServer/FocusRelayServer.swift
@@ -292,7 +292,7 @@ public enum FocusRelayServer {
                             "fields": .object([
                                 "type": .string("array"),
                                 "description": .string("CRITICAL: Specify which fields to return. DEFAULT ONLY includes 'id' and 'name'.\n\nIMPORTANT FIELD NAMES (case-sensitive):\n- 'completionDate' - when task was completed (NOT 'completedDate')\n- 'dueDate' - when task is due\n- 'plannedDate' - when task is planned for\n- 'deferDate' - when task becomes available\n- 'completed' - true/false completion status\n- 'projectName' - name of the project\n- 'tagNames' - list of tags\n- 'available' - whether task is actionable now\n- 'flagged' - whether this task itself is flagged\n- 'effectiveFlagged' - visible OmniFocus flag state, including flags inherited from a parent task or project\n\nFor Flagged-perspective questions, filter with flagged=true and request 'effectiveFlagged' when returning flag state. ALWAYS include the fields you need to answer the user's question."),
-                                "items": .object(["type": .string("string")]),
+                                "items": outputFieldItemsSchema(for: "list_tasks"),
                                 "examples": .array([
                                     .array([.string("id"), .string("name"), .string("completionDate"), .string("completed"), .string("projectName")]),
                                     .array([.string("id"), .string("name"), .string("dueDate"), .string("plannedDate"), .string("deferDate"), .string("available")]),
@@ -311,7 +311,7 @@ public enum FocusRelayServer {
                             "id": .object(["type": .string("string")]),
                             "fields": .object([
                                 "type": .string("array"),
-                                "items": .object(["type": .string("string")])
+                                "items": outputFieldItemsSchema(for: "get_task")
                             ])
                         ],
                         required: ["id"]
@@ -378,7 +378,7 @@ public enum FocusRelayServer {
                             "fields": .object([
                                 "type": .string("array"),
                                 "description": .string("Specify which fields to return. Useful fields: 'id', 'name', 'note', 'status', 'flagged', 'completionDate', 'lastReviewDate', 'nextReviewDate', 'reviewInterval', 'hasChildren', 'nextTask', 'containsSingletonActions', and 'isStalled'. Always include 'status' when comparing projects across statuses. Task-count fields are included by includeTaskCounts."),
-                                "items": .object(["type": .string("string")]),
+                                "items": outputFieldItemsSchema(for: "list_projects"),
                                 "examples": .array([
                                     .array([.string("id"), .string("name"), .string("status"), .string("isStalled")]),
                                     .array([.string("id"), .string("name"), .string("status"), .string("completionDate")]),
@@ -431,7 +431,7 @@ public enum FocusRelayServer {
                             "fields": .object([
                                 "type": .string("array"),
                                 "description": .string("Specify folder fields to return: id, name, parentID, parentName, projectCount, childFolderCount."),
-                                "items": .object(["type": .string("string")])
+                                "items": outputFieldItemsSchema(for: "list_folders")
                             ])
                         ]
                     ),
@@ -719,6 +719,7 @@ public enum FocusRelayServer {
                     }
                     let page = try decodePageRequest(from: params)
                     let requestedFields = decodeStringArray(params.arguments?["fields"]) ?? []
+                    try OutputFieldCatalog.validate(requestedFields, for: "list_tasks")
                     let fields = requestedFields.isEmpty ? ["id", "name"] : requestedFields
                     let result = try await service.listTasks(filter: filter, page: page, fields: fields)
                     let fieldSet = Set(fields)
@@ -731,6 +732,7 @@ public enum FocusRelayServer {
                         return .init(content: [.text(text: "Missing id", annotations: nil, _meta: nil)], isError: true)
                     }
                     let requestedFields = decodeStringArray(params.arguments?["fields"]) ?? []
+                    try OutputFieldCatalog.validate(requestedFields, for: "get_task")
                     let fields = requestedFields.isEmpty ? ["id", "name"] : requestedFields
                     let result = try await service.getTask(id: id, fields: fields)
                     let fieldSet = Set(fields)
@@ -748,6 +750,7 @@ public enum FocusRelayServer {
                     let completedBefore = try decodeArgument(Date.self, from: params.arguments, key: "completedBefore")
                     let completedAfter = try decodeArgument(Date.self, from: params.arguments, key: "completedAfter")
                     let requestedFields = decodeStringArray(params.arguments?["fields"]) ?? []
+                    try OutputFieldCatalog.validate(requestedFields, for: "list_projects")
                     let fields = resolvedProjectFields(
                         requestedFields: requestedFields,
                         statusFilter: statusFilter,
@@ -782,6 +785,7 @@ public enum FocusRelayServer {
                 case "list_folders":
                     let page = try decodePageRequest(from: params)
                     let requestedFields = decodeStringArray(params.arguments?["fields"]) ?? []
+                    try OutputFieldCatalog.validate(requestedFields, for: "list_folders")
                     let fields = requestedFields.isEmpty ? ["id", "name"] : requestedFields
                     let result = try await service.listFolders(page: page, fields: fields)
                     let fieldSet = Set(fields)
@@ -1048,6 +1052,14 @@ private func paginationCursorSchema() -> Value {
         type: "string",
         description: "Opaque cursor for the identical query. If membership filters change, omit the cursor and restart from page one."
     )
+}
+
+private func outputFieldItemsSchema(for toolName: String) -> Value {
+    let fields = OutputFieldCatalog.fields(for: toolName) ?? []
+    return .object([
+        "type": .string("string"),
+        "enum": .array(fields.map(Value.string))
+    ])
 }
 
 private func dateFilterSchema(_ description: String, example: Value) -> Value {

--- a/Tests/FocusRelayCLITests/FocusRelayCLITests.swift
+++ b/Tests/FocusRelayCLITests/FocusRelayCLITests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import FocusRelayCLI
+import FocusRelayOutput
 import FocusRelayVersion
 import OmniFocusCore
 
@@ -433,4 +434,16 @@ func listBenchmarkArtifactKeepsHistoricalKeys() throws {
         "ok", "timeout", "returnedCount", "totalCount", "firstItemID", "lastItemID"
     ])
     #expect(object["transport"] as? String == "plugin")
+}
+
+@Test
+func outputFieldCLIParsingUsesTheSharedCatalog() throws {
+    #expect(
+        try FieldList.parseOutputFields("id, name, completionDate", for: "list_tasks")
+            == ["id", "name", "completionDate"]
+    )
+
+    #expect(throws: OutputFieldValidationError.self) {
+        try FieldList.parseOutputFields("id,notAField", for: "list_tasks")
+    }
 }

--- a/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
+++ b/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import FocusRelayServer
+import FocusRelayOutput
 import FocusRelayVersion
 import MCP
 @testable import OmniFocusAutomation
@@ -167,6 +168,34 @@ func publicMCPToolSurfaceExcludesInternalDiagnostics() {
 }
 
 @Test
+func outputFieldCatalogAcceptsEverySupportedReadField() throws {
+    for toolName in ["list_tasks", "get_task", "list_projects", "list_folders"] {
+        let fields = try #require(OutputFieldCatalog.fields(for: toolName))
+        try OutputFieldCatalog.validate(fields, for: toolName)
+    }
+}
+
+@Test
+func outputFieldCatalogRejectsUnknownAndMixedFieldsDeterministically() {
+    #expect(throws: OutputFieldValidationError.self) {
+        try OutputFieldCatalog.validate(["id", "notAField"], for: "list_tasks")
+    }
+
+    do {
+        try OutputFieldCatalog.validate(
+            ["id", "unknownSecond", "unknownFirst", "unknownSecond"],
+            for: "list_projects"
+        )
+        Issue.record("Expected unsupported project fields to fail")
+    } catch {
+        #expect(
+            error.localizedDescription
+                .contains("list_projects.fields contains unsupported field(s): unknownSecond, unknownFirst")
+        )
+    }
+}
+
+@Test
 func mutationToolCatalogIsExplicitlySeparatedFromReadTools() {
     #expect(FocusRelayServer.mutationToolNames == [
         "edit_tasks",
@@ -242,6 +271,14 @@ func productionToolsListMatchesGoldenPublicCatalog() throws {
     for tool in tools {
         let schema = try #require(tool["inputSchema"] as? [String: Any])
         expectClosedObjectSchemas(schema)
+
+        if let name = tool["name"] as? String,
+           let expectedFields = OutputFieldCatalog.fields(for: name) {
+            let properties = try #require(schema["properties"] as? [String: Any])
+            let fields = try #require(properties["fields"] as? [String: Any])
+            let items = try #require(fields["items"] as? [String: Any])
+            #expect(items["enum"] as? [String] == expectedFields)
+        }
     }
 
     for name in FocusRelayServer.mutationToolNames {
@@ -306,13 +343,18 @@ func mcpWireRejectsUnknownTopLevelAndNestedArgumentsBeforeDispatch() throws {
         #"{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"list_tasks","arguments":{"page":{"offset":"50"}}}}"#,
         #"{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"edit_tasks","arguments":{"operation":"set_completion","targetIDs":["real-task"],"completion":{"state":"completed","unexpected":true}}}}"#,
         #"{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"list_projects","arguments":{"statusFilter":"active","page":{"cursor":"100"}}}}"#,
-        #"{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"list_projects","arguments":{"statusFilter":"active","reviewPerspective":false,"page":{"cursor":"\#(reviewCursor)"}}}}"#
+        #"{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"list_projects","arguments":{"statusFilter":"active","reviewPerspective":false,"page":{"cursor":"\#(reviewCursor)"}}}}"#,
+        #"{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"list_tasks","arguments":{"fields":["id","notAField"]}}}"#,
+        #"{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"get_task","arguments":{"id":"unused","fields":["unknownTaskField"]}}}"#,
+        #"{"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"list_projects","arguments":{"fields":["status","unknownProjectField"]}}}"#,
+        #"{"jsonrpc":"2.0","id":12,"method":"tools/call","params":{"name":"list_folders","arguments":{"fields":["id","unknownFolderField"]}}}"#,
+        #"{"jsonrpc":"2.0","id":13,"method":"tools/call","params":{"name":"list_tags","arguments":{"fields":["id"]}}}"#
     ].joined(separator: "\n") + "\n"
     try standardInput.fileHandleForWriting.write(contentsOf: Data(requests.utf8))
 
     var responses: [Int: [String: Any]] = [:]
     var buffered = Data()
-    while responses.count < 8 {
+    while responses.count < 13 {
         let chunk = standardOutput.fileHandleForReading.availableData
         guard !chunk.isEmpty else {
             Issue.record("MCP server exited before returning argument-validation responses")
@@ -337,6 +379,11 @@ func mcpWireRejectsUnknownTopLevelAndNestedArgumentsBeforeDispatch() throws {
     #expect(toolErrorText(responses[6]).contains("edit_tasks.completion.unexpected is unsupported"))
     #expect(toolErrorText(responses[7]).contains("Pagination cursor is malformed or unsupported"))
     #expect(toolErrorText(responses[8]).contains("Pagination cursor is for a different query"))
+    #expect(toolErrorText(responses[9]).contains("list_tasks.fields contains unsupported field(s): notAField"))
+    #expect(toolErrorText(responses[10]).contains("get_task.fields contains unsupported field(s): unknownTaskField"))
+    #expect(toolErrorText(responses[11]).contains("list_projects.fields contains unsupported field(s): unknownProjectField"))
+    #expect(toolErrorText(responses[12]).contains("list_folders.fields contains unsupported field(s): unknownFolderField"))
+    #expect(toolErrorText(responses[13]).contains("list_tags.fields is unsupported"))
 }
 
 @Test


### PR DESCRIPTION
Closes #161

## What changed

- Adds one authoritative output-field catalog shared by MCP and CLI read paths.
- Rejects unknown or mixed valid/invalid `fields` values before Bridge dispatch
  for `list_tasks`, `get_task`, `list_projects`, and `list_folders`.
- Publishes valid field names as MCP schema enums.
- Keeps `list_tags.fields` rejected until #70 introduces that separate query
  surface.
- Adds direct MCP boundary, schema, shared-catalog, and CLI regression coverage.

## Why

Unknown field names previously reached output shaping, where they were silently
ignored. A client could therefore receive a plausible successful response and
reason as though the requested value had been inspected. The new contract fails
closed with the tool name, unsupported values, and supported alternatives.

No OmniFocus task names, project names, notes, IDs, or other personal content
are included.

## User impact

Mistyped or invented fields now fail immediately and clearly instead of
returning incomplete-looking success. Models can discover the valid
case-sensitive values directly from the tool schema.

## Catalog measurement

- Equivalent catalog before field enums: 30,426 bytes
- Catalog after field enums: 31,082 bytes
- Increase: 656 bytes

The tool count is unchanged.

## Validation

- `swift run focusrelay-dev validate --impact server-wire`
  - 179 tests passed
  - release build passed
  - live Bridge tests correctly reported as skipped at this tier
- Direct MCP invalid/mixed field coverage passed for every current read-field
  tool.
- `list_tags.fields` fail-closed coverage passed.
- CLI invalid-field repro failed before Bridge access with the actionable
  validation error.
- `git diff --check` passed.

One direct `swift test` invocation initially hit SwiftPM's nested `sandbox-exec`
manifest restriction; the same targeted regression passed outside the managed
workspace sandbox.
