### PR TITLE
Require macOS 26 for packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
   build-and-test:
     needs: classify
     if: needs.classify.outputs.code_changed == 'true'
-    runs-on: macos-15
+    runs-on: macos-26
     env:
       SWIFTLY_VERSION: "1.1.3"
     steps:
@@ -107,6 +107,9 @@ jobs:
 
       - name: Build release product
         run: swift build -c release --product focusrelay
+
+      - name: Check minimum macOS
+        run: ./scripts/check-minimum-macos.sh .build/release/focusrelay
 
       - name: Check release surface
         run: ./scripts/check-bridge-only-architecture.sh .build/debug/focusrelay .build/release/focusrelay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- FocusRelay now requires macOS 26 or later so local builds, CI, release
+  packages, and Homebrew installation share one supported platform baseline.
+
 ## [0.11.0-beta] - 2026-07-24
 
 ### What’s new

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Thanks for helping make OmniFocus work better with AI assistants.
 
 Requirements:
 
-- macOS with OmniFocus 4 for live integration tests;
+- macOS 26 or later, with OmniFocus 4 for live integration tests;
 - Swift 6.3.3 selected through Swiftly and the checked-in `.swift-version`;
 - the Swift Testing framework included with the Swift toolchain.
 

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "FocusRelayMCP",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v26)
     ],
     products: [
         .executable(name: "focusrelay", targets: ["FocusRelayCLI"]),

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ sensitive data.
 
 Requirements:
 
-- macOS on Apple silicon;
+- macOS 26 or later on Apple silicon;
 - OmniFocus 4;
 - Homebrew;
 - an MCP-compatible assistant or a shell-capable AI agent.
@@ -187,7 +187,8 @@ Then ask:
 
 Download the latest binary and `FocusRelayBridge.omnijs` from
 [GitHub Releases](https://github.com/deverman/FocusRelayMCP/releases), or build
-with the Swift 6.3.3 toolchain selected by the checked-in `.swift-version`:
+on macOS 26 or later with the Swift 6.3.3 toolchain selected by the checked-in
+`.swift-version`:
 
 ```bash
 git clone https://github.com/deverman/FocusRelayMCP.git

--- a/Sources/FocusRelayDevCLI/FocusRelayDevCLI.swift
+++ b/Sources/FocusRelayDevCLI/FocusRelayDevCLI.swift
@@ -142,7 +142,8 @@ private struct ReleaseVerify: ParsableCommand {
         let binary = try required(binaries.first, "Packaged focusrelay binary is missing.")
         let embedded = try CommandRunner.capture(binary.path, ["--version"])
         guard embedded.contains(expectedVersion) else { throw ValidationError("Embedded version does not match \(expectedVersion): \(embedded)") }
-        print("Release \(tag) verified: checksum and embedded version match.")
+        try CommandRunner.run("Verify minimum macOS", "./scripts/check-minimum-macos.sh", [binary.path])
+        print("Release \(tag) verified: checksum, embedded version, and minimum macOS match.")
     }
 }
 

--- a/Sources/FocusRelayDevCore/ValidationPolicy.swift
+++ b/Sources/FocusRelayDevCore/ValidationPolicy.swift
@@ -98,6 +98,9 @@ public enum ValidationPlanner {
         if impact == .package || impact == .serverWire || impact == .mutation {
             steps.append(ValidationStep("Build release binary", "swift", ["build"] + sandboxArguments + ["-c", "release", "--product", "focusrelay"]))
         }
+        if impact == .package {
+            steps.append(ValidationStep("Check minimum macOS", "./scripts/check-minimum-macos.sh", [".build/release/focusrelay"]))
+        }
         if impact >= .query {
             steps.append(ValidationStep("Run semantic gates", "swift", ["run"] + sandboxArguments + ["focusrelay", "benchmark-gate-check", "--tool", "all"]))
         }

--- a/Tests/FocusRelayDevCoreTests/ValidationPolicyTests.swift
+++ b/Tests/FocusRelayDevCoreTests/ValidationPolicyTests.swift
@@ -17,6 +17,13 @@ import Testing
     #expect(steps.map(\.name) == ["Run Swift tests", "Build release binary"])
 }
 
+@Test func packageChecksBuiltMinimumMacOS() {
+    let steps = ValidationPlanner.steps(for: .package)
+    #expect(steps.map(\.name) == ["Run Swift tests", "Build release binary", "Check minimum macOS"])
+    #expect(steps.last?.executable == "./scripts/check-minimum-macos.sh")
+    #expect(steps.last?.arguments == [".build/release/focusrelay"])
+}
+
 @Test func queryAddsSemanticGate() {
     let steps = ValidationPlanner.steps(for: .query)
     #expect(steps.last?.arguments.contains("benchmark-gate-check") == true)

--- a/scripts/check-minimum-macos.sh
+++ b/scripts/check-minimum-macos.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+BINARY_PATH="${1:-}"
+EXPECTED_MINIMUM="${2:-26.0}"
+
+if [ -z "$BINARY_PATH" ] || [ ! -f "$BINARY_PATH" ]; then
+  echo "Usage: $0 <mach-o-binary> [expected-minimum]" >&2
+  exit 2
+fi
+
+ACTUAL_MINIMUM="$(
+  xcrun vtool -show-build "$BINARY_PATH" |
+    awk '$1 == "minos" { print $2; exit }'
+)"
+
+if [ -z "$ACTUAL_MINIMUM" ]; then
+  echo "Could not read a macOS minimum version from $BINARY_PATH" >&2
+  exit 1
+fi
+
+if [ "$ACTUAL_MINIMUM" != "$EXPECTED_MINIMUM" ]; then
+  echo "Minimum macOS mismatch: expected $EXPECTED_MINIMUM, got $ACTUAL_MINIMUM" >&2
+  exit 1
+fi
+
+printf 'Minimum macOS: %s\n' "$ACTUAL_MINIMUM"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -24,6 +24,7 @@ test -x "$BINARY_PATH"
 test -f "$ROOT_DIR/Plugin/FocusRelayBridge.omnijs/manifest.json"
 test -f "$ROOT_DIR/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js"
 test -f "$ROOT_DIR/README.md"
+"$ROOT_DIR/scripts/check-minimum-macos.sh" "$BINARY_PATH"
 
 REPORTED_VERSION="$($BINARY_PATH --version)"
 if [ "$REPORTED_VERSION" != "$VERSION" ]; then


### PR DESCRIPTION
Closes #174

## What changed

- Raised the Swift package deployment target to macOS 26.
- Moved package CI to a macOS 26 runner while retaining the pinned Swift 6.3.3
  toolchain.
- Updated user and contributor requirements plus the unreleased changelog.
- Added a reusable Mach-O minimum-version check to package validation, CI,
  release packaging, and published-release verification.

## Why

The package previously declared macOS 13 even though development and release
work now target the macOS 26 / Swift 6.3.3 baseline. That let source metadata,
CI, distribution, and actual support expectations disagree.

## User impact

Users on macOS 26 or later get one consistent supported configuration. Older
systems can fail early from package and Homebrew metadata rather than reaching
a late build or runtime failure.

## Validation impact

`package`

## Acceptance journey

A user on macOS 26 or later installs and runs FocusRelay normally, and the
packaged executable records macOS 26 as its minimum OS. An older macOS release
is rejected by distribution metadata before being presented as supported.

## Validation

- `swift run focusrelay-dev validate --impact package --base origin/master`
  was attempted; the current validator still rejects the documented `--base`
  option.
- `swift run focusrelay-dev validate --impact package`
  - 192 Swift Testing tests passed.
  - Release build passed.
  - Minimum-version gate reported `26.0`.
- A local release archive was produced with `scripts/package-release.sh`; its
  packaged executable reported `platform MACOS` and `minos 26.0`.
- `git diff --check` passed.

No Bridge, MCP schema, query, mutation, or runtime concurrency behavior changed.
No personal OmniFocus content is included.

## Release coordination

The matching Homebrew tap change will be prepared as a separate draft PR and
must remain unmerged until it points at the first macOS-26-only release.
