### PR TITLE
Add direct MCP Bridge burst harness

### DIFF
--- a/Sources/FocusRelayDevCLI/FocusRelayDevCLI.swift
+++ b/Sources/FocusRelayDevCLI/FocusRelayDevCLI.swift
@@ -3,11 +3,20 @@ import Foundation
 import FocusRelayDevCore
 
 @main
-struct FocusRelayDevCLI: ParsableCommand {
+struct FocusRelayDevCLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "focusrelay-dev",
         abstract: "Developer-only validation and release orchestration.",
-        subcommands: [Classify.self, Validate.self, CheckMarkdownLinks.self, Benchmark.self, ReleasePlan.self, ReleaseVerify.self, WorkspaceReport.self]
+        subcommands: [
+            Classify.self,
+            Validate.self,
+            CheckMarkdownLinks.self,
+            Benchmark.self,
+            BridgeBurst.self,
+            ReleasePlan.self,
+            ReleaseVerify.self,
+            WorkspaceReport.self
+        ]
     )
 }
 
@@ -92,6 +101,110 @@ private struct Benchmark: ParsableCommand {
         case .stress:
             try CommandRunner.run("Diagnostic stress suite", "./scripts/benchmark-suite.sh", ["--profile", "stress"], timeoutSeconds: 14_400)
         }
+    }
+}
+
+private struct BridgeBurst: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "bridge-burst",
+        abstract: "Measure direct MCP Bridge-backed request bursts without persisting response content."
+    )
+
+    @Option(help: "Required profile: canary, smoke, release, or stress.")
+    var profile: BridgeBurstProfile
+
+    @Option(help: "Required scenario: task-counts or completion-preview.")
+    var scenario: BridgeBurstScenario
+
+    @Option(name: .customLong("server-path"), help: "FocusRelay server binary to launch.")
+    var serverPath = ".build/release/focusrelay"
+
+    @Option(name: .customLong("fixture-task-id"), help: "Disposable task ID required only for completion-preview.")
+    var fixtureTaskID: String?
+
+    func run() async throws {
+        let fileManager = FileManager.default
+        let workingDirectory = fileManager.currentDirectoryPath
+        let serverURL = URL(
+            fileURLWithPath: serverPath,
+            relativeTo: URL(fileURLWithPath: workingDirectory, isDirectory: true)
+        ).standardizedFileURL
+        guard fileManager.isExecutableFile(atPath: serverURL.path) else {
+            throw BridgeBurstConfigurationError.invalidServerBinary
+        }
+
+        _ = try scenario.arguments(fixtureTaskID: fixtureTaskID)
+        let transport = StdioMCPBurstTransport(
+            serverPath: serverURL.path,
+            currentDirectory: workingDirectory
+        )
+        let runner = BridgeBurstRunner(transport: transport)
+        let heartbeat = CommandHeartbeat(message: "[running] bridge-burst")
+        heartbeat.start()
+        defer { heartbeat.cancel() }
+
+        emit("[start] bridge-burst profile=\(profile.rawValue) scenario=\(scenario.rawValue)")
+        let report = try await runner.run(
+            profile: profile,
+            scenario: scenario,
+            fixtureTaskID: fixtureTaskID
+        ) { message in
+            emit("[progress] \(message)")
+        }
+
+        let commit = try CommandRunner.capture("git", ["rev-parse", "HEAD"])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let fingerprint = try productionFingerprint()
+        let binaryHash = try required(
+            CommandRunner.capture("shasum", ["-a", "256", serverURL.path])
+                .split(whereSeparator: \.isWhitespace)
+                .first
+                .map(String.init),
+            "Could not calculate the server binary hash."
+        )
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let generatedAt = formatter.string(from: Date())
+        let artifact = BridgeBurstArtifact(
+            generatedAt: generatedAt,
+            gitCommit: commit,
+            productionFingerprint: fingerprint,
+            serverBinarySHA256: binaryHash,
+            report: report
+        )
+
+        let artifactDirectory = URL(fileURLWithPath: workingDirectory)
+            .appendingPathComponent(".build/benchmarks", isDirectory: true)
+        try fileManager.createDirectory(at: artifactDirectory, withIntermediateDirectories: true)
+        let timestamp = generatedAt
+            .replacingOccurrences(of: ":", with: "-")
+            .replacingOccurrences(of: ".", with: "-")
+        let artifactURL = artifactDirectory.appendingPathComponent(
+            "bridge-burst-\(timestamp)-\(profile.rawValue)-\(scenario.rawValue).json"
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(artifact).write(to: artifactURL, options: .atomic)
+
+        printSummary(report)
+        let relativeArtifact = ".build/benchmarks/\(artifactURL.lastPathComponent)"
+        emit("[end] bridge-burst elapsed=\(String(format: "%.2f", report.elapsedSeconds))s")
+        print("artifact: \(relativeArtifact)")
+    }
+
+    private func printSummary(_ report: BridgeBurstReport) {
+        print(summaryLine(label: "sequential", summary: report.sequential))
+        for level in report.bursts {
+            print(summaryLine(label: "burst-\(level.concurrency)", summary: level.summary))
+        }
+    }
+
+    private func summaryLine(label: String, summary: BridgeBurstSummary) -> String {
+        let p95 = summary.successfulRequestP95Milliseconds
+            .map { String(format: "%.2fms", $0) } ?? "n/a"
+        return "\(label): requests=\(summary.requestCount) success=\(summary.successCount) "
+            + "toolError=\(summary.toolErrorCount) protocolError=\(summary.protocolErrorCount) "
+            + "processExit=\(summary.processExitCount) timeout=\(summary.timeoutCount) p95=\(p95)"
     }
 }
 
@@ -232,6 +345,28 @@ private final class RunState: @unchecked Sendable {
     var timedOut: Bool { lock.withLock { didTimeOut } }
 }
 
