### PR TITLE
Bound concurrent Bridge dispatch

### DIFF
--- a/Sources/FocusRelayCLI/BenchmarkGateCheckCommand.swift
+++ b/Sources/FocusRelayCLI/BenchmarkGateCheckCommand.swift
@@ -104,7 +104,7 @@ func gateTaskCountContractScenarios() -> [GateTaskCountScenario] {
 
 private func checkBridgeHealth(using service: OmniFocusBridgeService) async -> GateCheck {
     do {
-        let result = try service.healthCheck()
+        let result = try await service.healthCheck()
         return GateCheck(
             name: "bridge_health",
             ok: result.ok,

--- a/Sources/FocusRelayCLI/BenchmarkListTasksCommand.swift
+++ b/Sources/FocusRelayCLI/BenchmarkListTasksCommand.swift
@@ -208,7 +208,7 @@ private func listTaskBenchCall(
             try? await Task.sleep(nanoseconds: UInt64(cooldownMS) * 1_000_000)
         }
         if timeout {
-            let diagnostic = captureBenchmarkTimeoutDiagnostic(
+            let diagnostic = await captureBenchmarkTimeoutDiagnostic(
                 scenario: scenario.name,
                 phase: phase,
                 callIndex: callIndex,

--- a/Sources/FocusRelayCLI/BenchmarkSupport.swift
+++ b/Sources/FocusRelayCLI/BenchmarkSupport.swift
@@ -135,7 +135,7 @@ func runCountBenchmarkCall<Counts: Codable>(
             try? await Task.sleep(nanoseconds: UInt64(cooldownMS) * 1_000_000)
         }
         if timeout {
-            let diagnostic = captureBenchmarkTimeoutDiagnostic(
+            let diagnostic = await captureBenchmarkTimeoutDiagnostic(
                 scenario: scenario,
                 phase: phase,
                 callIndex: callIndex,
@@ -246,7 +246,7 @@ func runBenchmarkTimeoutRecoveryGate() async {
     if recoveryMS > 0 {
         try? await Task.sleep(nanoseconds: UInt64(recoveryMS) * 1_000_000)
     }
-    _ = try? OmniFocusBridgeService().healthCheck()
+    _ = try? await OmniFocusBridgeService().healthCheck()
 }
 
 func enforceBenchmarkInterval(started: Date, intervalMS: Int) async throws {
@@ -379,7 +379,7 @@ func captureBenchmarkTimeoutDiagnostic(
     callIndex: Int,
     latencyMs: Double,
     errorMessage: String
-) -> BenchmarkTimeoutDiagnostic {
+) async -> BenchmarkTimeoutDiagnostic {
     let requestID = extractBenchmarkRequestID(from: errorMessage)
     let baseURL = defaultBenchmarkIPCBaseURL()
     let requestsURL = baseURL.appendingPathComponent("requests", isDirectory: true)
@@ -388,7 +388,7 @@ func captureBenchmarkTimeoutDiagnostic(
     let omniPID = currentOmniFocusPID()
     let benchmarkPID = ProcessInfo.processInfo.processIdentifier
     let bridgeHealth: BenchmarkTimeoutBridgeHealthSnapshot
-    if let result = try? OmniFocusBridgeService().healthCheck() {
+    if let result = try? await OmniFocusBridgeService().healthCheck() {
         bridgeHealth = BenchmarkTimeoutBridgeHealthSnapshot(
             ok: result.ok,
             detail: "plugin=\(result.plugin ?? "unknown") version=\(result.version ?? "unknown")"

--- a/Sources/FocusRelayCLI/FocusRelayCLI.swift
+++ b/Sources/FocusRelayCLI/FocusRelayCLI.swift
@@ -450,7 +450,7 @@ struct BridgeHealthCheck: AsyncParsableCommand {
 
     func run() async throws {
         let service = OmniFocusBridgeService()
-        let result = try service.healthCheck()
+        let result = try await service.healthCheck()
         print(try encodeJSON(result))
     }
 }

--- a/Sources/FocusRelayServer/FocusRelayServer.swift
+++ b/Sources/FocusRelayServer/FocusRelayServer.swift
@@ -764,8 +764,6 @@ public enum FocusRelayServer {
 
                 switch params.name {
                 case "list_tasks":
-                    // Debug: Log raw arguments
-                    logger.info("list_tasks called with arguments: \(String(describing: params.arguments))")
                     let filter: TaskFilter
                     do {
                         filter = try decodeArgument(TaskFilter.self, from: params.arguments, key: "filter") ?? TaskFilter()
@@ -881,6 +879,11 @@ public enum FocusRelayServer {
                 default:
                     return .init(content: [.text(text: "Unknown tool: \(params.name)", annotations: nil, _meta: nil)], isError: true)
                 }
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch let error as BridgeAdmissionError {
+                logger.notice("Tool call rejected by Bridge admission: \(error.code)")
+                return bridgeAdmissionErrorResult(error)
             } catch {
                 logger.error("Tool call failed: \(error.localizedDescription)")
                 return .init(content: [.text(text: "Error: \(error.localizedDescription)", annotations: nil, _meta: nil)], isError: true)
@@ -892,6 +895,24 @@ public enum FocusRelayServer {
         while true {
             try await Task.sleep(nanoseconds: 60 * 60 * 24 * 1_000_000_000)
         }
+    }
+
+    static func bridgeAdmissionErrorResult(_ error: BridgeAdmissionError) -> CallTool.Result {
+        .init(
+            content: [
+                .text(
+                    text: error.localizedDescription,
+                    annotations: nil,
+                    _meta: nil
+                )
+            ],
+            structuredContent: .object([
+                "code": .string(error.code),
+                "retryable": .bool(true),
+                "retryAfterMilliseconds": .int(error.retryAfterMilliseconds)
+            ]),
+            isError: true
+        )
     }
 
     static func decodeArgument<T: Decodable>(_ type: T.Type, from args: [String: Value]?, key: String) throws -> T? {

--- a/Sources/OmniFocusAutomation/BridgeRequestCoordinator.swift
+++ b/Sources/OmniFocusAutomation/BridgeRequestCoordinator.swift
@@ -1,0 +1,473 @@
+import Dispatch
+import Foundation
+import OSLog
+import Synchronization
+
+public enum BridgeAdmissionError: Error, Equatable, LocalizedError, Sendable {
+    case busy(retryAfterMilliseconds: Int)
+    case queueTimeout(retryAfterMilliseconds: Int)
+
+    public var code: String {
+        switch self {
+        case .busy:
+            "bridge_busy"
+        case .queueTimeout:
+            "bridge_queue_timeout"
+        }
+    }
+
+    public var retryAfterMilliseconds: Int {
+        switch self {
+        case .busy(let retryAfterMilliseconds), .queueTimeout(let retryAfterMilliseconds):
+            retryAfterMilliseconds
+        }
+    }
+
+    public var errorDescription: String? {
+        switch self {
+        case .busy:
+            "OmniFocus Bridge is busy. Retry after \(retryAfterMilliseconds) ms."
+        case .queueTimeout:
+            "OmniFocus Bridge queue wait expired. Retry after \(retryAfterMilliseconds) ms."
+        }
+    }
+}
+
+enum BridgeOperationCategory: String, Sendable {
+    case taskQuery = "task_query"
+    case projectQuery = "project_query"
+    case tagQuery = "tag_query"
+    case folderQuery = "folder_query"
+    case countsQuery = "counts_query"
+    case mutationPreview = "mutation_preview"
+    case mutationApply = "mutation_apply"
+    case health
+}
+
+struct BridgeCoordinatorPolicy: Equatable, Sendable {
+    let maximumAcceptedRequests: Int
+    let maximumQueueWait: Duration
+    let retryAfterMilliseconds: Int
+
+    // Calibrated from the sanitized completion-preview baseline recorded in #170.
+    static let production = BridgeCoordinatorPolicy(
+        maximumAcceptedRequests: 7,
+        maximumQueueWait: .seconds(43),
+        retryAfterMilliseconds: 6_750
+    )
+}
+
+private enum BridgeJobLifecycle: Sendable {
+    case queued
+    case dispatchCommitted
+    case finished
+}
+
+private enum BridgeCancellationOutcome: Sendable {
+    case queued
+    case dispatchCommitted
+    case alreadyFinished
+}
+
+private final class BridgeJobState<Value: Sendable>: Sendable {
+    private struct Storage {
+        var lifecycle = BridgeJobLifecycle.queued
+        var continuation: CheckedContinuation<Value, any Error>?
+        var callerResult: Result<Value, any Error>?
+    }
+
+    // The actor owns queue membership. This mutex decides the smaller
+    // cancellation-vs-dispatch race without waiting for another actor hop.
+    private let storage = Mutex(Storage())
+
+    var isQueued: Bool {
+        storage.withLock { $0.lifecycle == .queued }
+    }
+
+    func installContinuation(_ continuation: CheckedContinuation<Value, any Error>) {
+        let result = storage.withLock { state -> Result<Value, any Error>? in
+            if let callerResult = state.callerResult {
+                return callerResult
+            }
+            state.continuation = continuation
+            return nil
+        }
+        if let result {
+            continuation.resume(with: result)
+        }
+    }
+
+    func commitDispatch() -> Bool {
+        storage.withLock { state in
+            guard state.lifecycle == .queued else {
+                return false
+            }
+            state.lifecycle = .dispatchCommitted
+            return true
+        }
+    }
+
+    func cancelCaller() -> BridgeCancellationOutcome {
+        let cancellation = Result<Value, any Error>.failure(CancellationError())
+        let outcome = storage.withLock {
+            state -> (BridgeCancellationOutcome, CheckedContinuation<Value, any Error>?) in
+            switch state.lifecycle {
+            case .queued:
+                state.lifecycle = .finished
+                state.callerResult = cancellation
+                let continuation = state.continuation
+                state.continuation = nil
+                return (.queued, continuation)
+            case .dispatchCommitted:
+                guard state.callerResult == nil else {
+                    return (.dispatchCommitted, nil)
+                }
+                state.callerResult = cancellation
+                let continuation = state.continuation
+                state.continuation = nil
+                return (.dispatchCommitted, continuation)
+            case .finished:
+                return (.alreadyFinished, nil)
+            }
+        }
+        outcome.1?.resume(with: cancellation)
+        return outcome.0
+    }
+
+    @discardableResult
+    func failBeforeDispatch(_ error: any Error) -> Bool {
+        let failure = Result<Value, any Error>.failure(error)
+        let outcome = storage.withLock {
+            state -> (Bool, CheckedContinuation<Value, any Error>?) in
+            guard state.lifecycle == .queued else {
+                return (false, nil)
+            }
+            state.lifecycle = .finished
+            state.callerResult = failure
+            let continuation = state.continuation
+            state.continuation = nil
+            return (true, continuation)
+        }
+        outcome.1?.resume(with: failure)
+        return outcome.0
+    }
+
+    func finish(_ result: Result<Value, any Error>) {
+        let continuation = storage.withLock { state -> CheckedContinuation<Value, any Error>? in
+            guard state.lifecycle == .dispatchCommitted else {
+                return nil
+            }
+            state.lifecycle = .finished
+            guard state.callerResult == nil else {
+                return nil
+            }
+            state.callerResult = result
+            let continuation = state.continuation
+            state.continuation = nil
+            return continuation
+        }
+        continuation?.resume(with: result)
+    }
+}
+
+private struct BridgeQueuedJob: Sendable {
+    let id: UUID
+    let category: BridgeOperationCategory
+    let enqueuedAt: Date
+    let isQueued: @Sendable () -> Bool
+    let commitDispatch: @Sendable () -> Bool
+    let failBeforeDispatch: @Sendable (any Error) -> Bool
+    let run: @Sendable () async -> Void
+    var timeoutTask: Task<Void, Never>?
+}
+
+private struct BridgeCoordinatorShutdownError: Error, LocalizedError, Sendable {
+    var errorDescription: String? {
+        "OmniFocus Bridge coordinator is shutting down."
+    }
+}
+
+actor BridgeRequestCoordinator {
+    private let policy: BridgeCoordinatorPolicy
+    private let logger: Logger?
+    private var queue: [BridgeQueuedJob] = []
+    private var runningJobID: UUID?
+    private var acceptingRequests = true
+
+    init(
+        policy: BridgeCoordinatorPolicy = .production,
+        logger: Logger? = Logger(
+            subsystem: "com.focusrelay.mcp",
+            category: "bridge-coordinator"
+        )
+    ) {
+        precondition(policy.maximumAcceptedRequests > 0)
+        precondition(policy.maximumQueueWait > .zero)
+        self.policy = policy
+        self.logger = logger
+    }
+
+    func submit<Value: Sendable>(
+        category: BridgeOperationCategory,
+        operation: @escaping @Sendable () async throws -> Value
+    ) async throws -> Value {
+        try Task.checkCancellation()
+        removeFinishedQueuedJobs()
+
+        guard acceptingRequests else {
+            throw BridgeCoordinatorShutdownError()
+        }
+        guard acceptedRequestCount < policy.maximumAcceptedRequests else {
+            logger?.notice(
+                "event=bridge_busy operation=\(category.rawValue, privacy: .public) accepted=\(self.acceptedRequestCount, privacy: .public)"
+            )
+            throw BridgeAdmissionError.busy(
+                retryAfterMilliseconds: policy.retryAfterMilliseconds
+            )
+        }
+
+        let id = UUID()
+        let enqueuedAt = Date()
+        let state = BridgeJobState<Value>()
+        let jobLogger = logger
+        var job = BridgeQueuedJob(
+            id: id,
+            category: category,
+            enqueuedAt: enqueuedAt,
+            isQueued: { state.isQueued },
+            commitDispatch: { state.commitDispatch() },
+            failBeforeDispatch: { error in state.failBeforeDispatch(error) },
+            run: {
+                let workerStartedAt = Date()
+                do {
+                    let value = try await operation()
+                    state.finish(.success(value))
+                    let finishedAt = Date()
+                    let workerMilliseconds = finishedAt.timeIntervalSince(workerStartedAt) * 1_000
+                    let totalMilliseconds = finishedAt.timeIntervalSince(enqueuedAt) * 1_000
+                    jobLogger?.info(
+                        "event=bridge_finished operation=\(category.rawValue, privacy: .public) result=success workerMilliseconds=\(workerMilliseconds, privacy: .public) totalMilliseconds=\(totalMilliseconds, privacy: .public)"
+                    )
+                } catch {
+                    state.finish(.failure(error))
+                    let finishedAt = Date()
+                    let workerMilliseconds = finishedAt.timeIntervalSince(workerStartedAt) * 1_000
+                    let totalMilliseconds = finishedAt.timeIntervalSince(enqueuedAt) * 1_000
+                    jobLogger?.error(
+                        "event=bridge_finished operation=\(category.rawValue, privacy: .public) result=failure workerMilliseconds=\(workerMilliseconds, privacy: .public) totalMilliseconds=\(totalMilliseconds, privacy: .public)"
+                    )
+                }
+            },
+            timeoutTask: nil
+        )
+
+        queue.append(job)
+        let maximumQueueWait = policy.maximumQueueWait
+        let timeoutTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: maximumQueueWait)
+                await self?.expireQueuedJob(id: id)
+            } catch is CancellationError {
+                return
+            } catch {
+                return
+            }
+        }
+        job.timeoutTask = timeoutTask
+        if let index = queue.firstIndex(where: { $0.id == id }) {
+            queue[index] = job
+        } else {
+            timeoutTask.cancel()
+        }
+
+        logger?.info(
+            "event=bridge_accepted operation=\(category.rawValue, privacy: .public) queueDepth=\(self.queue.count, privacy: .public)"
+        )
+        startNextIfNeeded()
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                state.installContinuation(continuation)
+            }
+        } onCancel: {
+            let outcome = state.cancelCaller()
+            Task { [weak self] in
+                await self?.callerCanceled(jobID: id, category: category, outcome: outcome)
+            }
+        }
+    }
+
+    func shutdown() {
+        acceptingRequests = false
+        let queued = queue
+        queue.removeAll(keepingCapacity: false)
+        for job in queued {
+            job.timeoutTask?.cancel()
+            _ = job.failBeforeDispatch(BridgeCoordinatorShutdownError())
+        }
+    }
+
+    func snapshot() -> (running: Int, queued: Int, accepted: Int) {
+        removeFinishedQueuedJobs()
+        return (
+            running: runningJobID == nil ? 0 : 1,
+            queued: queue.count,
+            accepted: acceptedRequestCount
+        )
+    }
+
+    private var acceptedRequestCount: Int {
+        (runningJobID == nil ? 0 : 1) + queue.count
+    }
+
+    private func startNextIfNeeded() {
+        guard runningJobID == nil else {
+            return
+        }
+
+        while !queue.isEmpty {
+            let job = queue.removeFirst()
+            job.timeoutTask?.cancel()
+            guard job.commitDispatch() else {
+                continue
+            }
+
+            runningJobID = job.id
+            let queueWaitMilliseconds = Date().timeIntervalSince(job.enqueuedAt) * 1_000
+            logger?.info(
+                "event=bridge_dispatch_committed operation=\(job.category.rawValue, privacy: .public) queueWaitMilliseconds=\(queueWaitMilliseconds, privacy: .public) remainingQueueDepth=\(self.queue.count, privacy: .public)"
+            )
+            Task { @concurrent [job, weak self] in
+                await job.run()
+                await self?.jobFinished(id: job.id)
+            }
+            return
+        }
+    }
+
+    private func jobFinished(id: UUID) {
+        guard runningJobID == id else {
+            return
+        }
+        runningJobID = nil
+        startNextIfNeeded()
+    }
+
+    private func expireQueuedJob(id: UUID) {
+        guard let index = queue.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        let job = queue.remove(at: index)
+        let timeoutWon = job.failBeforeDispatch(
+            BridgeAdmissionError.queueTimeout(
+                retryAfterMilliseconds: policy.retryAfterMilliseconds
+            )
+        )
+        if timeoutWon {
+            logger?.notice(
+                "event=bridge_queue_timeout operation=\(job.category.rawValue, privacy: .public) queueDepth=\(self.queue.count, privacy: .public)"
+            )
+        }
+    }
+
+    private func callerCanceled(
+        jobID: UUID,
+        category: BridgeOperationCategory,
+        outcome: BridgeCancellationOutcome
+    ) {
+        switch outcome {
+        case .queued:
+            if let index = queue.firstIndex(where: { $0.id == jobID }) {
+                let job = queue.remove(at: index)
+                job.timeoutTask?.cancel()
+            }
+            logger?.info(
+                "event=bridge_canceled_before_dispatch operation=\(category.rawValue, privacy: .public) queueDepth=\(self.queue.count, privacy: .public)"
+            )
+        case .dispatchCommitted:
+            logger?.info(
+                "event=bridge_canceled_after_commit operation=\(category.rawValue, privacy: .public)"
+            )
+        case .alreadyFinished:
+            break
+        }
+    }
+
+    private func removeFinishedQueuedJobs() {
+        var retained: [BridgeQueuedJob] = []
+        retained.reserveCapacity(queue.count)
+        for job in queue {
+            if job.isQueued() {
+                retained.append(job)
+            } else {
+                job.timeoutTask?.cancel()
+            }
+        }
+        queue = retained
+    }
+}
+
+final class BridgeBlockingExecutor: Sendable {
+    private let queue: DispatchQueue
+    private let logger: Logger?
+
+    init(
+        queue: DispatchQueue = DispatchQueue(
+            label: "com.focusrelay.mcp.bridge-executor",
+            qos: .userInitiated
+        ),
+        logger: Logger? = Logger(
+            subsystem: "com.focusrelay.mcp",
+            category: "bridge-executor"
+        )
+    ) {
+        self.queue = queue
+        self.logger = logger
+    }
+
+    func run<Value: Sendable>(
+        category: BridgeOperationCategory,
+        _ operation: @escaping @Sendable () throws -> Value
+    ) async throws -> Value {
+        let submittedAt = Date()
+        return try await withTaskExecutorPreference(queue) {
+            let startedAt = Date()
+            let handoffMilliseconds = startedAt.timeIntervalSince(submittedAt) * 1_000
+            defer {
+                let executionMilliseconds = Date().timeIntervalSince(startedAt) * 1_000
+                logger?.info(
+                    "event=bridge_executor_finished operation=\(category.rawValue, privacy: .public) handoffMilliseconds=\(handoffMilliseconds, privacy: .public) executionMilliseconds=\(executionMilliseconds, privacy: .public)"
+                )
+            }
+            return try operation()
+        }
+    }
+}
+
+final class BridgeRuntime: Sendable {
+    // Every service instance in one server process shares the same admission
+    // lane and blocking executor. Catalog caches remain service-owned.
+    static let shared = BridgeRuntime()
+
+    let coordinator: BridgeRequestCoordinator
+    let executor: BridgeBlockingExecutor
+
+    init(
+        coordinator: BridgeRequestCoordinator = BridgeRequestCoordinator(),
+        executor: BridgeBlockingExecutor = BridgeBlockingExecutor()
+    ) {
+        self.coordinator = coordinator
+        self.executor = executor
+    }
+
+    func submit<Value: Sendable>(
+        category: BridgeOperationCategory,
+        bridge: @escaping @Sendable () throws -> Value,
+        finalize: @escaping @Sendable (Value) async throws -> Value = { $0 }
+    ) async throws -> Value {
+        try await coordinator.submit(category: category) {
+            let value = try await self.executor.run(category: category, bridge)
+            return try await finalize(value)
+        }
+    }
+}

--- a/Sources/OmniFocusAutomation/BridgeRequestCoordinator.swift
+++ b/Sources/OmniFocusAutomation/BridgeRequestCoordinator.swift
@@ -241,6 +241,7 @@ actor BridgeRequestCoordinator {
                 let workerStartedAt = Date()
                 do {
                     let value = try await operation()
+                    await self.jobFinished(id: id)
                     state.finish(.success(value))
                     let finishedAt = Date()
                     let workerMilliseconds = finishedAt.timeIntervalSince(workerStartedAt) * 1_000
@@ -249,6 +250,7 @@ actor BridgeRequestCoordinator {
                         "event=bridge_finished operation=\(category.rawValue, privacy: .public) result=success workerMilliseconds=\(workerMilliseconds, privacy: .public) totalMilliseconds=\(totalMilliseconds, privacy: .public)"
                     )
                 } catch {
+                    await self.jobFinished(id: id)
                     state.finish(.failure(error))
                     let finishedAt = Date()
                     let workerMilliseconds = finishedAt.timeIntervalSince(workerStartedAt) * 1_000
@@ -337,9 +339,8 @@ actor BridgeRequestCoordinator {
             logger?.info(
                 "event=bridge_dispatch_committed operation=\(job.category.rawValue, privacy: .public) queueWaitMilliseconds=\(queueWaitMilliseconds, privacy: .public) remainingQueueDepth=\(self.queue.count, privacy: .public)"
             )
-            Task { @concurrent [job, weak self] in
+            Task { @concurrent [job] in
                 await job.run()
-                await self?.jobFinished(id: job.id)
             }
             return
         }

--- a/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
+++ b/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
@@ -3,11 +3,20 @@ import OmniFocusCore
 
 public final class OmniFocusBridgeService: OmniFocusService {
     private let client: BridgeClient
-    private let cache = CatalogCache()
+    private let cache: CatalogCache
+    private let runtime: BridgeRuntime
     private let cacheTTL: TimeInterval = 300
 
     public init() {
         self.client = BridgeClient()
+        self.cache = CatalogCache()
+        self.runtime = .shared
+    }
+
+    init(client: BridgeClient, cache: CatalogCache, runtime: BridgeRuntime) {
+        self.client = client
+        self.cache = cache
+        self.runtime = runtime
     }
 
     public func setWarningsHandler(_ handler: (@Sendable (_ warnings: [String], _ op: String) -> Void)?) {
@@ -17,14 +26,16 @@ public final class OmniFocusBridgeService: OmniFocusService {
     public func listTasks(filter: TaskFilter, page: PageRequest, fields: [String]?) async throws -> Page<TaskItem> {
         let identity = try QueryBoundCursor.taskIdentity(for: filter)
         let bridgePage = try QueryBoundCursor.bridgePage(from: page, identity: identity)
-        let result = try await Task.detached {
+        let result = try await runtime.submit(category: .taskQuery) {
             try self.client.listTasks(filter: filter, page: bridgePage, fields: fields)
-        }.value
+        }
         return try QueryBoundCursor.publicPage(from: result, identity: identity)
     }
 
     public func getTask(id: String, fields: [String]?) async throws -> TaskItem {
-        return try await Task.detached { try self.client.getTask(id: id, fields: fields) }.value
+        try await runtime.submit(category: .taskQuery) {
+            try self.client.getTask(id: id, fields: fields)
+        }
     }
 
     public func listProjects(
@@ -69,26 +80,32 @@ public final class OmniFocusBridgeService: OmniFocusService {
             if let cached = await cache.getProjects(key: key) {
                 return try QueryBoundCursor.publicPage(from: cached, identity: identity)
             }
-            let pageResult = try await Task.detached {
-                try self.client.listProjects(
-                    page: bridgePage,
-                    statusFilter: statusFilter,
-                    includeTaskCounts: includeTaskCounts,
-                    search: normalizedSearch,
-                    reviewDueBefore: reviewDueBefore,
-                    reviewDueAfter: reviewDueAfter,
-                    reviewPerspective: reviewPerspective,
-                    completed: completed,
-                    completedBefore: completedBefore,
-                    completedAfter: completedAfter,
-                    fields: fields
-                )
-            }.value
-            await cache.setProjects(pageResult, key: key, ttl: cacheTTL)
+            let pageResult = try await runtime.submit(
+                category: .projectQuery,
+                bridge: {
+                    try self.client.listProjects(
+                        page: bridgePage,
+                        statusFilter: statusFilter,
+                        includeTaskCounts: includeTaskCounts,
+                        search: normalizedSearch,
+                        reviewDueBefore: reviewDueBefore,
+                        reviewDueAfter: reviewDueAfter,
+                        reviewPerspective: reviewPerspective,
+                        completed: completed,
+                        completedBefore: completedBefore,
+                        completedAfter: completedAfter,
+                        fields: fields
+                    )
+                },
+                finalize: { pageResult in
+                    await self.cache.setProjects(pageResult, key: key, ttl: self.cacheTTL)
+                    return pageResult
+                }
+            )
             return try QueryBoundCursor.publicPage(from: pageResult, identity: identity)
         }
 
-        let pageResult = try await Task.detached {
+        let pageResult = try await runtime.submit(category: .projectQuery) {
             try self.client.listProjects(
                 page: bridgePage,
                 statusFilter: statusFilter,
@@ -102,7 +119,7 @@ public final class OmniFocusBridgeService: OmniFocusService {
                 completedAfter: completedAfter,
                 fields: fields
             )
-        }.value
+        }
         return try QueryBoundCursor.publicPage(from: pageResult, identity: identity)
     }
 
@@ -142,16 +159,22 @@ public final class OmniFocusBridgeService: OmniFocusService {
         if let cached = await cache.getTags(key: key) {
             return try QueryBoundCursor.publicPage(from: cached, identity: identity)
         }
-        let pageResult = try await Task.detached {
-            try self.client.listTags(
-                page: bridgePage,
-                statusFilter: statusFilter,
-                includeTaskCounts: includeTaskCounts,
-                search: normalizedSearch,
-                fields: fields
-            )
-        }.value
-        await cache.setTags(pageResult, key: key, ttl: cacheTTL)
+        let pageResult = try await runtime.submit(
+            category: .tagQuery,
+            bridge: {
+                try self.client.listTags(
+                    page: bridgePage,
+                    statusFilter: statusFilter,
+                    includeTaskCounts: includeTaskCounts,
+                    search: normalizedSearch,
+                    fields: fields
+                )
+            },
+            finalize: { pageResult in
+                await self.cache.setTags(pageResult, key: key, ttl: self.cacheTTL)
+                return pageResult
+            }
+        )
         return try QueryBoundCursor.publicPage(from: pageResult, identity: identity)
     }
 
@@ -172,36 +195,50 @@ public final class OmniFocusBridgeService: OmniFocusService {
             input: "stable-folder-order-v1"
         )
         let bridgePage = try QueryBoundCursor.bridgePage(from: page, identity: identity)
-        let result = try await Task.detached {
+        let result = try await runtime.submit(category: .folderQuery) {
             try self.client.listFolders(page: bridgePage, fields: fields)
-        }.value
+        }
         return try QueryBoundCursor.publicPage(from: result, identity: identity)
     }
 
     public func getTaskCounts(filter: TaskFilter) async throws -> TaskCounts {
-        return try await Task.detached { try self.client.getTaskCounts(filter: filter) }.value
+        try await runtime.submit(category: .countsQuery) {
+            try self.client.getTaskCounts(filter: filter)
+        }
     }
 
     public func getProjectCounts(filter: TaskFilter) async throws -> ProjectCounts {
-        return try await Task.detached { try self.client.getProjectCounts(filter: filter) }.value
+        try await runtime.submit(category: .countsQuery) {
+            try self.client.getProjectCounts(filter: filter)
+        }
     }
 
     public func performMutation(_ request: MutationRequest) async throws -> MutationResponse {
-        let response = try await Task.detached { try self.client.performMutation(request) }.value
-        if !request.previewOnly && response.successCount > 0 {
-            await cache.invalidateAll()
-        }
-        return response
+        let category: BridgeOperationCategory = request.previewOnly ? .mutationPreview : .mutationApply
+        return try await runtime.submit(
+            category: category,
+            bridge: {
+                try self.client.performMutation(request)
+            },
+            finalize: { response in
+                if !request.previewOnly && response.successCount > 0 {
+                    await self.cache.invalidateAll()
+                }
+                return response
+            }
+        )
     }
 
-    public func healthCheck() throws -> BridgeHealthResult {
-        let response = try client.ping()
-        return BridgeHealthResult(
-            ok: response.ok,
-            plugin: response.data?.plugin,
-            version: response.data?.version,
-            error: response.error?.message
-        )
+    public func healthCheck() async throws -> BridgeHealthResult {
+        try await runtime.submit(category: .health) {
+            let response = try self.client.ping()
+            return BridgeHealthResult(
+                ok: response.ok,
+                plugin: response.data?.plugin,
+                version: response.data?.version,
+                error: response.error?.message
+            )
+        }
     }
 }
 

--- a/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
+++ b/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
@@ -583,6 +583,42 @@ private func toolErrorText(_ response: [String: Any]?) -> String {
 }
 
 @Test
+func bridgeAdmissionErrorsEncodeAsStructuredMCPToolFailures() throws {
+    let cases: [(BridgeAdmissionError, String)] = [
+        (.busy(retryAfterMilliseconds: 6_750), "bridge_busy"),
+        (.queueTimeout(retryAfterMilliseconds: 6_750), "bridge_queue_timeout")
+    ]
+
+    for (error, expectedCode) in cases {
+        let result = FocusRelayServer.bridgeAdmissionErrorResult(error)
+        #expect(result.isError == true)
+
+        guard case .object(let structured) = result.structuredContent else {
+            Issue.record("Expected structured Bridge admission content")
+            continue
+        }
+        #expect(structured["code"] == .string(expectedCode))
+        #expect(structured["retryable"] == .bool(true))
+        #expect(structured["retryAfterMilliseconds"] == .int(6_750))
+
+        let encoded = try JSONEncoder().encode(result)
+        let wire = try #require(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        #expect(wire["isError"] as? Bool == true)
+        let wireStructured = try #require(wire["structuredContent"] as? [String: Any])
+        #expect(wireStructured["code"] as? String == expectedCode)
+        #expect(wireStructured["retryable"] as? Bool == true)
+        #expect(wireStructured["retryAfterMilliseconds"] as? Int == 6_750)
+
+        let wireText = String(decoding: encoded, as: UTF8.self)
+        #expect(!wireText.contains("targetIDs"))
+        #expect(!wireText.contains("arguments"))
+        #expect(!wireText.contains("/Users/"))
+    }
+}
+
+@Test
 func taskEditWireArgumentsDispatchEveryOperation() throws {
     let update = try FocusRelayServer.decodeTaskEditRequest(from: [
         "operation": .string("update"),

--- a/Tests/OmniFocusIntegrationTests/BridgeRequestCoordinatorTests.swift
+++ b/Tests/OmniFocusIntegrationTests/BridgeRequestCoordinatorTests.swift
@@ -1,0 +1,439 @@
+import Dispatch
+import Foundation
+import Synchronization
+import Testing
+@testable import OmniFocusAutomation
+
+private actor CoordinatorGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isOpen else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        isOpen = true
+        let continuations = waiters
+        waiters.removeAll()
+        for continuation in continuations {
+            continuation.resume()
+        }
+    }
+}
+
+private actor CoordinatorProbe {
+    private(set) var active = 0
+    private(set) var maximumActive = 0
+    private(set) var starts: [String] = []
+    private(set) var finishes: [String] = []
+
+    func begin(_ label: String) {
+        active += 1
+        maximumActive = max(maximumActive, active)
+        starts.append(label)
+    }
+
+    func finish(_ label: String) {
+        finishes.append(label)
+        active -= 1
+    }
+
+    func snapshot() -> (active: Int, maximumActive: Int, starts: [String], finishes: [String]) {
+        (active, maximumActive, starts, finishes)
+    }
+}
+
+private final class LockedCounter: Sendable {
+    private let value = Mutex(0)
+
+    func increment() {
+        value.withLock { $0 += 1 }
+    }
+
+    var current: Int {
+        value.withLock { $0 }
+    }
+}
+
+private enum CoordinatorTestError: Error {
+    case expected
+}
+
+private func waitForCoordinator(
+    timeout: Duration = .seconds(2),
+    _ condition: @escaping @Sendable () async -> Bool
+) async throws {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: timeout)
+    while clock.now < deadline {
+        if await condition() {
+            return
+        }
+        try await Task.sleep(for: .milliseconds(1))
+    }
+    Issue.record("Timed out waiting for coordinator state")
+}
+
+private func expectCancellation<Value>(_ task: Task<Value, any Error>) async {
+    do {
+        _ = try await task.value
+        Issue.record("Expected CancellationError")
+    } catch is CancellationError {
+        // Expected.
+    } catch {
+        Issue.record("Expected CancellationError, received \(error)")
+    }
+}
+
+@Test
+func productionBridgeAdmissionPolicyMatchesMeasuredBaseline() {
+    let policy = BridgeCoordinatorPolicy.production
+    #expect(policy.maximumAcceptedRequests == 7)
+    #expect(policy.maximumQueueWait == .seconds(43))
+    #expect(policy.retryAfterMilliseconds == 6_750)
+}
+
+@Test
+func bridgeCoordinatorRunsMixedOperationsInFIFOOrderWithOneActiveJob() async throws {
+    let coordinator = BridgeRequestCoordinator(logger: nil)
+    let firstGate = CoordinatorGate()
+    let probe = CoordinatorProbe()
+
+    func makeTask(
+        label: String,
+        category: BridgeOperationCategory,
+        gate: CoordinatorGate? = nil
+    ) -> Task<String, any Error> {
+        Task {
+            try await coordinator.submit(category: category) {
+                await probe.begin(label)
+                if let gate {
+                    await gate.wait()
+                }
+                await probe.finish(label)
+                return label
+            }
+        }
+    }
+
+    let first = makeTask(label: "health", category: .health, gate: firstGate)
+    try await waitForCoordinator {
+        await coordinator.snapshot().running == 1
+    }
+
+    let second = makeTask(label: "read", category: .taskQuery)
+    try await waitForCoordinator {
+        await coordinator.snapshot().queued == 1
+    }
+    let third = makeTask(label: "preview", category: .mutationPreview)
+    try await waitForCoordinator {
+        await coordinator.snapshot().queued == 2
+    }
+    let fourth = makeTask(label: "apply", category: .mutationApply)
+    try await waitForCoordinator {
+        await coordinator.snapshot().queued == 3
+    }
+
+    await firstGate.open()
+    #expect(try await first.value == "health")
+    #expect(try await second.value == "read")
+    #expect(try await third.value == "preview")
+    #expect(try await fourth.value == "apply")
+
+    let snapshot = await probe.snapshot()
+    #expect(snapshot.starts == ["health", "read", "preview", "apply"])
+    #expect(snapshot.finishes == ["health", "read", "preview", "apply"])
+    #expect(snapshot.maximumActive == 1)
+}
+
+@Test
+func failedBridgeJobReleasesLaneForNextQueuedRequest() async throws {
+    let coordinator = BridgeRequestCoordinator(logger: nil)
+    let gate = CoordinatorGate()
+
+    let failing = Task<Int, any Error> {
+        try await coordinator.submit(category: .taskQuery) {
+            await gate.wait()
+            throw CoordinatorTestError.expected
+        }
+    }
+    try await waitForCoordinator {
+        await coordinator.snapshot().running == 1
+    }
+    let next = Task {
+        try await coordinator.submit(category: .health) { 2 }
+    }
+    try await waitForCoordinator {
+        await coordinator.snapshot().queued == 1
+    }
+
+    await gate.open()
+    do {
+        _ = try await failing.value
+        Issue.record("Expected Bridge job failure")
+    } catch CoordinatorTestError.expected {
+        // Expected.
+    }
+    #expect(try await next.value == 2)
+    #expect(await coordinator.snapshot().accepted == 0)
+}
+
+@Test
+func bridgeCoordinatorRejectsEighthRequestWithoutDispatch() async throws {
+    let coordinator = BridgeRequestCoordinator(logger: nil)
+    let gate = CoordinatorGate()
+    let calls = LockedCounter()
+    var accepted: [Task<Int, any Error>] = []
+
+    for expectedAccepted in 1...7 {
+        accepted.append(
+            Task {
+                try await coordinator.submit(category: .countsQuery) {
+                    calls.increment()
+                    await gate.wait()
+                    return 1
+                }
+            }
+        )
+        try await waitForCoordinator {
+            await coordinator.snapshot().accepted == expectedAccepted
+        }
+    }
+
+    let startedAt = ContinuousClock().now
+    do {
+        _ = try await coordinator.submit(category: .countsQuery) {
+            calls.increment()
+            return 8
+        }
+        Issue.record("Expected bridge_busy")
+    } catch let error as BridgeAdmissionError {
+        #expect(error == .busy(retryAfterMilliseconds: 6_750))
+    }
+    let elapsed = startedAt.duration(to: ContinuousClock().now)
+    #expect(elapsed < .milliseconds(250))
+    #expect(calls.current == 1)
+
+    await gate.open()
+    for task in accepted {
+        #expect(try await task.value == 1)
+    }
+    #expect(calls.current == 7)
+}
+
+@Test
+func cancelingQueuedRequestPreventsBridgeInvocation() async throws {
+    let coordinator = BridgeRequestCoordinator(logger: nil)
+    let gate = CoordinatorGate()
+    let queuedCalls = LockedCounter()
+
+    let blocker = Task {
+        try await coordinator.submit(category: .taskQuery) {
+            await gate.wait()
+            return 1
+        }
+    }
+    try await waitForCoordinator {
+        await coordinator.snapshot().running == 1
+    }
+
+    let queued = Task {
+        try await coordinator.submit(category: .mutationApply) {
+            queuedCalls.increment()
+            return 2
+        }
+    }
+    try await waitForCoordinator {
+        await coordinator.snapshot().queued == 1
+    }
+
+    queued.cancel()
+    await expectCancellation(queued)
+    try await waitForCoordinator {
+        await coordinator.snapshot().queued == 0
+    }
+    #expect(queuedCalls.current == 0)
+
+    await gate.open()
+    #expect(try await blocker.value == 1)
+}
+
+@Test
+func expiringQueuedRequestPreventsBridgeInvocation() async throws {
+    let coordinator = BridgeRequestCoordinator(
+        policy: BridgeCoordinatorPolicy(
+            maximumAcceptedRequests: 2,
+            maximumQueueWait: .milliseconds(25),
+            retryAfterMilliseconds: 50
+        ),
+        logger: nil
+    )
+    let gate = CoordinatorGate()
+    let queuedCalls = LockedCounter()
+
+    let blocker = Task {
+        try await coordinator.submit(category: .taskQuery) {
+            await gate.wait()
+            return 1
+        }
+    }
+    try await waitForCoordinator {
+        await coordinator.snapshot().running == 1
+    }
+
+    do {
+        _ = try await coordinator.submit(category: .projectQuery) {
+            queuedCalls.increment()
+            return 2
+        }
+        Issue.record("Expected bridge_queue_timeout")
+    } catch let error as BridgeAdmissionError {
+        #expect(error == .queueTimeout(retryAfterMilliseconds: 50))
+    }
+    #expect(queuedCalls.current == 0)
+
+    await gate.open()
+    #expect(try await blocker.value == 1)
+}
+
+@Test
+func cancelingCommittedRequestLetsWorkerFinalizeExactlyOnce() async throws {
+    let coordinator = BridgeRequestCoordinator(logger: nil)
+    let committed = CoordinatorGate()
+    let finishGate = CoordinatorGate()
+    let invocations = LockedCounter()
+    let finalizations = LockedCounter()
+
+    let task = Task {
+        try await coordinator.submit(category: .mutationApply) {
+            invocations.increment()
+            await committed.open()
+            await finishGate.wait()
+            finalizations.increment()
+            return 1
+        }
+    }
+    await committed.wait()
+
+    task.cancel()
+    await expectCancellation(task)
+    #expect(invocations.current == 1)
+    #expect(finalizations.current == 0)
+
+    await finishGate.open()
+    try await waitForCoordinator {
+        await coordinator.snapshot().accepted == 0
+    }
+    #expect(invocations.current == 1)
+    #expect(finalizations.current == 1)
+}
+
+@Test
+func bridgeRuntimeFinalizerSurvivesCallerCancellation() async throws {
+    let coordinator = BridgeRequestCoordinator(logger: nil)
+    let executor = BridgeBlockingExecutor(logger: nil)
+    let runtime = BridgeRuntime(coordinator: coordinator, executor: executor)
+    let finalizeStarted = CoordinatorGate()
+    let finishGate = CoordinatorGate()
+    let finalizations = LockedCounter()
+
+    let task = Task {
+        try await runtime.submit(
+            category: .mutationApply,
+            bridge: { 1 },
+            finalize: { value in
+                await finalizeStarted.open()
+                await finishGate.wait()
+                finalizations.increment()
+                return value
+            }
+        )
+    }
+    await finalizeStarted.wait()
+
+    task.cancel()
+    await expectCancellation(task)
+    await finishGate.open()
+    try await waitForCoordinator {
+        await coordinator.snapshot().accepted == 0
+    }
+    #expect(finalizations.current == 1)
+}
+
+@Test
+func bridgeBlockingExecutorRunsOperationOnConfiguredSerialQueue() async throws {
+    let key = DispatchSpecificKey<String>()
+    let queue = DispatchQueue(label: "bridge-executor-test")
+    queue.setSpecific(key: key, value: "bridge-executor-test")
+    let executor = BridgeBlockingExecutor(queue: queue, logger: nil)
+
+    let observed = try await executor.run(category: .health) {
+        DispatchQueue.getSpecific(key: key)
+    }
+
+    #expect(observed == "bridge-executor-test")
+}
+
+@Test
+func shuttingDownCoordinatorResumesQueuedWaitersOnce() async throws {
+    let coordinator = BridgeRequestCoordinator(logger: nil)
+    let gate = CoordinatorGate()
+
+    let blocker = Task {
+        try await coordinator.submit(category: .health) {
+            await gate.wait()
+            return 1
+        }
+    }
+    try await waitForCoordinator {
+        await coordinator.snapshot().running == 1
+    }
+    let queued = Task {
+        try await coordinator.submit(category: .taskQuery) { 2 }
+    }
+    try await waitForCoordinator {
+        await coordinator.snapshot().queued == 1
+    }
+
+    await coordinator.shutdown()
+    do {
+        _ = try await queued.value
+        Issue.record("Expected shutdown error")
+    } catch {
+        #expect(error.localizedDescription.contains("shutting down"))
+    }
+
+    await gate.open()
+    #expect(try await blocker.value == 1)
+}
+
+@Test
+func bridgeCoordinatorCompletesTenThousandShortJobsWithoutStranding() async throws {
+    let coordinator = BridgeRequestCoordinator(logger: nil)
+    let completed = LockedCounter()
+
+    for batchStart in stride(from: 0, to: 10_000, by: 7) {
+        let batchEnd = min(batchStart + 7, 10_000)
+        let tasks = (batchStart..<batchEnd).map { value in
+            Task {
+                try await coordinator.submit(category: .countsQuery) {
+                    completed.increment()
+                    return value
+                }
+            }
+        }
+        for (offset, task) in tasks.enumerated() {
+            #expect(try await task.value == batchStart + offset)
+        }
+    }
+
+    let snapshot = await coordinator.snapshot()
+    #expect(snapshot.accepted == 0)
+    #expect(completed.current == 10_000)
+}


### PR DESCRIPTION
## Outcome

FocusRelay now admits Bridge work into one process-wide FIFO lane instead of
launching competing detached Bridge requests. It runs one Bridge operation at a
time, queues at most six more, and rejects excess work immediately with a
structured retryable error.

Closes #170.

## Behavior

- shares one actor-owned admission lane across queries, previews, applies, and
  health checks
- lets valid project/tag cache hits bypass the lane
- runs blocking Bridge polling on a dedicated serial `DispatchQueue` through
  `withTaskExecutorPreference`
- atomically resolves cancellation versus dispatch commitment with
  `Synchronization.Mutex`
- guarantees canceled or expired queued work never invokes Bridge
- lets committed work and cache finalization finish exactly once after caller
  cancellation
- returns structured `bridge_busy` and `bridge_queue_timeout` MCP tool errors
- rethrows `CancellationError` so the MCP SDK can suppress canceled responses
- removes the existing raw `list_tasks` argument log
- adds only coarse, content-free queue and duration diagnostics

No third-party concurrency dependency was added.

## Checked-in policy

- one executing request
- six queued requests
- 43-second maximum queue wait
- 6.75-second retry hint

These constants are derived from the sanitized completion-preview baseline
recorded on #170.

## Validation

- complete Swift Testing suite: passed
- deterministic cancellation, race, overload, wire, executor, shutdown, and
  10,000-job soak coverage: passed
- `swift run focusrelay-dev validate --impact transport-reliability`: passed
  tests and all live semantic gates
- release build: passed
- CI: passed
- task-count canary:
  - width 7: 7/7
  - width 12: 7 admitted successes, 5 `bridge_busy`, 0 client timeouts
- no-write completion-preview canary with a recorded 60-second response budget:
  - width 7: 6 successes, 1 `bridge_queue_timeout`, 0 client timeouts
  - width 12: 6 successes, 5 `bridge_busy`, 1 `bridge_queue_timeout`, 0 client
    timeouts
  - preview persistence remained unchanged
- same-session five-run sequential A/B:
  - prior binary: 1.38-1.51 seconds
  - candidate: 1.38-1.48 seconds
- coordinator-to-executor handoff: 0.006-0.024 ms

The documented validator form with `--base origin/master` was attempted first,
but the current command rejects `--base`; the supported explicit-impact form
passed.

No task IDs, arguments, responses, names, or other OmniFocus content are
included in this PR or its evidence.
