### PR TITLE
Guide MCP clients to serialize mutations

### DIFF
--- a/Sources/FocusRelayServer/FocusRelayServer.swift
+++ b/Sources/FocusRelayServer/FocusRelayServer.swift
@@ -44,6 +44,9 @@ public enum FocusRelayServer {
         openWorldHint: false
     )
 
+    static let mutationToolSequencingGuidance =
+        "\n\nRun edit_tasks and edit_projects calls sequentially: wait for each mutation response before starting another mutation. A structured bridge_busy or bridge_queue_timeout response means that rejected request was not dispatched; wait at least retryAfterMilliseconds before retrying only that request. Do not automatically retry any other mutation failure."
+
     static let processInboxPrompt = Prompt(
         name: "process_inbox",
         title: "Process OmniFocus Inbox",
@@ -497,7 +500,7 @@ public enum FocusRelayServer {
                 ),
                 Tool(
                     name: "edit_tasks",
-                    description: "Edit existing OmniFocus tasks by ID. Choose exactly one operation and include only its matching payload: update with taskPatch, set_status with taskStatus, set_completion with completion, or move with move. One call applies the same operation and payload to every target.\n\nUse update for fields and tags, set_status for dropping/restoring, set_completion only for complete/reopen, and move for inbox/project/parent changes. Never translate drop, discard, abandon, or cancel into completion. Repeating drops require an explicit occurrence or series scope. No plannedDate writes.\n\nThe complete target set is preflighted before any apply or save; one missing target fails the whole request without changing valid targets. Set previewOnly=true to validate without writing. Use verify=true for post-write readback. Repeating completion may advance the original task.",
+                    description: "Edit existing OmniFocus tasks by ID. Choose exactly one operation and include only its matching payload: update with taskPatch, set_status with taskStatus, set_completion with completion, or move with move. One call applies the same operation and payload to every target.\n\nUse update for fields and tags, set_status for dropping/restoring, set_completion only for complete/reopen, and move for inbox/project/parent changes. Never translate drop, discard, abandon, or cancel into completion. Repeating drops require an explicit occurrence or series scope. No plannedDate writes.\n\nThe complete target set is preflighted before any apply or save; one missing target fails the whole request without changing valid targets. Set previewOnly=true to validate without writing. Use verify=true for post-write readback. Repeating completion may advance the original task." + mutationToolSequencingGuidance,
                     inputSchema: makeTaskEditSchema(
                         properties: [
                             "operation": .object([
@@ -592,7 +595,7 @@ public enum FocusRelayServer {
                 ),
                 Tool(
                     name: "edit_projects",
-                    description: "Edit existing OmniFocus projects by ID. Choose exactly one operation and include only its matching payload: update with projectPatch, set_status with projectStatus, set_completion with completion, or move with move. One call applies the same operation and payload to every target.\n\nUse set_status for active/on-hold/dropped and set_completion for complete/reopen. Use list_folders before a folder move when its ID is unknown; omit destinationID for the root library. Project tags and containsSingletonActions writes are not supported.\n\nThe complete target set is preflighted before any apply or save; one missing target fails the whole request without changing valid targets. Set previewOnly=true to validate without writing. Use verify=true for post-write readback. Repeating completion may advance the original project.",
+                    description: "Edit existing OmniFocus projects by ID. Choose exactly one operation and include only its matching payload: update with projectPatch, set_status with projectStatus, set_completion with completion, or move with move. One call applies the same operation and payload to every target.\n\nUse set_status for active/on-hold/dropped and set_completion for complete/reopen. Use list_folders before a folder move when its ID is unknown; omit destinationID for the root library. Project tags and containsSingletonActions writes are not supported.\n\nThe complete target set is preflighted before any apply or save; one missing target fails the whole request without changing valid targets. Set previewOnly=true to validate without writing. Use verify=true for post-write readback. Repeating completion may advance the original project." + mutationToolSequencingGuidance,
                     inputSchema: makeProjectEditSchema(
                         properties: [
                             "operation": .object([

--- a/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
+++ b/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
@@ -412,6 +412,14 @@ func productionToolsListMatchesGoldenPublicCatalog() throws {
 
     for name in FocusRelayServer.mutationToolNames {
         let tool = try #require(tools.first { $0["name"] as? String == name })
+        let description = try #require(tool["description"] as? String)
+        #expect(description.contains("Run edit_tasks and edit_projects calls sequentially"))
+        #expect(description.contains("wait for each mutation response"))
+        #expect(description.contains("bridge_busy or bridge_queue_timeout"))
+        #expect(description.contains("wait at least retryAfterMilliseconds"))
+        #expect(description.contains("retrying only that request"))
+        #expect(description.contains("Do not automatically retry any other mutation failure"))
+
         let annotations = try #require(tool["annotations"] as? [String: Any])
         #expect(annotations["readOnlyHint"] as? Bool == false)
         #expect(annotations["destructiveHint"] as? Bool == true)


### PR DESCRIPTION
## Outcome

- Tells every MCP client to run task and project mutation calls sequentially, even when no workflow prompt was selected.
- Explains that structured `bridge_busy` and `bridge_queue_timeout` responses are safe to retry only after the returned delay because the rejected request was never dispatched.
- Does not encourage retrying ambiguous mutation failures.
- Changes descriptions only; tool names, schemas, queue policy, and mutation behavior are unchanged.

## User acceptance journey

An ordinary natural-language chat loads FocusRelay's tools, discovers the mutation sequencing rule through `tools/list`, and avoids a preventable concurrent burst without depending on the optional `process_inbox` prompt.

## Validation

- Focused production `tools/list` wire test: passed
- `swift run focusrelay-dev validate --impact server-wire`: 219 tests passed and release build passed
- `git diff --check`: passed

The development guide's documented `--base origin/master` form was attempted, but the current validator does not support a `--base` option.

Closes #185