+private final class CommandHeartbeat: @unchecked Sendable {
+    private let timer: DispatchSourceTimer
+
+    init(message: String) {
+        timer = DispatchSource.makeTimerSource(
+            queue: DispatchQueue(label: "focusrelay-dev.heartbeat")
+        )
+        timer.schedule(deadline: .now() + 25, repeating: 25)
+        timer.setEventHandler {
+            emit(message)
+        }
+    }
+
+    func start() {
+        timer.resume()
+    }
+
+    func cancel() {
+        timer.cancel()
+    }
+}
+
 private func emit(_ message: String) {
     FileHandle.standardOutput.write(Data("\(message)\n".utf8))
 }
@@ -263,3 +398,5 @@ private func writeReport(kind: String, values: [String: String]) throws {
 }
 
 extension ValidationImpact: ExpressibleByArgument {}
+extension BridgeBurstProfile: ExpressibleByArgument {}
+extension BridgeBurstScenario: ExpressibleByArgument {}

--- a/Sources/FocusRelayDevCore/BridgeBurst.swift
+++ b/Sources/FocusRelayDevCore/BridgeBurst.swift
@@ -1,0 +1,599 @@
+import Foundation
+
+public enum BridgeBurstProfile: String, Codable, CaseIterable, Sendable {
+    case canary
+    case smoke
+    case release
+    case stress
+
+    public var warmupCount: Int { 1 }
+    public var sequentialSampleCount: Int { 12 }
+    public var burstSizes: [Int] { [2, 4, 7, 12] }
+
+    public var targetBurstDuration: Duration? {
+        switch self {
+        case .canary: nil
+        case .smoke: .seconds(600)
+        case .release: .seconds(5_400)
+        case .stress: .seconds(10_800)
+        }
+    }
+}
+
+public enum BridgeBurstScenario: String, Codable, CaseIterable, Sendable {
+    case taskCounts = "task-counts"
+    case completionPreview = "completion-preview"
+
+    public var toolName: String {
+        switch self {
+        case .taskCounts: "get_task_counts"
+        case .completionPreview: "edit_tasks"
+        }
+    }
+
+    public func sequentialSampleCount(for profile: BridgeBurstProfile) -> Int {
+        switch self {
+        case .taskCounts: profile.sequentialSampleCount
+        case .completionPreview: 3
+        }
+    }
+
+    public func arguments(fixtureTaskID: String?) throws -> BurstJSONValue {
+        switch self {
+        case .taskCounts:
+            return .object([
+                "filter": .object([
+                    "inboxOnly": .bool(true),
+                    "inboxView": .string("remaining"),
+                ]),
+            ])
+        case .completionPreview:
+            guard let fixtureTaskID,
+                  !fixtureTaskID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw BridgeBurstConfigurationError.missingFixtureTaskID
+            }
+            return .object([
+                "operation": .string("set_completion"),
+                "targetIDs": .array([.string(fixtureTaskID)]),
+                "completion": .object(["state": .string("completed")]),
+                "previewOnly": .bool(true),
+            ])
+        }
+    }
+}
+
+public enum BridgeBurstConfigurationError: Error, LocalizedError, Sendable {
+    case missingFixtureTaskID
+    case invalidServerBinary
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingFixtureTaskID:
+            "completion-preview requires --fixture-task-id."
+        case .invalidServerBinary:
+            "The server binary is missing or is not executable."
+        }
+    }
+}
+
+public enum BurstJSONValue: Codable, Equatable, Sendable {
+    case null
+    case bool(Bool)
+    case number(Double)
+    case string(String)
+    case array([BurstJSONValue])
+    case object([String: BurstJSONValue])
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([BurstJSONValue].self) {
+            self = .array(value)
+        } else {
+            self = .object(try container.decode([String: BurstJSONValue].self))
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null:
+            try container.encodeNil()
+        case .bool(let value):
+            try container.encode(value)
+        case .number(let value):
+            try container.encode(value)
+        case .string(let value):
+            try container.encode(value)
+        case .array(let value):
+            try container.encode(value)
+        case .object(let value):
+            try container.encode(value)
+        }
+    }
+}
+
+public struct BridgeBurstRequest: Equatable, Sendable {
+    public let id: Int
+    public let toolName: String
+    public let arguments: BurstJSONValue
+
+    public init(id: Int, toolName: String, arguments: BurstJSONValue) {
+        self.id = id
+        self.toolName = toolName
+        self.arguments = arguments
+    }
+}
+
+public enum BridgeBurstClassification: String, Codable, CaseIterable, Sendable {
+    case success
+    case toolError
+    case protocolError
+    case processExit
+    case timeout
+}
+
+public enum BridgeBurstTransportError: Error, LocalizedError, Sendable {
+    case protocolError
+    case processExit(Int32)
+    case timeout
+
+    public var classification: BridgeBurstClassification {
+        switch self {
+        case .protocolError: .protocolError
+        case .processExit: .processExit
+        case .timeout: .timeout
+        }
+    }
+
+    public var errorDescription: String? {
+        switch self {
+        case .protocolError:
+            "The MCP server returned a malformed or unmatched response."
+        case .processExit:
+            "The MCP server exited before completing the request."
+        case .timeout:
+            "The MCP response deadline expired."
+        }
+    }
+}
+
+public protocol BridgeBurstTransport: Sendable {
+    func start() async throws
+    func initialize(timeout: Duration) async throws
+    func call(
+        _ request: BridgeBurstRequest,
+        timeout: Duration
+    ) async throws -> BridgeBurstClassification
+    func stop() async
+}
+
+public struct BridgeBurstSample: Codable, Equatable, Sendable {
+    public let classification: BridgeBurstClassification
+    public let elapsedMilliseconds: Double
+
+    public init(classification: BridgeBurstClassification, elapsedMilliseconds: Double) {
+        self.classification = classification
+        self.elapsedMilliseconds = elapsedMilliseconds
+    }
+}
+
+public struct BridgeBurstSummary: Codable, Equatable, Sendable {
+    public let requestCount: Int
+    public let successCount: Int
+    public let toolErrorCount: Int
+    public let protocolErrorCount: Int
+    public let processExitCount: Int
+    public let timeoutCount: Int
+    public let successfulRequestP50Milliseconds: Double?
+    public let successfulRequestP95Milliseconds: Double?
+    public let successfulRequestMaximumMilliseconds: Double?
+    public let batchCount: Int
+    public let batchP50Milliseconds: Double?
+    public let batchP95Milliseconds: Double?
+    public let batchMaximumMilliseconds: Double?
+
+    public init(samples: [BridgeBurstSample], batchElapsedMilliseconds: [Double] = []) {
+        requestCount = samples.count
+        successCount = samples.count { $0.classification == .success }
+        toolErrorCount = samples.count { $0.classification == .toolError }
+        protocolErrorCount = samples.count { $0.classification == .protocolError }
+        processExitCount = samples.count { $0.classification == .processExit }
+        timeoutCount = samples.count { $0.classification == .timeout }
+
+        let successful = samples
+            .filter { $0.classification == .success }
+            .map(\.elapsedMilliseconds)
+        successfulRequestP50Milliseconds = Self.percentile(successful, percentile: 0.50)
+        successfulRequestP95Milliseconds = Self.percentile(successful, percentile: 0.95)
+        successfulRequestMaximumMilliseconds = successful.max()
+
+        batchCount = batchElapsedMilliseconds.count
+        batchP50Milliseconds = Self.percentile(batchElapsedMilliseconds, percentile: 0.50)
+        batchP95Milliseconds = Self.percentile(batchElapsedMilliseconds, percentile: 0.95)
+        batchMaximumMilliseconds = batchElapsedMilliseconds.max()
+    }
+
+    static func percentile(_ values: [Double], percentile: Double) -> Double? {
+        guard !values.isEmpty else { return nil }
+        let sorted = values.sorted()
+        let rank = max(1, Int(ceil(percentile * Double(sorted.count))))
+        return sorted[min(sorted.count - 1, rank - 1)]
+    }
+}
+
+public struct BridgeBurstLevelReport: Codable, Equatable, Sendable {
+    public let concurrency: Int
+    public let summary: BridgeBurstSummary
+
+    public init(concurrency: Int, summary: BridgeBurstSummary) {
+        self.concurrency = concurrency
+        self.summary = summary
+    }
+}
+
+public struct BridgeBurstReport: Codable, Equatable, Sendable {
+    public let profile: BridgeBurstProfile
+    public let scenario: BridgeBurstScenario
+    public let elapsedSeconds: Double
+    public let sequential: BridgeBurstSummary
+    public let bursts: [BridgeBurstLevelReport]
+
+    public init(
+        profile: BridgeBurstProfile,
+        scenario: BridgeBurstScenario,
+        elapsedSeconds: Double,
+        sequential: BridgeBurstSummary,
+        bursts: [BridgeBurstLevelReport]
+    ) {
+        self.profile = profile
+        self.scenario = scenario
+        self.elapsedSeconds = elapsedSeconds
+        self.sequential = sequential
+        self.bursts = bursts
+    }
+}
+
+public struct BridgeBurstArtifact: Codable, Equatable, Sendable {
+    public let schemaVersion: Int
+    public let generatedAt: String
+    public let gitCommit: String
+    public let productionFingerprint: String
+    public let serverBinarySHA256: String
+    public let report: BridgeBurstReport
+
+    public init(
+        schemaVersion: Int = 1,
+        generatedAt: String,
+        gitCommit: String,
+        productionFingerprint: String,
+        serverBinarySHA256: String,
+        report: BridgeBurstReport
+    ) {
+        self.schemaVersion = schemaVersion
+        self.generatedAt = generatedAt
+        self.gitCommit = gitCommit
+        self.productionFingerprint = productionFingerprint
+        self.serverBinarySHA256 = serverBinarySHA256
+        self.report = report
+    }
+}
+
+public enum BridgeBurstRunError: Error, LocalizedError, Sendable {
+    case warmupFailed(BridgeBurstClassification)
+
+    public var errorDescription: String? {
+        switch self {
+        case .warmupFailed(let classification):
+            "Bridge burst warmup failed with \(classification.rawValue)."
+        }
+    }
+}
+
+public struct BridgeBurstRunner: Sendable {
+    public let transport: any BridgeBurstTransport
+    public let responseTimeout: Duration
+
+    public init(
+        transport: any BridgeBurstTransport,
+        responseTimeout: Duration = .seconds(15)
+    ) {
+        self.transport = transport
+        self.responseTimeout = responseTimeout
+    }
+
+    public func run(
+        profile: BridgeBurstProfile,
+        scenario: BridgeBurstScenario,
+        fixtureTaskID: String?,
+        progress: @Sendable (String) -> Void = { _ in }
+    ) async throws -> BridgeBurstReport {
+        let arguments = try scenario.arguments(fixtureTaskID: fixtureTaskID)
+        let runClock = ContinuousClock()
+        let runStarted = runClock.now
+
+        try await transport.start()
+        do {
+            try await transport.initialize(timeout: .seconds(10))
+            progress("MCP initialized")
+
+            var nextRequestID = 100
+            for _ in 0..<profile.warmupCount {
+                let request = BridgeBurstRequest(
+                    id: nextRequestID,
+                    toolName: scenario.toolName,
+                    arguments: arguments
+                )
+                nextRequestID += 1
+                let sample = await measure(request)
+                guard sample.classification == .success else {
+                    throw BridgeBurstRunError.warmupFailed(sample.classification)
+                }
+            }
+            progress("Warmup complete")
+
+            var sequentialSamples: [BridgeBurstSample] = []
+            var consecutiveInfrastructureFailures = 0
+            let sequentialSampleCount = scenario.sequentialSampleCount(for: profile)
+            for sampleNumber in 1...sequentialSampleCount {
+                try Task.checkCancellation()
+                let request = BridgeBurstRequest(
+                    id: nextRequestID,
+                    toolName: scenario.toolName,
+                    arguments: arguments
+                )
+                nextRequestID += 1
+                let sample = await measure(request)
+                sequentialSamples.append(sample)
+                progress(
+                    "Sequential sample \(sampleNumber)/\(sequentialSampleCount) "
+                        + "\(sample.classification.rawValue) "
+                        + "\(String(format: "%.2f", sample.elapsedMilliseconds))ms"
+                )
+                if sample.classification == .success {
+                    consecutiveInfrastructureFailures = 0
+                } else if sample.classification != .toolError {
+                    consecutiveInfrastructureFailures += 1
+                }
+                if consecutiveInfrastructureFailures >= 2 {
+                    progress("Sequential baseline stopped after two infrastructure failures")
+                    break
+                }
+            }
+            progress("Sequential baseline complete")
+
+            var samplesByBurst = Dictionary(
+                uniqueKeysWithValues: profile.burstSizes.map { ($0, [BridgeBurstSample]()) }
+            )
+            var batchDurationsByBurst = Dictionary(
+                uniqueKeysWithValues: profile.burstSizes.map { ($0, [Double]()) }
+            )
+            let burstPhaseStarted = runClock.now
+
+            repeat {
+                for burstSize in profile.burstSizes {
+                    try Task.checkCancellation()
+                    let requests = (0..<burstSize).map { _ -> BridgeBurstRequest in
+                        defer { nextRequestID += 1 }
+                        return BridgeBurstRequest(
+                            id: nextRequestID,
+                            toolName: scenario.toolName,
+                            arguments: arguments
+                        )
+                    }
+                    let batchStarted = runClock.now
+                    let samples = await withTaskGroup(of: BridgeBurstSample.self) { group in
+                        for request in requests {
+                            group.addTask {
+                                await measure(request)
+                            }
+                        }
+                        var collected: [BridgeBurstSample] = []
+                        for await sample in group {
+                            collected.append(sample)
+                        }
+                        return collected
+                    }
+                    samplesByBurst[burstSize, default: []].append(contentsOf: samples)
+                    let batchElapsed = batchStarted.duration(to: runClock.now).milliseconds
+                    batchDurationsByBurst[burstSize, default: []].append(batchElapsed)
+                    let successes = samples.count { $0.classification == .success }
+                    progress(
+                        "Burst \(burstSize) complete success=\(successes)/\(samples.count) "
+                            + "elapsed=\(String(format: "%.2f", batchElapsed))ms"
+                    )
+                }
+            } while shouldContinueBurstPhase(
+                targetDuration: profile.targetBurstDuration,
+                elapsed: burstPhaseStarted.duration(to: runClock.now)
+            )
+
+            let report = BridgeBurstReport(
+                profile: profile,
+                scenario: scenario,
+                elapsedSeconds: runStarted.duration(to: runClock.now).seconds,
+                sequential: BridgeBurstSummary(samples: sequentialSamples),
+                bursts: profile.burstSizes.map { burstSize in
+                    BridgeBurstLevelReport(
+                        concurrency: burstSize,
+                        summary: BridgeBurstSummary(
+                            samples: samplesByBurst[burstSize, default: []],
+                            batchElapsedMilliseconds: batchDurationsByBurst[burstSize, default: []]
+                        )
+                    )
+                }
+            )
+            await transport.stop()
+            return report
+        } catch {
+            await transport.stop()
+            throw error
+        }
+    }
+
+    private func measure(_ request: BridgeBurstRequest) async -> BridgeBurstSample {
+        let clock = ContinuousClock()
+        let started = clock.now
+        let classification: BridgeBurstClassification
+        do {
+            classification = try await transport.call(request, timeout: responseTimeout)
+        } catch let error as BridgeBurstTransportError {
+            classification = error.classification
+        } catch is CancellationError {
+            classification = .timeout
+        } catch {
+            classification = .protocolError
+        }
+        return BridgeBurstSample(
+            classification: classification,
+            elapsedMilliseconds: started.duration(to: clock.now).milliseconds
+        )
+    }
+
+    private func shouldContinueBurstPhase(
+        targetDuration: Duration?,
+        elapsed: Duration
+    ) -> Bool {
+        guard let targetDuration else { return false }
+        return elapsed < targetDuration
+    }
+}
+
+public enum MCPResponseClassifier {
+    public static func classify(_ data: Data) -> BridgeBurstClassification {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return .protocolError
+        }
+        if object["error"] != nil {
+            return .protocolError
+        }
+        guard let result = object["result"] as? [String: Any] else {
+            return .protocolError
+        }
+        return result["isError"] as? Bool == true ? .toolError : .success
+    }
+}
+
+public actor MCPResponseBroker {
+    private var expectedIDs = Set<Int>()
+    private var bufferedResponses: [Int: Data] = [:]
+    private var waiters: [Int: CheckedContinuation<Data, any Error>] = [:]
+    private var timeoutTasks: [Int: Task<Void, Never>] = [:]
+    private var lineBuffer = Data()
+    private var terminalError: BridgeBurstTransportError?
+
+    public init() {}
+
+    public func expect(_ id: Int) throws {
+        if let terminalError {
+            throw terminalError
+        }
+        expectedIDs.insert(id)
+    }
+
+    public func receive(chunk: Data) {
+        guard terminalError == nil else { return }
+        lineBuffer.append(chunk)
+        while let newline = lineBuffer.firstIndex(of: 0x0A) {
+            let line = Data(lineBuffer[..<newline])
+            lineBuffer.removeSubrange(...newline)
+            guard !line.isEmpty else { continue }
+            receive(line: line)
+        }
+    }
+
+    public func response(for id: Int, timeout: Duration) async throws -> Data {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                if let terminalError {
+                    continuation.resume(throwing: terminalError)
+                    return
+                }
+                if let buffered = bufferedResponses.removeValue(forKey: id) {
+                    expectedIDs.remove(id)
+                    continuation.resume(returning: buffered)
+                    return
+                }
+                waiters[id] = continuation
+                timeoutTasks[id] = Task { @concurrent [weak self] in
+                    do {
+                        try await Task.sleep(for: timeout)
+                    } catch {
+                        return
+                    }
+                    await self?.expire(id)
+                }
+            }
+        } onCancel: {
+            Task { @concurrent in
+                await cancel(id)
+            }
+        }
+    }
+
+    public func finish(_ error: BridgeBurstTransportError) {
+        guard terminalError == nil else { return }
+        terminalError = error
+        lineBuffer.removeAll(keepingCapacity: false)
+        bufferedResponses.removeAll(keepingCapacity: false)
+        expectedIDs.removeAll(keepingCapacity: false)
+        for task in timeoutTasks.values {
+            task.cancel()
+        }
+        timeoutTasks.removeAll(keepingCapacity: false)
+        let pending = waiters.values
+        waiters.removeAll(keepingCapacity: false)
+        for continuation in pending {
+            continuation.resume(throwing: error)
+        }
+    }
+
+    private func receive(line: Data) {
+        guard let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
+              let id = object["id"] as? Int else {
+            finish(.protocolError)
+            return
+        }
+        guard expectedIDs.contains(id) else { return }
+        timeoutTasks.removeValue(forKey: id)?.cancel()
+        if let continuation = waiters.removeValue(forKey: id) {
+            expectedIDs.remove(id)
+            continuation.resume(returning: line)
+        } else {
+            bufferedResponses[id] = line
+        }
+    }
+
+    private func expire(_ id: Int) {
+        timeoutTasks.removeValue(forKey: id)?.cancel()
+        expectedIDs.remove(id)
+        bufferedResponses.removeValue(forKey: id)
+        waiters.removeValue(forKey: id)?.resume(throwing: BridgeBurstTransportError.timeout)
+    }
+
+    private func cancel(_ id: Int) {
+        timeoutTasks.removeValue(forKey: id)?.cancel()
+        expectedIDs.remove(id)
+        bufferedResponses.removeValue(forKey: id)
+        waiters.removeValue(forKey: id)?.resume(throwing: CancellationError())
+    }
+}
+
+extension Duration {
+    fileprivate var milliseconds: Double {
+        let components = self.components
+        return Double(components.seconds) * 1_000
+            + Double(components.attoseconds) / 1_000_000_000_000_000
+    }
+
+    fileprivate var seconds: Double {
+        milliseconds / 1_000
+    }
+}

