### PR TITLE
Make Bridge burst deadline explicit

### DIFF
--- a/Sources/FocusRelayDevCLI/FocusRelayDevCLI.swift
+++ b/Sources/FocusRelayDevCLI/FocusRelayDevCLI.swift
@@ -122,7 +122,16 @@ private struct BridgeBurst: AsyncParsableCommand {
     @Option(name: .customLong("fixture-task-id"), help: "Disposable task ID required only for completion-preview.")
     var fixtureTaskID: String?
 
+    @Option(
+        name: .customLong("response-timeout-seconds"),
+        help: "Per-request MCP response deadline from 1 through 120 seconds."
+    )
+    var responseTimeoutSeconds = BridgeBurstResponseDeadline.defaultSeconds
+
     func run() async throws {
+        let responseDeadline = try BridgeBurstResponseDeadline(
+            seconds: responseTimeoutSeconds
+        )
         let fileManager = FileManager.default
         let workingDirectory = fileManager.currentDirectoryPath
         let serverURL = URL(
@@ -138,12 +147,18 @@ private struct BridgeBurst: AsyncParsableCommand {
             serverPath: serverURL.path,
             currentDirectory: workingDirectory
         )
-        let runner = BridgeBurstRunner(transport: transport)
+        let runner = BridgeBurstRunner(
+            transport: transport,
+            responseTimeout: responseDeadline.duration
+        )
         let heartbeat = CommandHeartbeat(message: "[running] bridge-burst")
         heartbeat.start()
         defer { heartbeat.cancel() }
 
-        emit("[start] bridge-burst profile=\(profile.rawValue) scenario=\(scenario.rawValue)")
+        emit(
+            "[start] bridge-burst profile=\(profile.rawValue) scenario=\(scenario.rawValue) "
+                + "responseTimeoutMilliseconds=\(responseDeadline.milliseconds)"
+        )
         let report = try await runner.run(
             profile: profile,
             scenario: scenario,

--- a/Sources/FocusRelayDevCore/BridgeBurst.swift
+++ b/Sources/FocusRelayDevCore/BridgeBurst.swift
@@ -65,6 +65,7 @@ public enum BridgeBurstScenario: String, Codable, CaseIterable, Sendable {
 public enum BridgeBurstConfigurationError: Error, LocalizedError, Sendable {
     case missingFixtureTaskID
     case invalidServerBinary
+    case invalidResponseTimeoutSeconds
 
     public var errorDescription: String? {
         switch self {
@@ -72,7 +73,25 @@ public enum BridgeBurstConfigurationError: Error, LocalizedError, Sendable {
             "completion-preview requires --fixture-task-id."
         case .invalidServerBinary:
             "The server binary is missing or is not executable."
+        case .invalidResponseTimeoutSeconds:
+            "Response timeout must be a finite value from 1 through 120 seconds."
         }
+    }
+}
+
+public struct BridgeBurstResponseDeadline: Equatable, Sendable {
+    public static let defaultSeconds = 15.0
+    public let milliseconds: Int
+
+    public init(seconds: Double = defaultSeconds) throws {
+        guard seconds.isFinite, (1...120).contains(seconds) else {
+            throw BridgeBurstConfigurationError.invalidResponseTimeoutSeconds
+        }
+        milliseconds = Int((seconds * 1_000).rounded())
+    }
+
+    public var duration: Duration {
+        .milliseconds(milliseconds)
     }
 }
 
@@ -242,6 +261,7 @@ public struct BridgeBurstLevelReport: Codable, Equatable, Sendable {
 public struct BridgeBurstReport: Codable, Equatable, Sendable {
     public let profile: BridgeBurstProfile
     public let scenario: BridgeBurstScenario
+    public let responseTimeoutMilliseconds: Int
     public let elapsedSeconds: Double
     public let sequential: BridgeBurstSummary
     public let bursts: [BridgeBurstLevelReport]
@@ -249,12 +269,14 @@ public struct BridgeBurstReport: Codable, Equatable, Sendable {
     public init(
         profile: BridgeBurstProfile,
         scenario: BridgeBurstScenario,
+        responseTimeoutMilliseconds: Int,
         elapsedSeconds: Double,
         sequential: BridgeBurstSummary,
         bursts: [BridgeBurstLevelReport]
     ) {
         self.profile = profile
         self.scenario = scenario
+        self.responseTimeoutMilliseconds = responseTimeoutMilliseconds
         self.elapsedSeconds = elapsedSeconds
         self.sequential = sequential
         self.bursts = bursts
@@ -270,7 +292,7 @@ public struct BridgeBurstArtifact: Codable, Equatable, Sendable {
     public let report: BridgeBurstReport
 
     public init(
-        schemaVersion: Int = 1,
+        schemaVersion: Int = 2,
         generatedAt: String,
         gitCommit: String,
         productionFingerprint: String,
@@ -418,6 +440,7 @@ public struct BridgeBurstRunner: Sendable {
             let report = BridgeBurstReport(
                 profile: profile,
                 scenario: scenario,
+                responseTimeoutMilliseconds: Int(responseTimeout.milliseconds.rounded()),
                 elapsedSeconds: runStarted.duration(to: runClock.now).seconds,
                 sequential: BridgeBurstSummary(samples: sequentialSamples),
                 bursts: profile.burstSizes.map { burstSize in

--- a/Tests/FocusRelayDevCoreTests/BridgeBurstTests.swift
+++ b/Tests/FocusRelayDevCoreTests/BridgeBurstTests.swift
@@ -17,6 +17,26 @@ func bridgeBurstProfilesAreExplicitAndBounded() {
 }
 
 @Test
+func bridgeBurstResponseDeadlineDefaultsToFifteenSecondsAndAcceptsSixty() throws {
+    let defaultDeadline = try BridgeBurstResponseDeadline()
+    let coordinatorDeadline = try BridgeBurstResponseDeadline(seconds: 60)
+
+    #expect(defaultDeadline.milliseconds == 15_000)
+    #expect(defaultDeadline.duration == .seconds(15))
+    #expect(coordinatorDeadline.milliseconds == 60_000)
+    #expect(coordinatorDeadline.duration == .seconds(60))
+}
+
+@Test
+func bridgeBurstResponseDeadlineRejectsInvalidValues() {
+    for seconds in [0, -1, 120.1, .infinity, -.infinity, .nan] {
+        #expect(throws: BridgeBurstConfigurationError.self) {
+            try BridgeBurstResponseDeadline(seconds: seconds)
+        }
+    }
+}
+
+@Test
 func completionBurstRequiresFixtureAndRemainsPreviewOnly() throws {
     #expect(throws: BridgeBurstConfigurationError.self) {
         try BridgeBurstScenario.completionPreview.arguments(fixtureTaskID: nil)
@@ -157,6 +177,26 @@ func canaryRunnerInitializesBeforeUniqueConcurrentCalls() async throws {
     #expect(report.sequential.requestCount == 12)
     #expect(report.bursts.map(\.concurrency) == [2, 4, 7, 12])
     #expect(report.bursts.map(\.summary.requestCount) == [2, 4, 7, 12])
+    #expect(report.responseTimeoutMilliseconds == 1_000)
+}
+
+@Test
+func runnerPassesSelectedSixtySecondDeadlineToEveryMCPCall() async throws {
+    let transport = FakeBurstTransport()
+    let runner = BridgeBurstRunner(
+        transport: transport,
+        responseTimeout: .seconds(60)
+    )
+    let report = try await runner.run(
+        profile: .canary,
+        scenario: .taskCounts,
+        fixtureTaskID: nil
+    )
+
+    let state = await transport.state()
+    #expect(report.responseTimeoutMilliseconds == 60_000)
+    #expect(state.callTimeouts.count == 38)
+    #expect(state.callTimeouts.allSatisfy { $0 == .seconds(60) })
 }
 
 @Test
@@ -180,6 +220,7 @@ func artifactContainsOnlySanitizedAggregateFields() throws {
     let report = BridgeBurstReport(
         profile: .canary,
         scenario: .completionPreview,
+        responseTimeoutMilliseconds: 60_000,
         elapsedSeconds: 1,
         sequential: BridgeBurstSummary(samples: [
             BridgeBurstSample(classification: .success, elapsedMilliseconds: 1)
@@ -193,7 +234,13 @@ func artifactContainsOnlySanitizedAggregateFields() throws {
         serverBinarySHA256: "hash",
         report: report
     )
-    let text = String(decoding: try JSONEncoder().encode(artifact), as: UTF8.self)
+    let data = try JSONEncoder().encode(artifact)
+    let decoded = try JSONDecoder().decode(BridgeBurstArtifact.self, from: data)
+    let text = String(decoding: data, as: UTF8.self)
+    #expect(artifact.schemaVersion == 2)
+    #expect(decoded == artifact)
+    #expect(decoded.report.responseTimeoutMilliseconds == 60_000)
+    #expect(text.contains(#""responseTimeoutMilliseconds":60000"#))
     #expect(!text.contains("private-fixture"))
     #expect(!text.contains("/Users/"))
     #expect(!text.contains("targetIDs"))
@@ -224,6 +271,7 @@ private actor FakeBurstTransport: BridgeBurstTransport {
         let didInitialize: Bool
         let didStop: Bool
         let callIDs: [Int]
+        let callTimeouts: [Duration]
         let maxActiveCalls: Int
     }
 
@@ -231,6 +279,7 @@ private actor FakeBurstTransport: BridgeBurstTransport {
     private var didInitialize = false
     private var didStop = false
     private var callIDs: [Int] = []
+    private var callTimeouts: [Duration] = []
     private var activeCalls = 0
     private var maxActiveCalls = 0
 
@@ -245,10 +294,11 @@ private actor FakeBurstTransport: BridgeBurstTransport {
 
     func call(
         _ request: BridgeBurstRequest,
-        timeout _: Duration
+        timeout: Duration
     ) async throws -> BridgeBurstClassification {
         guard didInitialize else { throw BridgeBurstTransportError.protocolError }
         callIDs.append(request.id)
+        callTimeouts.append(timeout)
         activeCalls += 1
         maxActiveCalls = max(maxActiveCalls, activeCalls)
         await Task.yield()
@@ -266,6 +316,7 @@ private actor FakeBurstTransport: BridgeBurstTransport {
             didInitialize: didInitialize,
             didStop: didStop,
             callIDs: callIDs,
+            callTimeouts: callTimeouts,
             maxActiveCalls: maxActiveCalls
         )
     }

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -77,6 +77,21 @@ The harness always covers concurrency 2, 4, 7, and 12. The
 never writes. Its artifacts contain aggregate timings and classifications only;
 raw MCP arguments and responses are not persisted.
 
+The per-request response deadline defaults to 15 seconds for timeout diagnosis.
+When validating an intentionally queued client budget, select it explicitly and
+keep it within the supported 1-to-120-second range:
+
+```bash
+swift run focusrelay-dev bridge-burst \
+  --profile canary \
+  --scenario completion-preview \
+  --response-timeout-seconds 60 \
+  --fixture-task-id "$DISPOSABLE_FIXTURE_ID" \
+  --server-path .build/release/focusrelay
+```
+
+The sanitized artifact records the selected deadline in milliseconds.
+
 ## 4. Release Flow
 
 1. Merge independently validated vertical PRs.


### PR DESCRIPTION
## Outcome

The direct MCP burst harness can now use and record a response deadline that matches the client budget under test.

Closes #178.

## Changes

- adds `--response-timeout-seconds` with a backward-compatible 15-second default
- validates finite values from 1 through 120 before server or transport startup
- passes the selected duration into `BridgeBurstRunner`
- records `responseTimeoutMilliseconds` in the aggregate report
- bumps the sanitized artifact schema to version 2
- documents the 60-second completion-preview command used by #170

No MCP arguments, responses, fixture IDs, or OmniFocus content are added to the artifact.

## Validation

- 13 focused Bridge burst tests passed
- full declared `performance` validation tier passed:
  - 205 Swift tests
  - all live semantic gates
- the runner test verifies all 38 canary calls receive the selected 60-second deadline
- artifact encode/decode round trip records `60000` and remains aggregate-only
- invalid zero, negative, non-finite, and greater-than-120 values fail closed
- direct CLI probe confirmed invalid timeout validation runs before server-path or transport startup
- generated help shows the 1-to-120 range and default `15.0`
- Markdown links and whitespace checks passed

The combined no-write 60-second completion-preview canary remains the finishing gate on #170 after this process/tooling PR is merged.
