### PR TITLE
Harden query-bound pagination

### DIFF
--- a/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
+++ b/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
@@ -15,12 +15,12 @@ public final class OmniFocusBridgeService: OmniFocusService {
     }
 
     public func listTasks(filter: TaskFilter, page: PageRequest, fields: [String]?) async throws -> Page<TaskItem> {
-        let queryKey = try QueryBoundCursor.queryKey(tool: "list_tasks", input: filter)
-        let bridgePage = try QueryBoundCursor.bridgePage(from: page, queryKey: queryKey)
+        let identity = try QueryBoundCursor.taskIdentity(for: filter)
+        let bridgePage = try QueryBoundCursor.bridgePage(from: page, identity: identity)
         let result = try await Task.detached {
             try self.client.listTasks(filter: filter, page: bridgePage, fields: fields)
         }.value
-        return try QueryBoundCursor.publicPage(from: result, queryKey: queryKey)
+        return try QueryBoundCursor.publicPage(from: result, identity: identity)
     }
 
     public func getTask(id: String, fields: [String]?) async throws -> TaskItem {
@@ -52,11 +52,11 @@ public final class OmniFocusBridgeService: OmniFocusService {
             completedBefore: completedBefore,
             completedAfter: completedAfter
         )
-        let queryKey = try QueryBoundCursor.queryKey(
+        let identity = try QueryBoundCursor.queryIdentity(
             tool: "list_projects",
             input: projectFilter
         )
-        let bridgePage = try QueryBoundCursor.bridgePage(from: page, queryKey: queryKey)
+        let bridgePage = try QueryBoundCursor.bridgePage(from: page, identity: identity)
         let shouldBypassCache = reviewPerspective || reviewDueBefore != nil || reviewDueAfter != nil || completed != nil || completedBefore != nil || completedAfter != nil
         if !shouldBypassCache {
             let key = CacheKey.projects(
@@ -67,7 +67,7 @@ public final class OmniFocusBridgeService: OmniFocusService {
                 search: normalizedSearch
             )
             if let cached = await cache.getProjects(key: key) {
-                return try QueryBoundCursor.publicPage(from: cached, queryKey: queryKey)
+                return try QueryBoundCursor.publicPage(from: cached, identity: identity)
             }
             let pageResult = try await Task.detached {
                 try self.client.listProjects(
@@ -85,7 +85,7 @@ public final class OmniFocusBridgeService: OmniFocusService {
                 )
             }.value
             await cache.setProjects(pageResult, key: key, ttl: cacheTTL)
-            return try QueryBoundCursor.publicPage(from: pageResult, queryKey: queryKey)
+            return try QueryBoundCursor.publicPage(from: pageResult, identity: identity)
         }
 
         let pageResult = try await Task.detached {
@@ -103,7 +103,7 @@ public final class OmniFocusBridgeService: OmniFocusService {
                 fields: fields
             )
         }.value
-        return try QueryBoundCursor.publicPage(from: pageResult, queryKey: queryKey)
+        return try QueryBoundCursor.publicPage(from: pageResult, identity: identity)
     }
 
     static func normalizeProjectSearch(_ search: String?) throws -> String? {
@@ -122,15 +122,15 @@ public final class OmniFocusBridgeService: OmniFocusService {
             statusFilter: statusFilter,
             includeTaskCounts: includeTaskCounts
         )
-        let queryKey = try QueryBoundCursor.queryKey(tool: "list_tags", input: filter)
-        let bridgePage = try QueryBoundCursor.bridgePage(from: page, queryKey: queryKey)
+        let identity = try QueryBoundCursor.queryIdentity(tool: "list_tags", input: filter)
+        let bridgePage = try QueryBoundCursor.bridgePage(from: page, identity: identity)
         let key = CacheKey.tags(
             page: bridgePage,
             statusFilter: statusFilter,
             includeTaskCounts: includeTaskCounts
         )
         if let cached = await cache.getTags(key: key) {
-            return try QueryBoundCursor.publicPage(from: cached, queryKey: queryKey)
+            return try QueryBoundCursor.publicPage(from: cached, identity: identity)
         }
         let pageResult = try await Task.detached {
             try self.client.listTags(
@@ -140,19 +140,19 @@ public final class OmniFocusBridgeService: OmniFocusService {
             )
         }.value
         await cache.setTags(pageResult, key: key, ttl: cacheTTL)
-        return try QueryBoundCursor.publicPage(from: pageResult, queryKey: queryKey)
+        return try QueryBoundCursor.publicPage(from: pageResult, identity: identity)
     }
 
     public func listFolders(page: PageRequest, fields: [String]?) async throws -> Page<FolderItem> {
-        let queryKey = try QueryBoundCursor.queryKey(
+        let identity = try QueryBoundCursor.queryIdentity(
             tool: "list_folders",
             input: "stable-folder-order-v1"
         )
-        let bridgePage = try QueryBoundCursor.bridgePage(from: page, queryKey: queryKey)
+        let bridgePage = try QueryBoundCursor.bridgePage(from: page, identity: identity)
         let result = try await Task.detached {
             try self.client.listFolders(page: bridgePage, fields: fields)
         }.value
-        return try QueryBoundCursor.publicPage(from: result, queryKey: queryKey)
+        return try QueryBoundCursor.publicPage(from: result, identity: identity)
     }
 
     public func getTaskCounts(filter: TaskFilter) async throws -> TaskCounts {

--- a/Sources/OmniFocusAutomation/QueryBoundCursor.swift
+++ b/Sources/OmniFocusAutomation/QueryBoundCursor.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import OmniFocusCore
 
@@ -5,20 +6,68 @@ enum QueryBoundCursor {
     private struct Envelope: Codable {
         let version: Int
         let offset: String
-        let queryKey: String
+        let tool: String?
+        let queryFingerprint: String?
+        let dimensionFingerprints: [String: String]?
     }
 
-    private static let version = 1
+    struct QueryIdentity: Equatable, Sendable {
+        let tool: String
+        let fingerprint: String
+        let dimensionFingerprints: [String: String]
+    }
 
-    static func queryKey<Input: Encodable>(tool: String, input: Input) throws -> String {
+    private static let version = 2
+
+    static func taskIdentity(for filter: TaskFilter) throws -> QueryIdentity {
+        try queryIdentity(
+            tool: "list_tasks",
+            input: TaskFilter(
+                completed: filter.completed,
+                flagged: filter.flagged,
+                availableOnly: filter.availableOnly,
+                inboxView: filter.inboxView ?? "available",
+                project: filter.project,
+                tags: filter.tags,
+                dueBefore: filter.dueBefore,
+                dueAfter: filter.dueAfter,
+                deferBefore: filter.deferBefore,
+                deferAfter: filter.deferAfter,
+                plannedBefore: filter.plannedBefore,
+                plannedAfter: filter.plannedAfter,
+                completedBefore: filter.completedBefore,
+                completedAfter: filter.completedAfter,
+                search: filter.search,
+                inboxOnly: filter.inboxOnly ?? false,
+                projectView: filter.projectView,
+                maxEstimatedMinutes: filter.maxEstimatedMinutes,
+                minEstimatedMinutes: filter.minEstimatedMinutes,
+                includeTotalCount: filter.includeTotalCount ?? false
+            )
+        )
+    }
+
+    static func queryIdentity<Input: Encodable>(
+        tool: String,
+        input: Input
+    ) throws -> QueryIdentity {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
         let inputData = try encoder.encode(input)
-        return tool + ":" + inputData.base64EncodedString()
+        let fingerprint = sha256(Data(tool.utf8) + Data([0]) + inputData)
+        let dimensions = try dimensionFingerprints(from: inputData)
+        return QueryIdentity(
+            tool: tool,
+            fingerprint: fingerprint,
+            dimensionFingerprints: dimensions
+        )
     }
 
-    static func bridgePage(from page: PageRequest, queryKey: String) throws -> PageRequest {
+    static func bridgePage(
+        from page: PageRequest,
+        identity: QueryIdentity
+    ) throws -> PageRequest {
         guard let cursor = page.cursor else { return page }
         let envelope: Envelope
         do {
@@ -29,18 +78,45 @@ enum QueryBoundCursor {
         guard envelope.version == version else {
             throw cursorError("from an unsupported version")
         }
-        guard envelope.queryKey == queryKey else {
-            throw cursorError("for a different query")
+        guard let cursorTool = envelope.tool,
+              let cursorFingerprint = envelope.queryFingerprint,
+              let cursorDimensions = envelope.dimensionFingerprints else {
+            throw cursorError("malformed or unsupported")
+        }
+        guard cursorTool == identity.tool,
+              cursorFingerprint == identity.fingerprint else {
+            let changedDimensions = changedDimensions(
+                cursorTool: cursorTool,
+                cursorDimensions: cursorDimensions,
+                current: identity
+            )
+            throw cursorError(
+                """
+                for a different query \
+                (cursorVersion=\(version), tool=\(identity.tool), \
+                cursorFingerprint=\(shortFingerprint(cursorFingerprint)), \
+                currentFingerprint=\(shortFingerprint(identity.fingerprint)), \
+                changedDimensions=\(changedDimensions.joined(separator: ",")))
+                """
+            )
         }
         return PageRequest(limit: page.limit, cursor: envelope.offset)
     }
 
     static func publicPage<Item>(
         from page: Page<Item>,
-        queryKey: String
+        identity: QueryIdentity
     ) throws -> Page<Item> where Item: Codable & Sendable {
         let nextCursor = try page.nextCursor.map { offset in
-            try encode(Envelope(version: version, offset: offset, queryKey: queryKey))
+            try encode(
+                Envelope(
+                    version: version,
+                    offset: offset,
+                    tool: identity.tool,
+                    queryFingerprint: identity.fingerprint,
+                    dimensionFingerprints: identity.dimensionFingerprints
+                )
+            )
         }
         return Page(
             items: page.items,
@@ -63,6 +139,46 @@ enum QueryBoundCursor {
             throw cursorError("malformed")
         }
         return try JSONDecoder().decode(Envelope.self, from: data)
+    }
+
+    private static func dimensionFingerprints(from inputData: Data) throws -> [String: String] {
+        let object = try JSONSerialization.jsonObject(
+            with: inputData,
+            options: [.fragmentsAllowed]
+        )
+        guard let dictionary = object as? [String: Any] else {
+            return ["input": sha256(inputData)]
+        }
+
+        return try dictionary.reduce(into: [:]) { result, element in
+            let data = try JSONSerialization.data(
+                withJSONObject: element.value,
+                options: [.sortedKeys, .fragmentsAllowed, .withoutEscapingSlashes]
+            )
+            result[element.key] = sha256(data)
+        }
+    }
+
+    private static func changedDimensions(
+        cursorTool: String,
+        cursorDimensions: [String: String],
+        current: QueryIdentity
+    ) -> [String] {
+        guard cursorTool == current.tool else { return ["tool"] }
+        return Set(cursorDimensions.keys)
+            .union(current.dimensionFingerprints.keys)
+            .filter {
+                cursorDimensions[$0] != current.dimensionFingerprints[$0]
+            }
+            .sorted()
+    }
+
+    private static func sha256(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func shortFingerprint(_ value: String) -> String {
+        String(value.prefix(12))
     }
 
     private static func cursorError(_ reason: String) -> AutomationError {

--- a/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
+++ b/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
@@ -319,7 +319,7 @@ func mcpWireRejectsUnknownTopLevelAndNestedArgumentsBeforeDispatch() throws {
         }
     }
 
-    let reviewQueryKey = try QueryBoundCursor.queryKey(
+    let reviewIdentity = try QueryBoundCursor.queryIdentity(
         tool: "list_projects",
         input: ProjectFilter(statusFilter: "active", reviewPerspective: true)
     )
@@ -330,7 +330,7 @@ func mcpWireRejectsUnknownTopLevelAndNestedArgumentsBeforeDispatch() throws {
                 nextCursor: "100",
                 returnedCount: 100
             ),
-            queryKey: reviewQueryKey
+            identity: reviewIdentity
         ).nextCursor
     )
 
@@ -806,6 +806,98 @@ func cursorOnlyPagesApplyDefaultsAtMCPWireBoundary() throws {
         #expect(page.limit == testCase.expectedLimit)
         #expect(page.cursor == testCase.cursor)
     }
+}
+
+@Test
+func compoundTaskPaginationSurvivesSeparateMCPArgumentDecoding() throws {
+    let firstData = Data(
+        #"""
+        {
+          "jsonrpc": "2.0",
+          "id": 1,
+          "method": "tools/call",
+          "params": {
+            "name": "list_tasks",
+            "arguments": {
+              "filter": {
+                "project": "project-fixture",
+                "completed": false,
+                "availableOnly": false,
+                "includeTotalCount": true
+              },
+              "fields": ["id", "name", "note"],
+              "page": {"limit": 50}
+            }
+          }
+        }
+        """#.utf8
+    )
+    let firstRequest = try JSONDecoder().decode(Request<CallTool>.self, from: firstData)
+    let decodedFirstFilter = try FocusRelayServer.decodeArgument(
+        TaskFilter.self,
+        from: firstRequest.params.arguments,
+        key: "filter"
+    )
+    let firstFilter = try #require(decodedFirstFilter)
+    let firstIdentity = try QueryBoundCursor.taskIdentity(for: firstFilter)
+    let cursor = try #require(
+        QueryBoundCursor.publicPage(
+            from: Page<TaskItem>(
+                items: [],
+                nextCursor: "50",
+                returnedCount: 50,
+                totalCount: 69
+            ),
+            identity: firstIdentity
+        ).nextCursor
+    )
+
+    let continuationData = Data(
+        #"""
+        {
+          "jsonrpc": "2.0",
+          "id": 2,
+          "method": "tools/call",
+          "params": {
+            "name": "list_tasks",
+            "arguments": {
+              "page": {"cursor": "\#(cursor)", "limit": 20},
+              "fields": ["note", "name", "id"],
+              "filter": {
+                "includeTotalCount": true,
+                "availableOnly": false,
+                "completed": false,
+                "project": "project-fixture"
+              }
+            }
+          }
+        }
+        """#.utf8
+    )
+    let continuationRequest = try JSONDecoder().decode(
+        Request<CallTool>.self,
+        from: continuationData
+    )
+    let decodedContinuationFilter = try FocusRelayServer.decodeArgument(
+        TaskFilter.self,
+        from: continuationRequest.params.arguments,
+        key: "filter"
+    )
+    let continuationFilter = try #require(decodedContinuationFilter)
+    let continuationIdentity = try QueryBoundCursor.taskIdentity(
+        for: continuationFilter
+    )
+    let continuationPage = try FocusRelayServer.decodePageRequest(
+        from: continuationRequest.params
+    )
+    let bridgePage = try QueryBoundCursor.bridgePage(
+        from: continuationPage,
+        identity: continuationIdentity
+    )
+
+    #expect(firstIdentity == continuationIdentity)
+    #expect(bridgePage.limit == 20)
+    #expect(bridgePage.cursor == "50")
 }
 
 @Test

--- a/Tests/OmniFocusIntegrationTests/QueryBoundCursorTests.swift
+++ b/Tests/OmniFocusIntegrationTests/QueryBoundCursorTests.swift
@@ -5,9 +5,8 @@ import Testing
 
 @Test
 func queryBoundCursorContinuesIdenticalQueryAndPreservesLimit() throws {
-    let key = try QueryBoundCursor.queryKey(
-        tool: "list_tasks",
-        input: TaskFilter(search: "drop test")
+    let identity = try QueryBoundCursor.taskIdentity(
+        for: TaskFilter(search: "drop test")
     )
     let publicPage = try QueryBoundCursor.publicPage(
         from: Page<TaskItem>(
@@ -16,14 +15,14 @@ func queryBoundCursorContinuesIdenticalQueryAndPreservesLimit() throws {
             returnedCount: 50,
             totalCount: 120
         ),
-        queryKey: key
+        identity: identity
     )
     let cursor = try #require(publicPage.nextCursor)
     #expect(cursor != "50")
 
     let bridgePage = try QueryBoundCursor.bridgePage(
         from: PageRequest(limit: 75, cursor: cursor),
-        queryKey: key
+        identity: identity
     )
     #expect(bridgePage.limit == 75)
     #expect(bridgePage.cursor == "50")
@@ -31,11 +30,11 @@ func queryBoundCursorContinuesIdenticalQueryAndPreservesLimit() throws {
 
 @Test
 func queryBoundCursorRejectsChangedQueryBeforeBridgePaging() throws {
-    let reviewKey = try QueryBoundCursor.queryKey(
+    let reviewIdentity = try QueryBoundCursor.queryIdentity(
         tool: "list_projects",
         input: ProjectFilter(statusFilter: "active", reviewPerspective: true)
     )
-    let ordinaryKey = try QueryBoundCursor.queryKey(
+    let ordinaryIdentity = try QueryBoundCursor.queryIdentity(
         tool: "list_projects",
         input: ProjectFilter(statusFilter: "active", reviewPerspective: false)
     )
@@ -46,47 +45,141 @@ func queryBoundCursorRejectsChangedQueryBeforeBridgePaging() throws {
                 nextCursor: "100",
                 returnedCount: 100
             ),
-            queryKey: reviewKey
+            identity: reviewIdentity
         ).nextCursor
     )
 
-    #expect(throws: AutomationError.self) {
-        try QueryBoundCursor.bridgePage(
+    do {
+        _ = try QueryBoundCursor.bridgePage(
             from: PageRequest(limit: 100, cursor: cursor),
-            queryKey: ordinaryKey
+            identity: ordinaryIdentity
         )
+        Issue.record("Expected a changed query to reject its cursor")
+    } catch {
+        let message = error.localizedDescription
+        #expect(message.contains("cursorVersion=2"))
+        #expect(message.contains("tool=list_projects"))
+        #expect(message.contains("cursorFingerprint="))
+        #expect(message.contains("currentFingerprint="))
+        #expect(message.contains("changedDimensions=reviewPerspective"))
+        #expect(!message.contains("active"))
     }
 }
 
-@Test(arguments: ["100", "not-a-cursor", versionTwoCursor()])
+@Test(arguments: ["100", "not-a-cursor", versionOneCursor()])
 func queryBoundCursorRejectsMalformedAndUnsupportedTokens(cursor: String) throws {
-    let key = try QueryBoundCursor.queryKey(
+    let identity = try QueryBoundCursor.queryIdentity(
         tool: "list_folders",
         input: "stable-folder-order-v1"
     )
     #expect(throws: AutomationError.self) {
         try QueryBoundCursor.bridgePage(
             from: PageRequest(limit: 150, cursor: cursor),
-            queryKey: key
+            identity: identity
         )
     }
 }
 
 @Test
-func everyPublicListToolUsesASeparateQueryNamespace() throws {
-    let keys = try [
-        QueryBoundCursor.queryKey(tool: "list_tasks", input: TaskFilter()),
-        QueryBoundCursor.queryKey(tool: "list_projects", input: ProjectFilter()),
-        QueryBoundCursor.queryKey(tool: "list_tags", input: TagFilter()),
-        QueryBoundCursor.queryKey(tool: "list_folders", input: "stable-folder-order-v1")
-    ]
-    #expect(Set(keys).count == 4)
+func queryBoundCursorDoesNotExposeRawFilterValues() throws {
+    let privateProjectID = "private-project-identifier"
+    let privateSearch = "private search phrase"
+    let identity = try QueryBoundCursor.taskIdentity(
+        for: TaskFilter(
+            completed: false,
+            availableOnly: false,
+            project: privateProjectID,
+            search: privateSearch,
+            includeTotalCount: true
+        )
+    )
+    let cursor = try #require(
+        QueryBoundCursor.publicPage(
+            from: Page<TaskItem>(
+                items: [],
+                nextCursor: "50",
+                returnedCount: 50,
+                totalCount: 100
+            ),
+            identity: identity
+        ).nextCursor
+    )
+    let decodedCursor = try #require(Data(base64URLTestString: cursor))
+    let cursorText = String(decoding: decodedCursor, as: UTF8.self)
+
+    #expect(!cursorText.contains(privateProjectID))
+    #expect(!cursorText.contains(privateSearch))
+    #expect(!cursorText.contains("queryKey"))
+    #expect(cursorText.contains("queryFingerprint"))
+    #expect(cursorText.contains("dimensionFingerprints"))
 }
 
-private func versionTwoCursor() -> String {
+@Test
+func compoundTaskFilterIdentityIsStableAndNamesChangedDimensions() throws {
+    let first = TaskFilter(
+        completed: false,
+        availableOnly: false,
+        project: "project-fixture",
+        includeTotalCount: true
+    )
+    let identical = TaskFilter(
+        completed: false,
+        availableOnly: false,
+        project: "project-fixture",
+        includeTotalCount: true
+    )
+    let changedCountSemantics = TaskFilter(
+        completed: false,
+        availableOnly: false,
+        project: "project-fixture",
+        includeTotalCount: false
+    )
+
+    let firstIdentity = try QueryBoundCursor.taskIdentity(for: first)
+    let identicalIdentity = try QueryBoundCursor.taskIdentity(for: identical)
+    let changedIdentity = try QueryBoundCursor.taskIdentity(for: changedCountSemantics)
+
+    #expect(firstIdentity == identicalIdentity)
+    #expect(firstIdentity.fingerprint != changedIdentity.fingerprint)
+    #expect(
+        firstIdentity.dimensionFingerprints["includeTotalCount"]
+            != changedIdentity.dimensionFingerprints["includeTotalCount"]
+    )
+}
+
+@Test
+func taskCursorIdentityNormalizesProvenBridgeDefaults() throws {
+    let omittedDefaults = try QueryBoundCursor.taskIdentity(for: TaskFilter())
+    let explicitDefaults = try QueryBoundCursor.taskIdentity(
+        for: TaskFilter(
+            inboxView: "available",
+            inboxOnly: false,
+            includeTotalCount: false
+        )
+    )
+    let meaningfulChange = try QueryBoundCursor.taskIdentity(
+        for: TaskFilter(availableOnly: false)
+    )
+
+    #expect(omittedDefaults == explicitDefaults)
+    #expect(omittedDefaults != meaningfulChange)
+}
+
+@Test
+func everyPublicListToolUsesASeparateQueryNamespace() throws {
+    let keys = try [
+        QueryBoundCursor.taskIdentity(for: TaskFilter()),
+        QueryBoundCursor.queryIdentity(tool: "list_projects", input: ProjectFilter()),
+        QueryBoundCursor.queryIdentity(tool: "list_tags", input: TagFilter()),
+        QueryBoundCursor.queryIdentity(tool: "list_folders", input: "stable-folder-order-v1")
+    ]
+    #expect(Set(keys.map(\.fingerprint)).count == 4)
+}
+
+private func versionOneCursor() -> String {
     let data = try! JSONSerialization.data(
         withJSONObject: [
-            "version": 2,
+            "version": 1,
             "offset": "50",
             "queryKey": "list_tasks:any"
         ],
@@ -96,4 +189,17 @@ private func versionTwoCursor() -> String {
         .replacingOccurrences(of: "+", with: "-")
         .replacingOccurrences(of: "/", with: "_")
         .replacingOccurrences(of: "=", with: "")
+}
+
+private extension Data {
+    init?(base64URLTestString: String) {
+        var base64 = base64URLTestString
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = base64.count % 4
+        if remainder != 0 {
+            base64.append(String(repeating: "=", count: 4 - remainder))
+        }
+        self.init(base64Encoded: base64)
+    }
 }


### PR DESCRIPTION
Closes #163

## What changed

- Replaced recoverable query data in public pagination cursors with privacy-safe SHA-256 fingerprints.
- Normalized proven `list_tasks` defaults so omitted and explicitly equivalent arguments can continue the same pagination sequence.
- Added actionable, privacy-safe mismatch diagnostics naming the changed query dimensions.
- Added direct MCP regression coverage for a compound task query continued through a separately decoded request with reordered fields and a different page size.

## Root cause and impact

The reported identical-looking compound continuation is deterministic in the new boundary regression and does not reproduce as a general MCP decoding failure. Investigation did uncover a real false-mismatch edge: omitted defaults and their explicit equivalents previously produced different cursor identities. A running OpenCode MCP process can also retain an older executable until fully restarted.

Users can now continue compatible paginated queries more reliably. Genuine query changes still fail closed before Bridge dispatch, while cursor diagnostics no longer expose raw filter values. Version 1 cursors are intentionally rejected after upgrading; pagination should be restarted once.

## Validation

- `swift run focusrelay-dev validate --impact transport-reliability`: passed (183 tests plus Bridge semantic gates)
- Direct MCP compound-pagination regression: passed
- Read-only live pagination across two separate executable invocations: passed
- 10-minute targeted `list_tasks` smoke: 159 successful calls, 0 errors, 0 timeouts, all 10 scenarios covered
- `swift build -c release --product focusrelay`: passed
- `git diff --check`: passed

No private OmniFocus content or raw cursor values are included in this PR or its validation evidence.