--- a/Sources/FocusRelayDevCore/StdioMCPBurstTransport.swift
+++ b/Sources/FocusRelayDevCore/StdioMCPBurstTransport.swift
@@ -1,0 +1,193 @@
+import Foundation
+
+public actor StdioMCPBurstTransport: BridgeBurstTransport {
+    private let serverPath: String
+    private let currentDirectory: String
+    private let broker = MCPResponseBroker()
+    private let encoder: JSONEncoder
+
+    private var process: Process?
+    private var inputHandle: FileHandle?
+    private var outputHandle: FileHandle?
+    private var errorHandle: FileHandle?
+
+    public init(serverPath: String, currentDirectory: String) {
+        self.serverPath = serverPath
+        self.currentDirectory = currentDirectory
+        encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+    }
+
+    public func start() async throws {
+        guard process == nil else { return }
+
+        let process = Process()
+        let standardInput = Pipe()
+        let standardOutput = Pipe()
+        let standardError = Pipe()
+        process.executableURL = URL(fileURLWithPath: serverPath)
+        process.arguments = ["serve"]
+        process.currentDirectoryURL = URL(fileURLWithPath: currentDirectory)
+        process.standardInput = standardInput
+        process.standardOutput = standardOutput
+        process.standardError = standardError
+
+        let broker = broker
+        process.terminationHandler = { process in
+            let status = process.terminationStatus
+            Task { @concurrent in
+                await broker.finish(.processExit(status))
+            }
+        }
+
+        let outputHandle = standardOutput.fileHandleForReading
+        outputHandle.readabilityHandler = { handle in
+            let data = handle.availableData
+            guard !data.isEmpty else { return }
+            Task { @concurrent in
+                await broker.receive(chunk: data)
+            }
+        }
+
+        let errorHandle = standardError.fileHandleForReading
+        errorHandle.readabilityHandler = { handle in
+            _ = handle.availableData
+        }
+
+        do {
+            try process.run()
+        } catch {
+            outputHandle.readabilityHandler = nil
+            errorHandle.readabilityHandler = nil
+            throw BridgeBurstTransportError.processExit(-1)
+        }
+
+        self.process = process
+        inputHandle = standardInput.fileHandleForWriting
+        self.outputHandle = outputHandle
+        self.errorHandle = errorHandle
+    }
+
+    public func initialize(timeout: Duration) async throws {
+        let requestID = 1
+        try await broker.expect(requestID)
+        try write(try encoder.encode(InitializeEnvelope(id: requestID)))
+        let response = try await broker.response(for: requestID, timeout: timeout)
+        guard MCPResponseClassifier.classify(response) == .success else {
+            throw BridgeBurstTransportError.protocolError
+        }
+        try write(try encoder.encode(InitializedEnvelope()))
+    }
+
+    public func call(
+        _ request: BridgeBurstRequest,
+        timeout: Duration
+    ) async throws -> BridgeBurstClassification {
+        try await broker.expect(request.id)
+        do {
+            try write(try encoder.encode(ToolCallEnvelope(request: request)))
+        } catch {
+            await broker.finish(.processExit(-1))
+            throw BridgeBurstTransportError.processExit(-1)
+        }
+        do {
+            let response = try await broker.response(for: request.id, timeout: timeout)
+            return MCPResponseClassifier.classify(response)
+        } catch {
+            try? write(try encoder.encode(CancelledEnvelope(requestID: request.id)))
+            throw error
+        }
+    }
+
+    public func stop() async {
+        outputHandle?.readabilityHandler = nil
+        errorHandle?.readabilityHandler = nil
+        try? inputHandle?.close()
+
+        if let process, process.isRunning {
+            process.terminate()
+            for _ in 0..<20 where process.isRunning {
+                try? await Task.sleep(for: .milliseconds(50))
+            }
+        }
+
+        await broker.finish(.processExit(process?.terminationStatus ?? 0))
+        inputHandle = nil
+        outputHandle = nil
+        errorHandle = nil
+        process = nil
+    }
+
+    private func write(_ data: Data) throws {
+        guard let inputHandle else {
+            throw BridgeBurstTransportError.processExit(-1)
+        }
+        var line = data
+        line.append(0x0A)
+        try inputHandle.write(contentsOf: line)
+    }
+}
+
+private struct InitializeEnvelope: Encodable {
+    let jsonrpc = "2.0"
+    let id: Int
+    let method = "initialize"
+    let params = InitializeParameters()
+}
+
+private struct InitializeParameters: Encodable {
+    let protocolVersion = "2025-06-18"
+    let capabilities = EmptyObject()
+    let clientInfo = ClientInformation()
+}
+
+private struct ClientInformation: Encodable {
+    let name = "focusrelay-bridge-burst"
+    let version = "1"
+}
+
+private struct InitializedEnvelope: Encodable {
+    let jsonrpc = "2.0"
+    let method = "notifications/initialized"
+    let params = EmptyObject()
+}
+
+private struct CancelledEnvelope: Encodable {
+    let jsonrpc = "2.0"
+    let method = "notifications/cancelled"
+    let params: CancelledParameters
+
+    init(requestID: Int) {
+        params = CancelledParameters(
+            requestId: requestID,
+            reason: "bridge-burst response deadline expired"
+        )
+    }
+}
+
+private struct CancelledParameters: Encodable {
+    let requestId: Int
+    let reason: String
+}
+
+private struct EmptyObject: Encodable {}
+
+private struct ToolCallEnvelope: Encodable {
+    let jsonrpc = "2.0"
+    let id: Int
+    let method = "tools/call"
+    let params: ToolCallParameters
+
+    init(request: BridgeBurstRequest) {
+        id = request.id
+        params = ToolCallParameters(
+            name: request.toolName,
+            arguments: request.arguments
+        )
+    }
+}
+
+private struct ToolCallParameters: Encodable {
+    let name: String
+    let arguments: BurstJSONValue
+}

