### PR TITLE
Add parent-aware tag search

### DIFF
--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -1626,6 +1626,42 @@
     }
     // END PROJECT COMPLETION QUERY MODULE
 
+    // TAG QUERY MODULE - list_tags search and hierarchy
+    function normalizedTagNameSearch(search) {
+      if (typeof search !== "string") return null;
+      const normalized = search.trim();
+      return normalized.length > 0 ? normalized.toLocaleLowerCase() : null;
+    }
+
+    function tagMatchesNameSearch(tag, searchQuery) {
+      if (!searchQuery) return true;
+      const name = String(safe(() => tag.name) || "");
+      return name.toLocaleLowerCase().includes(searchQuery);
+    }
+
+    function tagHierarchyPayload(tag) {
+      const parent = safe(() => tag.parent);
+      const reversedPath = [];
+      const visited = {};
+      let current = tag;
+      while (current) {
+        const id = String(safe(() => current.id.primaryKey) || "");
+        if (visited[id]) break;
+        visited[id] = true;
+        reversedPath.push({
+          id: id,
+          name: String(safe(() => current.name) || "")
+        });
+        current = safe(() => current.parent);
+      }
+      return {
+        parentID: parent ? String(safe(() => parent.id.primaryKey) || "") : null,
+        parentName: parent ? String(safe(() => parent.name) || "") : null,
+        path: reversedPath.reverse()
+      };
+    }
+    // END TAG QUERY MODULE
+
     // Normalize OmniFocus collections to plain arrays.
     function toTaskArray(collection) {
       if (!collection) { return []; }
@@ -2616,6 +2652,9 @@
           const filter = request.tagFilter || request.filter || {};
           const statusFilter = (typeof filter.statusFilter === "string") ? filter.statusFilter.toLowerCase() : "active";
           const includeTaskCounts = filter.includeTaskCounts === true;
+          const searchQuery = normalizedTagNameSearch(filter.search);
+          const fields = request.fields || [];
+          const hasField = field => fields.indexOf(field) >= 0;
           
           let tags = flattenedTags;
           
@@ -2634,6 +2673,10 @@
               }
               return true;
             });
+          }
+
+          if (searchQuery) {
+            tags = tags.filter(tag => tagMatchesNameSearch(tag, searchQuery));
           }
           
           const limit = request.page && request.page.limit ? Math.max(1, request.page.limit) : 150;
@@ -2665,6 +2708,24 @@
               name: String(safe(() => tag.name) || ""),
               status: getTagStatusString(tag)
             };
+
+            const hierarchy = (hasField("parentID") || hasField("parentName") || hasField("path"))
+              ? tagHierarchyPayload(tag)
+              : null;
+            if (hasField("parentID")) {
+              item.parentID = hierarchy.parentID;
+            }
+            if (hasField("parentName")) {
+              item.parentName = hierarchy.parentName;
+            }
+            if (hasField("path")) {
+              item.path = hierarchy.path;
+            }
+            if (hasField("childrenAreMutuallyExclusive")) {
+              item.childrenAreMutuallyExclusive = Boolean(
+                safe(() => tag.childrenAreMutuallyExclusive)
+              );
+            }
 
             // Get task counts using OmniFocus built-in properties only when requested.
             // Note: Per documentation, cleanUp() should be called for accurate counts