--- a/Tests/FocusRelayDevCoreTests/BridgeBurstTests.swift
+++ b/Tests/FocusRelayDevCoreTests/BridgeBurstTests.swift
@@ -1,0 +1,272 @@
+import Foundation
+import FocusRelayDevCore
+import Testing
+
+@Test
+func bridgeBurstProfilesAreExplicitAndBounded() {
+    #expect(BridgeBurstProfile.allCases.map(\.rawValue) == [
+        "canary", "smoke", "release", "stress"
+    ])
+    #expect(BridgeBurstProfile.canary.targetBurstDuration == nil)
+    #expect(BridgeBurstProfile.smoke.targetBurstDuration == .seconds(600))
+    #expect(BridgeBurstProfile.release.targetBurstDuration == .seconds(5_400))
+    #expect(BridgeBurstProfile.stress.targetBurstDuration == .seconds(10_800))
+    #expect(BridgeBurstProfile.canary.burstSizes == [2, 4, 7, 12])
+    #expect(BridgeBurstScenario.taskCounts.sequentialSampleCount(for: .canary) == 12)
+    #expect(BridgeBurstScenario.completionPreview.sequentialSampleCount(for: .canary) == 3)
+}
+
+@Test
+func completionBurstRequiresFixtureAndRemainsPreviewOnly() throws {
+    #expect(throws: BridgeBurstConfigurationError.self) {
+        try BridgeBurstScenario.completionPreview.arguments(fixtureTaskID: nil)
+    }
+
+    let arguments = try BridgeBurstScenario.completionPreview.arguments(
+        fixtureTaskID: "private-fixture"
+    )
+    let encoded = try JSONEncoder().encode(arguments)
+    let object = try #require(
+        JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+    )
+    #expect(object["operation"] as? String == "set_completion")
+    #expect(object["targetIDs"] as? [String] == ["private-fixture"])
+    #expect(object["previewOnly"] as? Bool == true)
+    #expect(object["verify"] == nil)
+}
+
+@Test
+func responseClassifierSeparatesToolAndProtocolErrors() {
+    #expect(MCPResponseClassifier.classify(
+        Data(#"{"jsonrpc":"2.0","id":1,"result":{"content":[],"isError":false}}"#.utf8)
+    ) == .success)
+    #expect(MCPResponseClassifier.classify(
+        Data(#"{"jsonrpc":"2.0","id":1,"result":{"content":[],"isError":true}}"#.utf8)
+    ) == .toolError)
+    #expect(MCPResponseClassifier.classify(
+        Data(#"{"jsonrpc":"2.0","id":1,"error":{"code":-32603}}"#.utf8)
+    ) == .protocolError)
+    #expect(MCPResponseClassifier.classify(Data("not-json".utf8)) == .protocolError)
+}
+
+@Test
+func responseBrokerCorrelatesOutOfOrderLines() async throws {
+    let broker = MCPResponseBroker()
+    try await broker.expect(1)
+    try await broker.expect(2)
+
+    async let first = broker.response(for: 1, timeout: .seconds(1))
+    async let second = broker.response(for: 2, timeout: .seconds(1))
+
+    await broker.receive(chunk: Data(
+        """
+        {"jsonrpc":"2.0","id":2,"result":{"content":[]}}
+        {"jsonrpc":"2.0","id":1,"result":{"content":[]}}
+
+        """.utf8
+    ))
+
+    let firstObject = try #require(
+        JSONSerialization.jsonObject(with: try await first) as? [String: Any]
+    )
+    let secondObject = try #require(
+        JSONSerialization.jsonObject(with: try await second) as? [String: Any]
+    )
+    #expect(firstObject["id"] as? Int == 1)
+    #expect(secondObject["id"] as? Int == 2)
+}
+
+@Test
+func responseBrokerCancellationRemovesPendingWaiter() async throws {
+    let broker = MCPResponseBroker()
+    try await broker.expect(7)
+    let task = Task {
+        try await broker.response(for: 7, timeout: .seconds(30))
+    }
+    await Task.yield()
+    task.cancel()
+
+    do {
+        _ = try await task.value
+        Issue.record("Expected cancellation")
+    } catch is CancellationError {
+        // Expected.
+    }
+
+    await broker.receive(chunk: Data(
+        #"{"jsonrpc":"2.0","id":7,"result":{"content":[]}}"#.utf8
+    ))
+}
+
+@Test
+func responseBrokerEnforcesDeadline() async throws {
+    let broker = MCPResponseBroker()
+    try await broker.expect(9)
+    do {
+        _ = try await broker.response(for: 9, timeout: .zero)
+        Issue.record("Expected timeout")
+    } catch let error as BridgeBurstTransportError {
+        #expect(error.classification == .timeout)
+    }
+}
+
+@Test
+func summaryUsesSuccessfulLatencyAndCountsEveryFailure() {
+    let samples = [
+        BridgeBurstSample(classification: .success, elapsedMilliseconds: 10),
+        BridgeBurstSample(classification: .success, elapsedMilliseconds: 20),
+        BridgeBurstSample(classification: .success, elapsedMilliseconds: 30),
+        BridgeBurstSample(classification: .toolError, elapsedMilliseconds: 40),
+        BridgeBurstSample(classification: .protocolError, elapsedMilliseconds: 50),
+        BridgeBurstSample(classification: .processExit, elapsedMilliseconds: 60),
+        BridgeBurstSample(classification: .timeout, elapsedMilliseconds: 70)
+    ]
+    let summary = BridgeBurstSummary(
+        samples: samples,
+        batchElapsedMilliseconds: [100, 200, 300]
+    )
+    #expect(summary.requestCount == 7)
+    #expect(summary.successCount == 3)
+    #expect(summary.toolErrorCount == 1)
+    #expect(summary.protocolErrorCount == 1)
+    #expect(summary.processExitCount == 1)
+    #expect(summary.timeoutCount == 1)
+    #expect(summary.successfulRequestP50Milliseconds == 20)
+    #expect(summary.successfulRequestP95Milliseconds == 30)
+    #expect(summary.batchP50Milliseconds == 200)
+    #expect(summary.batchP95Milliseconds == 300)
+}
+
+@Test
+func canaryRunnerInitializesBeforeUniqueConcurrentCalls() async throws {
+    let transport = FakeBurstTransport()
+    let runner = BridgeBurstRunner(transport: transport, responseTimeout: .seconds(1))
+    let report = try await runner.run(
+        profile: .canary,
+        scenario: .taskCounts,
+        fixtureTaskID: nil
+    )
+
+    let state = await transport.state()
+    #expect(state.didStart)
+    #expect(state.didInitialize)
+    #expect(state.didStop)
+    #expect(state.callIDs.count == 38)
+    #expect(Set(state.callIDs).count == 38)
+    #expect(state.maxActiveCalls == 12)
+    #expect(report.sequential.requestCount == 12)
+    #expect(report.bursts.map(\.concurrency) == [2, 4, 7, 12])
+    #expect(report.bursts.map(\.summary.requestCount) == [2, 4, 7, 12])
+}
+
+@Test
+func canaryStopsSequentialBaselineAfterTwoInfrastructureFailures() async throws {
+    let transport = FailingAfterWarmupTransport()
+    let runner = BridgeBurstRunner(transport: transport, responseTimeout: .seconds(1))
+    let report = try await runner.run(
+        profile: .canary,
+        scenario: .taskCounts,
+        fixtureTaskID: nil
+    )
+
+    #expect(report.sequential.requestCount == 2)
+    #expect(report.sequential.timeoutCount == 2)
+    #expect(report.bursts.map(\.summary.requestCount) == [2, 4, 7, 12])
+    #expect(report.bursts.map(\.summary.timeoutCount) == [2, 4, 7, 12])
+}
+
+@Test
+func artifactContainsOnlySanitizedAggregateFields() throws {
+    let report = BridgeBurstReport(
+        profile: .canary,
+        scenario: .completionPreview,
+        elapsedSeconds: 1,
+        sequential: BridgeBurstSummary(samples: [
+            BridgeBurstSample(classification: .success, elapsedMilliseconds: 1)
+        ]),
+        bursts: []
+    )
+    let artifact = BridgeBurstArtifact(
+        generatedAt: "2026-07-28T00:00:00Z",
+        gitCommit: "commit",
+        productionFingerprint: "fingerprint",
+        serverBinarySHA256: "hash",
+        report: report
+    )
+    let text = String(decoding: try JSONEncoder().encode(artifact), as: UTF8.self)
+    #expect(!text.contains("private-fixture"))
+    #expect(!text.contains("/Users/"))
+    #expect(!text.contains("targetIDs"))
+    #expect(!text.contains("arguments"))
+    #expect(!text.contains("content"))
+}
+
+private actor FailingAfterWarmupTransport: BridgeBurstTransport {
+    private var callCount = 0
+
+    func start() {}
+    func initialize(timeout _: Duration) {}
+
+    func call(
+        _: BridgeBurstRequest,
+        timeout _: Duration
+    ) -> BridgeBurstClassification {
+        defer { callCount += 1 }
+        return callCount == 0 ? .success : .timeout
+    }
+
+    func stop() {}
+}
+
+private actor FakeBurstTransport: BridgeBurstTransport {
+    struct State: Sendable {
+        let didStart: Bool
+        let didInitialize: Bool
+        let didStop: Bool
+        let callIDs: [Int]
+        let maxActiveCalls: Int
+    }
+
+    private var didStart = false
+    private var didInitialize = false
+    private var didStop = false
+    private var callIDs: [Int] = []
+    private var activeCalls = 0
+    private var maxActiveCalls = 0
+
+    func start() {
+        didStart = true
+    }
+
+    func initialize(timeout _: Duration) throws {
+        guard didStart else { throw BridgeBurstTransportError.protocolError }
+        didInitialize = true
+    }
+
+    func call(
+        _ request: BridgeBurstRequest,
+        timeout _: Duration
+    ) async throws -> BridgeBurstClassification {
+        guard didInitialize else { throw BridgeBurstTransportError.protocolError }
+        callIDs.append(request.id)
+        activeCalls += 1
+        maxActiveCalls = max(maxActiveCalls, activeCalls)
+        await Task.yield()
+        activeCalls -= 1
+        return .success
+    }
+
+    func stop() {
+        didStop = true
+    }
+
+    func state() -> State {
+        State(
+            didStart: didStart,
+            didInitialize: didInitialize,
+            didStop: didStop,
+            callIDs: callIDs,
+            maxActiveCalls: maxActiveCalls
+        )
+    }
+}

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -59,8 +59,23 @@ persistence verification, and restoration—not only a CLI write.
 - `stress`: run three hours only when an issue names the diagnostic question.
 
 Any production query/transport change after a release certificate invalidates
-the certificate. Documentation-only changes do not. Raw output is written to
-`.build/benchmarks`.
+the certificate. Documentation-only changes do not. Existing semantic-suite raw
+output is written to `.build/benchmarks`.
+
+Use the direct MCP burst harness when the question is concurrent Bridge
+admission rather than query semantics:
+
+```bash
+swift run focusrelay-dev bridge-burst \
+  --profile canary \
+  --scenario task-counts \
+  --server-path .build/release/focusrelay
+```
+
+The harness always covers concurrency 2, 4, 7, and 12. The
+`completion-preview` scenario additionally requires `--fixture-task-id` and
+never writes. Its artifacts contain aggregate timings and classifications only;
+raw MCP arguments and responses are not persisted.
 
 ## 4. Release Flow
 


### PR DESCRIPTION
Closes #176
Supports #170

## What changed

- Added `focusrelay-dev bridge-burst` with required
  `canary`/`smoke`/`release`/`stress` profiles.
- Added direct stdio MCP initialization, request correlation, fixed concurrent
  bursts at 2/4/7/12, a 15-second diagnostic deadline, cancellation
  notifications, bounded shutdown, and a 25-second heartbeat.
- Added safe `task-counts` and write-free `completion-preview` scenarios.
- Added aggregate latency/failure summaries and privacy-sanitized JSON artifacts
  under `.build/benchmarks`.