--- a/Sources/FocusRelayCLI/FocusRelayCLI.swift
+++ b/Sources/FocusRelayCLI/FocusRelayCLI.swift
@@ -195,12 +195,34 @@ struct ListTags: AsyncParsableCommand {
     @Flag(name: .customLong("include-task-counts"), help: "Include task counts for each tag.")
     var includeTaskCounts: Bool = false
 
+    @Option(help: "Case-insensitive substring to match against tag names.")
+    var search: String?
+
+    @Option(help: "Comma-separated field names to return.")
+    var fields: String?
+
     func run() async throws {
         let service = OmniFocusBridgeService()
         let pageRequest = page.makePageRequest(defaultLimit: 150)
+        let requestedFields = fields?
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty } ?? []
+        try OutputFieldCatalog.validate(requestedFields, for: "list_tags")
+        let resolvedFields = FocusRelayServer.resolvedTagFields(
+            requestedFields: requestedFields,
+            statusFilter: statusFilter,
+            includeTaskCounts: includeTaskCounts
+        )
 
-        let result = try await service.listTags(page: pageRequest, statusFilter: statusFilter, includeTaskCounts: includeTaskCounts)
-        let fieldSet: Set<String> = ["id", "name", "status", "availableTasks", "remainingTasks", "totalTasks"]
+        let result = try await service.listTags(
+            page: pageRequest,
+            statusFilter: statusFilter,
+            includeTaskCounts: includeTaskCounts,
+            search: search,
+            fields: resolvedFields
+        )
+        let fieldSet = Set(resolvedFields)
         let items = result.items.map { makeTagOutput(from: $0, fields: fieldSet, includeTaskCounts: includeTaskCounts) }
         let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount)
         print(try encodeJSON(output))

--- a/Sources/FocusRelayOutput/OutputModels.swift
+++ b/Sources/FocusRelayOutput/OutputModels.swift
@@ -18,12 +18,19 @@ public enum OutputFieldCatalog {
         "id", "name", "parentID", "parentName", "projectCount", "childFolderCount"
     ]
 