- Documented when and how to use the harness.

## Why

Interactive OpenCode UAT exposed concurrent Bridge preview failures, but the
existing benchmark scripts were sequential and could not reproduce the public
MCP request shape. #170 needs a comparable baseline and candidate measurement
before an admission policy can be selected.

## User and developer impact

Maintainers can now measure real MCP burst reliability without exposing or
persisting OmniFocus content. This is developer-only tooling; no production
Bridge dispatch, MCP schema, query, mutation, or cache behavior changes.

## Validation impact

`performance`

## Acceptance journey

A maintainer selects an explicit profile and scenario, launches an exact
FocusRelay binary through the harness, measures concurrency 2/4/7/12, sees
aggregate results and heartbeats, and receives a sanitized artifact suitable
for comparing #170 before and after behavior.

## Automated validation

- `swift run focusrelay-dev validate --impact performance --base origin/master`
  was attempted; the current validator still rejects the documented `--base`
  option.
- `swift run focusrelay-dev validate --impact performance`
  - 202 Swift Testing tests passed.
  - All live semantic gates passed.
- Ten focused harness tests cover profiles, preview-only arguments, response
  classification, out-of-order correlation, cancellation, deadline, failure
  circuit breaking, fixed concurrency, unique request IDs, percentiles, and
  artifact privacy.
- Local Markdown links and `git diff --check` pass.
- The command help proves `--profile` and `--scenario` are required.

## Sanitized live baseline

The Bridge was installed with the repository script, OmniFocus was restarted
once, and both canaries used the exact release server through stdio MCP. No
task, project, tag, note, ID, path, session, account, or raw response content is
included.

Task-count canary:

- Sequential: 12/12 succeeded; p95 396 ms.
- Concurrency 2: 2/2 succeeded; p95 657 ms.
- Concurrency 4: 4/4 succeeded; p95 1,189 ms.
- Concurrency 7: 7/7 succeeded; p95 2,045 ms.
- Concurrency 12: 12/12 succeeded; p95 3,478 ms.

Completion-preview canary:

- Sequential: 3/3 succeeded; p95 6,762 ms.
- Concurrency 2: 2/2 succeeded; p95 14,908 ms.
- Concurrency 4: 2/4 succeeded and 2 hit the diagnostic deadline.
- Concurrency 7: 0/7 succeeded before the diagnostic deadline.
- Concurrency 12: 0/12 succeeded before the diagnostic deadline.

Every completion request used `previewOnly=true`; no write occurred. All canary
artifacts were scanned for private paths, fixture IDs, arguments, target IDs,
and raw response content.