+    public static let tag = [
+        "id", "name", "status", "availableTasks", "remainingTasks", "totalTasks",
+        "parentID", "parentName", "path", "childrenAreMutuallyExclusive"
+    ]
+
     public static func fields(for toolName: String) -> [String]? {
         switch toolName {
         case "list_tasks", "get_task":
             task
         case "list_projects":
             project
+        case "list_tags":
+            tag
         case "list_folders":
             folder
         default:
@@ -196,20 +203,28 @@ public struct ProjectOutput: Encodable {
 }
 
 public struct TagOutput: Encodable {
-    public let id: String
-    public let name: String
+    public let id: String?
+    public let name: String?
     public let status: String?
     public let availableTasks: Int?
     public let remainingTasks: Int?
     public let totalTasks: Int?
+    public let parentID: String?
+    public let parentName: String?
+    public let path: [TagPathElement]?
+    public let childrenAreMutuallyExclusive: Bool?
 
     public init(
-        id: String,
-        name: String,
+        id: String?,
+        name: String?,
         status: String?,
         availableTasks: Int?,
         remainingTasks: Int?,
-        totalTasks: Int?
+        totalTasks: Int?,
+        parentID: String?,
+        parentName: String?,
+        path: [TagPathElement]?,
+        childrenAreMutuallyExclusive: Bool?
     ) {
         self.id = id
         self.name = name
@@ -217,6 +232,10 @@ public struct TagOutput: Encodable {
         self.availableTasks = availableTasks
         self.remainingTasks = remainingTasks
         self.totalTasks = totalTasks
+        self.parentID = parentID
+        self.parentName = parentName
+        self.path = path
+        self.childrenAreMutuallyExclusive = childrenAreMutuallyExclusive
     }
 }
 
@@ -291,12 +310,18 @@ public func makeProjectOutput(from project: ProjectItem, fields: Set<String>, in
 
 public func makeTagOutput(from tag: TagItem, fields: Set<String>, includeTaskCounts: Bool) -> TagOutput {
     TagOutput(
-        id: tag.id,
-        name: tag.name,
+        id: fields.contains("id") ? tag.id : nil,
+        name: fields.contains("name") ? tag.name : nil,
         status: fields.contains("status") ? tag.status : nil,
         availableTasks: includeTaskCounts ? tag.availableTasks : nil,
         remainingTasks: includeTaskCounts ? tag.remainingTasks : nil,
-        totalTasks: includeTaskCounts ? tag.totalTasks : nil
+        totalTasks: includeTaskCounts ? tag.totalTasks : nil,
+        parentID: fields.contains("parentID") ? tag.parentID : nil,
+        parentName: fields.contains("parentName") ? tag.parentName : nil,
+        path: fields.contains("path") ? tag.path : nil,
+        childrenAreMutuallyExclusive: fields.contains("childrenAreMutuallyExclusive")
+            ? tag.childrenAreMutuallyExclusive
+            : nil
     )
 }
 

--- a/Sources/FocusRelayServer/FocusRelayServer.swift
+++ b/Sources/FocusRelayServer/FocusRelayServer.swift
@@ -391,7 +391,7 @@ public enum FocusRelayServer {
                 ),
                 Tool(
                     name: "list_tags",
-                    description: "List OmniFocus tags with pagination and filtering. Tags have a status (active, onHold, dropped) and can optionally include task counts. Use statusFilter to show only tags with a specific status, and includeTaskCounts to get the number of tasks associated with each tag.",
+                    description: "Find OmniFocus tags by partial name with pagination and status filtering. Request parentID, parentName, or path to distinguish duplicate names without loading the full tag catalog. Search is a trimmed, literal, case-insensitive substring and is applied before pagination.",
                     inputSchema: toolSchema(
                         properties: [
                             "page": .object([
@@ -411,6 +411,15 @@ public enum FocusRelayServer {
                                 "type": .string("boolean"),
                                 "description": .string("Include task counts for each tag (available, remaining, total)"),
                                 "default": .bool(false)
+                            ]),
+                            "search": .object([
+                                "type": .string("string"),
+                                "description": .string("Trimmed, literal, case-insensitive substring match against tag names")
+                            ]),
+                            "fields": .object([
+                                "type": .string("array"),
+                                "description": .string("Fields to return. Defaults to the existing id, name, and status shape. Request path to disambiguate duplicate tag names."),
+                                "items": outputFieldItemsSchema(for: "list_tags")
                             ])
                         ]
                     ),
@@ -777,8 +786,22 @@ public enum FocusRelayServer {
                     let page = try decodePageRequest(from: params)
                     let statusFilter = try decodeArgument(String.self, from: params.arguments, key: "statusFilter") ?? "active"
                     let includeTaskCounts = try decodeArgument(Bool.self, from: params.arguments, key: "includeTaskCounts") ?? false
-                    let result = try await service.listTags(page: page, statusFilter: statusFilter, includeTaskCounts: includeTaskCounts)
-                    let fieldSet = Set(["id", "name", "status", "availableTasks", "remainingTasks", "totalTasks"])
+                    let search = try decodeArgument(String.self, from: params.arguments, key: "search")
+                    let requestedFields = decodeStringArray(params.arguments?["fields"]) ?? []
+                    try OutputFieldCatalog.validate(requestedFields, for: "list_tags")
+                    let fields = Self.resolvedTagFields(
+                        requestedFields: requestedFields,
+                        statusFilter: statusFilter,
+                        includeTaskCounts: includeTaskCounts
+                    )
+                    let result = try await service.listTags(
+                        page: page,
+                        statusFilter: statusFilter,
+                        includeTaskCounts: includeTaskCounts,
+                        search: search,
+                        fields: fields
+                    )
+                    let fieldSet = Set(fields)
                     let items = result.items.map { makeTagOutput(from: $0, fields: fieldSet, includeTaskCounts: includeTaskCounts) }
                     let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount, warnings: result.warnings)
                     return .init(content: [.text(text: try encodeJSON(output), annotations: nil, _meta: nil)])
@@ -960,6 +983,15 @@ public enum FocusRelayServer {
             throw MutationValidationError("Tool \(params.name) does not accept page arguments.")
         }
         return try decodePageRequest(from: params.arguments, defaultLimit: defaultLimit)
+    }
+
+    public static func resolvedTagFields(
+        requestedFields: [String],
+        statusFilter: String,
+        includeTaskCounts: Bool
+    ) -> [String] {
+        guard requestedFields.isEmpty else { return requestedFields }
+        return ["id", "name", "status"]
     }
 }
 

--- a/Sources/OmniFocusAutomation/BridgeClient.swift
+++ b/Sources/OmniFocusAutomation/BridgeClient.swift
@@ -166,9 +166,19 @@ final class BridgeClient: @unchecked Sendable {
         throw AutomationError.executionFailed(message)
     }
 
-    func listTags(page: PageRequest, statusFilter: String?, includeTaskCounts: Bool) throws -> Page<TagItem> {
+    func listTags(
+        page: PageRequest,
+        statusFilter: String?,
+        includeTaskCounts: Bool,
+        search: String? = nil,
+        fields: [String]? = nil
+    ) throws -> Page<TagItem> {
         let requestId = UUID().uuidString
-        let tagFilter = TagFilter(statusFilter: statusFilter, includeTaskCounts: includeTaskCounts)
+        let tagFilter = TagFilter(
+            statusFilter: statusFilter,
+            includeTaskCounts: includeTaskCounts,
+            search: search
+        )
         let request = BridgeRequest(
             schemaVersion: 1,
             requestId: requestId,
@@ -180,7 +190,7 @@ final class BridgeClient: @unchecked Sendable {
             tagFilter: tagFilter,
             projectFilter: nil,
             mutation: nil,
-            fields: nil,
+            fields: fields,
             page: page
         )
 
@@ -193,7 +203,11 @@ final class BridgeClient: @unchecked Sendable {
                     status: payload.status,
                     availableTasks: payload.availableTasks,
                     remainingTasks: payload.remainingTasks,
-                    totalTasks: payload.totalTasks
+                    totalTasks: payload.totalTasks,
+                    parentID: payload.parentID,
+                    parentName: payload.parentName,
+                    path: payload.path,
+                    childrenAreMutuallyExclusive: payload.childrenAreMutuallyExclusive
                 )
             }
             return Page(items: items, nextCursor: payloadPage.nextCursor, returnedCount: payloadPage.returnedCount, totalCount: payloadPage.totalCount, warnings: response.warnings)

--- a/Sources/OmniFocusAutomation/CatalogCache.swift
+++ b/Sources/OmniFocusAutomation/CatalogCache.swift
@@ -44,16 +44,18 @@ struct CacheKey: Hashable {
 
     static func tags(
         page: PageRequest,
+        fields: [String]? = nil,
         statusFilter: String?,
-        includeTaskCounts: Bool
+        includeTaskCounts: Bool,
+        search: String? = nil
     ) -> CacheKey {
         CacheKey(
             limit: page.limit,
             cursor: page.cursor,
-            fieldsKey: "",
+            fieldsKey: (fields ?? []).joined(separator: ","),
             statusFilter: statusFilter,
             includeTaskCounts: includeTaskCounts,
-            search: nil
+            search: search
         )
     }
 }

--- a/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
+++ b/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
@@ -117,17 +117,27 @@ public final class OmniFocusBridgeService: OmniFocusService {
         return normalized
     }
 
-    public func listTags(page: PageRequest, statusFilter: String?, includeTaskCounts: Bool) async throws -> Page<TagItem> {
+    public func listTags(
+        page: PageRequest,
+        statusFilter: String?,
+        includeTaskCounts: Bool,
+        search: String?,
+        fields: [String]?
+    ) async throws -> Page<TagItem> {
+        let normalizedSearch = try Self.normalizeTagSearch(search)
         let filter = TagFilter(
             statusFilter: statusFilter,
-            includeTaskCounts: includeTaskCounts
+            includeTaskCounts: includeTaskCounts,
+            search: normalizedSearch
         )
         let identity = try QueryBoundCursor.queryIdentity(tool: "list_tags", input: filter)
         let bridgePage = try QueryBoundCursor.bridgePage(from: page, identity: identity)
         let key = CacheKey.tags(
             page: bridgePage,
+            fields: fields,
             statusFilter: statusFilter,
-            includeTaskCounts: includeTaskCounts
+            includeTaskCounts: includeTaskCounts,
+            search: normalizedSearch
         )
         if let cached = await cache.getTags(key: key) {
             return try QueryBoundCursor.publicPage(from: cached, identity: identity)
@@ -136,11 +146,24 @@ public final class OmniFocusBridgeService: OmniFocusService {
             try self.client.listTags(
                 page: bridgePage,
                 statusFilter: statusFilter,
-                includeTaskCounts: includeTaskCounts
+                includeTaskCounts: includeTaskCounts,
+                search: normalizedSearch,
+                fields: fields
             )
         }.value
         await cache.setTags(pageResult, key: key, ttl: cacheTTL)
         return try QueryBoundCursor.publicPage(from: pageResult, identity: identity)
+    }
+
+    static func normalizeTagSearch(_ search: String?) throws -> String? {
+        guard let search else { return nil }
+        let normalized = search.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else {
+            throw AutomationError.executionFailed(
+                "Tag search must contain at least one non-whitespace character."
+            )
+        }
+        return normalized
     }
 
     public func listFolders(page: PageRequest, fields: [String]?) async throws -> Page<FolderItem> {

--- a/Sources/OmniFocusAutomation/PayloadModels.swift
+++ b/Sources/OmniFocusAutomation/PayloadModels.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OmniFocusCore
 
 struct TaskItemPayload: Codable {
     let id: String?
@@ -57,6 +58,10 @@ struct TagItemPayload: Codable {
     let availableTasks: Int?
     let remainingTasks: Int?
     let totalTasks: Int?
+    let parentID: String?
+    let parentName: String?
+    let path: [TagPathElement]?
+    let childrenAreMutuallyExclusive: Bool?
 }
 
 struct FolderItemPayload: Codable {

--- a/Sources/OmniFocusCore/OmniFocusCore.swift
+++ b/Sources/OmniFocusCore/OmniFocusCore.swift
@@ -136,6 +136,16 @@ public struct ProjectItem: Codable, Sendable {
     }
 }
 
+public struct TagPathElement: Codable, Sendable, Equatable {
+    public let id: String
+    public let name: String
+
+    public init(id: String, name: String) {
+        self.id = id
+        self.name = name
+    }
+}
+
 public struct TagItem: Codable, Sendable {
     public let id: String
     public let name: String
@@ -143,6 +153,10 @@ public struct TagItem: Codable, Sendable {
     public let availableTasks: Int?
     public let remainingTasks: Int?
     public let totalTasks: Int?
+    public let parentID: String?
+    public let parentName: String?
+    public let path: [TagPathElement]?
+    public let childrenAreMutuallyExclusive: Bool?
 
     public init(
         id: String,
@@ -150,7 +164,11 @@ public struct TagItem: Codable, Sendable {
         status: String? = nil,
         availableTasks: Int? = nil,
         remainingTasks: Int? = nil,
-        totalTasks: Int? = nil
+        totalTasks: Int? = nil,
+        parentID: String? = nil,
+        parentName: String? = nil,
+        path: [TagPathElement]? = nil,
+        childrenAreMutuallyExclusive: Bool? = nil
     ) {
         self.id = id
         self.name = name
@@ -158,6 +176,10 @@ public struct TagItem: Codable, Sendable {
         self.availableTasks = availableTasks
         self.remainingTasks = remainingTasks
         self.totalTasks = totalTasks
+        self.parentID = parentID
+        self.parentName = parentName
+        self.path = path
+        self.childrenAreMutuallyExclusive = childrenAreMutuallyExclusive
     }
 }
 
@@ -229,13 +251,16 @@ public struct Page<T: Codable & Sendable>: Codable, Sendable {
 public struct TagFilter: Codable, Sendable {
     public var statusFilter: String?
     public var includeTaskCounts: Bool?
+    public var search: String?
 
     public init(
         statusFilter: String? = nil,
-        includeTaskCounts: Bool? = nil
+        includeTaskCounts: Bool? = nil,
+        search: String? = nil
     ) {
         self.statusFilter = statusFilter
         self.includeTaskCounts = includeTaskCounts
+        self.search = search
     }
 }
 
@@ -366,7 +391,13 @@ public protocol OmniFocusService: Sendable {
         completedAfter: Date?,
         fields: [String]?
     ) async throws -> Page<ProjectItem>
-    func listTags(page: PageRequest, statusFilter: String?, includeTaskCounts: Bool) async throws -> Page<TagItem>
+    func listTags(
+        page: PageRequest,
+        statusFilter: String?,
+        includeTaskCounts: Bool,
+        search: String?,
+        fields: [String]?
+    ) async throws -> Page<TagItem>
     func listFolders(page: PageRequest, fields: [String]?) async throws -> Page<FolderItem>
     func getTaskCounts(filter: TaskFilter) async throws -> TaskCounts
     func getProjectCounts(filter: TaskFilter) async throws -> ProjectCounts

--- a/Tests/FocusRelayCLITests/FocusRelayCLITests.swift
+++ b/Tests/FocusRelayCLITests/FocusRelayCLITests.swift
@@ -43,6 +43,19 @@ func listProjectsParsesProjectNameSearch() throws {
 }
 
 @Test
+func listTagsParsesSearchAndHierarchyFields() throws {
+    let command = try ListTags.parse([
+        "--search", "contact",
+        "--status", "all",
+        "--fields", "id,name,parentID,path"
+    ])
+
+    #expect(command.search == "contact")
+    #expect(command.statusFilter == "all")
+    #expect(command.fields == "id,name,parentID,path")
+}
+
+@Test
 func iso8601DateParserAcceptsValidDates() throws {
     let date = try ISO8601DateParser.parse("2026-02-04T12:00:00Z", argumentName: "--due-before")
     #expect(date.timeIntervalSince1970 > 0)

--- a/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
+++ b/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
@@ -348,13 +348,14 @@ func mcpWireRejectsUnknownTopLevelAndNestedArgumentsBeforeDispatch() throws {
         #"{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"get_task","arguments":{"id":"unused","fields":["unknownTaskField"]}}}"#,
         #"{"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"list_projects","arguments":{"fields":["status","unknownProjectField"]}}}"#,
         #"{"jsonrpc":"2.0","id":12,"method":"tools/call","params":{"name":"list_folders","arguments":{"fields":["id","unknownFolderField"]}}}"#,
-        #"{"jsonrpc":"2.0","id":13,"method":"tools/call","params":{"name":"list_tags","arguments":{"fields":["id"]}}}"#
+        #"{"jsonrpc":"2.0","id":13,"method":"tools/call","params":{"name":"list_tags","arguments":{"fields":["id","unknownTagField"]}}}"#,
+        #"{"jsonrpc":"2.0","id":14,"method":"tools/call","params":{"name":"list_tags","arguments":{"search":"   ","fields":["id","name","path"]}}}"#
     ].joined(separator: "\n") + "\n"
     try standardInput.fileHandleForWriting.write(contentsOf: Data(requests.utf8))
 
     var responses: [Int: [String: Any]] = [:]
     var buffered = Data()
-    while responses.count < 13 {
+    while responses.count < 14 {
         let chunk = standardOutput.fileHandleForReading.availableData
         guard !chunk.isEmpty else {
             Issue.record("MCP server exited before returning argument-validation responses")
@@ -383,7 +384,8 @@ func mcpWireRejectsUnknownTopLevelAndNestedArgumentsBeforeDispatch() throws {
     #expect(toolErrorText(responses[10]).contains("get_task.fields contains unsupported field(s): unknownTaskField"))
     #expect(toolErrorText(responses[11]).contains("list_projects.fields contains unsupported field(s): unknownProjectField"))
     #expect(toolErrorText(responses[12]).contains("list_folders.fields contains unsupported field(s): unknownFolderField"))
-    #expect(toolErrorText(responses[13]).contains("list_tags.fields is unsupported"))
+    #expect(toolErrorText(responses[13]).contains("list_tags.fields contains unsupported field(s): unknownTagField"))
+    #expect(toolErrorText(responses[14]).contains("Tag search must contain at least one non-whitespace character"))
 }
 
 @Test
@@ -622,6 +624,33 @@ func projectDefaultsIncludeStatusWhenCountsOrHistoricalStatusesNeedInterpretatio
         statusFilter: "all",
         includeTaskCounts: true
     ) == ["id", "name", "completionDate"])
+}
+
+@Test
+func tagDefaultsPreserveExistingShapeAndExplicitFieldsStayCompact() {
+    #expect(FocusRelayServer.resolvedTagFields(
+        requestedFields: [],
+        statusFilter: "active",
+        includeTaskCounts: false
+    ) == ["id", "name", "status"])
+
+    #expect(FocusRelayServer.resolvedTagFields(
+        requestedFields: [],
+        statusFilter: "all",
+        includeTaskCounts: false
+    ) == ["id", "name", "status"])
+
+    #expect(FocusRelayServer.resolvedTagFields(
+        requestedFields: [],
+        statusFilter: "active",
+        includeTaskCounts: true
+    ) == ["id", "name", "status"])
+
+    #expect(FocusRelayServer.resolvedTagFields(
+        requestedFields: ["id", "path"],
+        statusFilter: "all",
+        includeTaskCounts: true
+    ) == ["id", "path"])
 }
 
 @Test

--- a/Tests/OmniFocusCoreTests/OmniFocusCoreTests.swift
+++ b/Tests/OmniFocusCoreTests/OmniFocusCoreTests.swift
@@ -63,6 +63,29 @@ func pageWarningsRoundTripAndAbsenceTolerance() throws {
 }
 
 @Test
+func tagHierarchyRoundTrip() throws {
+    let tag = TagItem(
+        id: "contact",
+        name: "Contact",
+        status: "active",
+        parentID: "people",
+        parentName: "People",
+        path: [
+            TagPathElement(id: "people", name: "People"),
+            TagPathElement(id: "contact", name: "Contact")
+        ],
+        childrenAreMutuallyExclusive: true
+    )
+
+    let data = try JSONEncoder().encode(tag)
+    let decoded = try JSONDecoder().decode(TagItem.self, from: data)
+    #expect(decoded.parentID == "people")
+    #expect(decoded.parentName == "People")
+    #expect(decoded.path == tag.path)
+    #expect(decoded.childrenAreMutuallyExclusive == true)
+}
+
+@Test
 func projectItemReviewRoundTrip() throws {
     let interval = ReviewInterval(steps: 2, unit: "weeks")
     let project = ProjectItem(

--- a/Tests/OmniFocusIntegrationTests/CatalogCacheTests.swift
+++ b/Tests/OmniFocusIntegrationTests/CatalogCacheTests.swift
@@ -115,6 +115,35 @@ func tagCacheKeySeparatesIncludeTaskCounts() {
 }
 
 @Test
+func tagCacheKeySeparatesSearchAndHierarchyFields() {
+    let page = PageRequest(limit: 10, cursor: "cursor")
+    let compact = CacheKey.tags(
+        page: page,
+        fields: ["id", "name"],
+        statusFilter: "active",
+        includeTaskCounts: false,
+        search: "contact"
+    )
+    let hierarchy = CacheKey.tags(
+        page: page,
+        fields: ["id", "name", "path"],
+        statusFilter: "active",
+        includeTaskCounts: false,
+        search: "contact"
+    )
+    let differentSearch = CacheKey.tags(
+        page: page,
+        fields: ["id", "name"],
+        statusFilter: "active",
+        includeTaskCounts: false,
+        search: "context"
+    )
+
+    #expect(compact != hierarchy)
+    #expect(compact != differentSearch)
+}
+
+@Test
 func catalogCacheSeparatesProjectEntriesByKey() async {
     let cache = CatalogCache()
     let page = PageRequest(limit: 10)

--- a/Tests/OmniFocusIntegrationTests/TagSearchHierarchyTests.swift
+++ b/Tests/OmniFocusIntegrationTests/TagSearchHierarchyTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import JavaScriptCore
+@testable import OmniFocusAutomation
+import OmniFocusCore
+import Testing
+
+@Test
+func tagNameSearchIsCaseInsensitiveAndHierarchyDistinguishesDuplicates() throws {
+    let module = try tagQueryHelperModule()
+    let context = JSContext()!
+    var exceptionMessage: String?
+    context.exceptionHandler = { _, exception in
+        exceptionMessage = exception?.toString()
+    }
+
+    let script = """
+    function safe(fn) { try { return fn(); } catch (_) { return null; } }
+    \(module)
+    function tag(id, name, parent, exclusive) {
+      return {
+        id: { primaryKey: id },
+        name: name,
+        parent: parent || null,
+        childrenAreMutuallyExclusive: exclusive === true
+      };
+    }
+    const people = tag("people", "People", null, false);
+    const material = tag("material", "Material", null, true);
+    const peopleContact = tag("people-contact", "Contact", people, false);
+    const peopleContactDuplicate = tag("people-contact-2", "Contact", people, false);
+    const materialContact = tag("material-contact", "CONTACT", material, false);
+    const nested = tag("nested", "Preferred Contact", peopleContact, false);
+    const tags = [
+      people,
+      peopleContact,
+      peopleContactDuplicate,
+      material,
+      materialContact,
+      nested
+    ];
+    const query = normalizedTagNameSearch("  contact ");
+    const matches = tags.filter(tag => tagMatchesNameSearch(tag, query));
+    JSON.stringify(matches.map(tag => ({
+      id: tag.id.primaryKey,
+      hierarchy: tagHierarchyPayload(tag)
+    })));
+    """
+
+    let json = try #require(context.evaluateScript(script)?.toString())
+    #expect(exceptionMessage == nil)
+
+    struct Match: Decodable {
+        struct Hierarchy: Decodable {
+            let parentID: String?
+            let parentName: String?
+            let path: [TagPathElement]
+        }
+        let id: String
+        let hierarchy: Hierarchy
+    }
+
+    let matches = try JSONDecoder().decode([Match].self, from: Data(json.utf8))
+    #expect(matches.map(\.id) == [
+        "people-contact",
+        "people-contact-2",
+        "material-contact",
+        "nested"
+    ])
+    #expect(matches[0].hierarchy.parentID == "people")
+    #expect(matches[0].hierarchy.parentName == "People")
+    #expect(matches[0].hierarchy.path.map(\.name) == ["People", "Contact"])
+    #expect(matches[1].hierarchy.path.map(\.name) == ["People", "Contact"])
+    #expect(matches[2].hierarchy.path.map(\.name) == ["Material", "CONTACT"])
+    #expect(matches[3].hierarchy.path.map(\.name) == ["People", "Contact", "Preferred Contact"])
+}
+
+@Test
+func tagSearchNormalizationRejectsWhitespaceOnlyInput() throws {
+    #expect(try OmniFocusBridgeService.normalizeTagSearch("  Contact \n") == "Contact")
+    #expect(try OmniFocusBridgeService.normalizeTagSearch(nil) == nil)
+    #expect(throws: AutomationError.self) {
+        try OmniFocusBridgeService.normalizeTagSearch(" \t\n ")
+    }
+}
+
+private func tagQueryHelperModule() throws -> String {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js")
+    let source = try String(contentsOf: sourceURL, encoding: .utf8)
+    let startMarker = "// TAG QUERY MODULE - list_tags search and hierarchy"
+    let endMarker = "// END TAG QUERY MODULE"
+    let start = try #require(source.range(of: startMarker))
+    let end = try #require(
+        source.range(of: endMarker, range: start.upperBound..<source.endIndex)
+    )
+    return String(source[start.lowerBound..<end.upperBound])
+}


### PR DESCRIPTION
Closes #70

## User outcome

Users and assistants can search tags by a partial name and request parent/path information, making identically named tags distinguishable without loading the full tag catalog.

## What changed

- Added trimmed, literal, case-insensitive `search` to `list_tags`, applied with status filtering before pagination.
- Added opt-in tag fields for direct parent, full root-to-tag path, and mutually-exclusive child-group behavior.
- Preserved the existing default `id`, `name`, and `status` response shape and existing task-count behavior.
- Added matching CLI options and kept search, hierarchy fields, pagination, status, counts, cursor identity, and cache keys composed consistently.
- Added deterministic JavaScriptCore, MCP wire, CLI, model, output, and cache coverage, including nested and duplicate tag names.

Validation impact: `query`.

## Validation

- `swift test`: passed (189 tests)
- `swift build -c release --product focusrelay`: passed
- `swift run focusrelay-dev validate --impact query`: passed, including live Bridge semantic gates
- Privacy-safe live tag search/hierarchy probe: passed; one matched result, 195 serialized bytes, 377 ms end to end
- `git diff --check`: passed

The repository guide’s optional `--base origin/master` example is not accepted by the current validator CLI, so validation used its supported `validate --impact query` syntax.

No private OmniFocus tag names, IDs, paths, task data, or raw query results are included in this PR or its evidence.