### PR TITLE
Exit stdio server when MCP client disconnects

### DIFF
--- a/Sources/FocusRelayServer/FocusRelayServer.swift
+++ b/Sources/FocusRelayServer/FocusRelayServer.swift
@@ -304,8 +304,23 @@ public enum FocusRelayServer {
         let server = await configuredServer(service: bridgeService, logger: logger)
         let transport = StdioTransport(logger: logger)
         try await server.start(transport: transport)
-        while true {
-            try await Task.sleep(nanoseconds: 60 * 60 * 24 * 1_000_000_000)
+        try await waitUntilTransportCompletes(server)
+    }
+
+    static func waitUntilTransportCompletes(_ server: Server) async throws {
+        do {
+            try await withTaskCancellationHandler {
+                await server.waitUntilCompleted()
+                try Task.checkCancellation()
+            } onCancel: {
+                Task {
+                    await server.stop()
+                }
+            }
+            await server.stop()
+        } catch {
+            await server.stop()
+            throw error
         }
     }
 

--- a/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
+++ b/Tests/FocusRelayServerTests/FocusRelayServerTests.swift
@@ -433,6 +433,75 @@ func productionToolsListMatchesGoldenPublicCatalog() throws {
 }
 
 @Test
+func stdioServerExitsAfterInitializedClientClosesInput() throws {
+    let packageRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    let executable = packageRoot.appendingPathComponent(".build/debug/focusrelay")
+    #expect(FileManager.default.isExecutableFile(atPath: executable.path))
+
+    for _ in 0..<3 {
+        let process = Process()
+        let standardInput = Pipe()
+        let standardOutput = Pipe()
+        process.executableURL = executable
+        process.arguments = ["serve"]
+        process.currentDirectoryURL = packageRoot
+        process.standardInput = standardInput
+        process.standardOutput = standardOutput
+        process.standardError = Pipe()
+        try process.run()
+        defer {
+            if process.isRunning {
+                process.terminate()
+                process.waitUntilExit()
+            }
+        }
+
+        let initialize =
+            #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"stdio-lifecycle-test","version":"1"}}}"#
+            + "\n"
+        try standardInput.fileHandleForWriting.write(contentsOf: Data(initialize.utf8))
+
+        var buffered = Data()
+        var initialized = false
+        while !initialized {
+            let chunk = standardOutput.fileHandleForReading.availableData
+            guard !chunk.isEmpty else {
+                Issue.record("MCP server exited before returning initialize")
+                break
+            }
+            buffered.append(chunk)
+            while let newline = buffered.firstIndex(of: 0x0A) {
+                let line = buffered[..<newline]
+                buffered.removeSubrange(...newline)
+                guard let object = try JSONSerialization.jsonObject(with: line) as? [String: Any],
+                      object["id"] as? Int == 1 else {
+                    continue
+                }
+                initialized = object["result"] != nil
+                break
+            }
+        }
+        try #require(initialized)
+
+        try standardInput.fileHandleForWriting.close()
+
+        let deadline = Date().addingTimeInterval(2)
+        while process.isRunning, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+
+        #expect(!process.isRunning, "FocusRelay must exit when its initialized stdio client closes input")
+        if !process.isRunning {
+            #expect(process.terminationReason == .exit)
+            #expect(process.terminationStatus == 0)
+        }
+    }
+}
+
+@Test
 func mcpWireRejectsUnknownTopLevelAndNestedArgumentsBeforeDispatch() throws {
     let packageRoot = URL(fileURLWithPath: #filePath)
         .deletingLastPathComponent()

--- a/Tests/FocusRelayServerTests/MCPCancellationBoundaryTests.swift
+++ b/Tests/FocusRelayServerTests/MCPCancellationBoundaryTests.swift
@@ -220,6 +220,29 @@ private func withCancellationBoundary(
 }
 
 @Test
+func mcpServerLifecycleCancellationStopsTheTransport() async throws {
+    let logger = Logger(label: "focus.relay.mcp.lifecycle-cancellation-test")
+    let (_, serverTransport) = await InMemoryTransport.createConnectedPair(logger: logger)
+    let service = CancellationBoundaryService()
+    let server = await FocusRelayServer.configuredServer(service: service, logger: logger)
+    try await server.start(transport: serverTransport)
+
+    let lifecycle = Task {
+        try await FocusRelayServer.waitUntilTransportCompletes(server)
+    }
+    lifecycle.cancel()
+
+    do {
+        try await lifecycle.value
+        Issue.record("Expected lifecycle cancellation")
+    } catch is CancellationError {
+        // Expected.
+    } catch {
+        Issue.record("Expected CancellationError, received \(error)")
+    }
+}
+
+@Test
 func mcpCancellationRemovesQueuedBridgeRequestBeforeInvocation() async throws {
     try await withCancellationBoundary { client, service, logStore in
         let running: RequestContext<CallTool.Result> = try await client.callTool(


### PR DESCRIPTION
Closes #187.

## User journey

When an MCP client disconnects or restarts, its FocusRelay stdio child exits promptly instead of remaining as an orphaned process. Explicit server-task cancellation also stops the transport cleanly.

## Changes

- replace the server's infinite sleep with the MCP SDK lifecycle completion signal
- stop the server on normal transport completion and task cancellation
- exercise the production `focusrelay serve` stdio boundary across three initialize/EOF cycles
- cover explicit Swift task cancellation

## Validation

Impact: `transport-reliability`

- focused lifecycle tests passed
- `swift run focusrelay-dev validate --impact transport-reliability` passed: 221 tests and all live semantic gates
- `swift run focusrelay-dev benchmark --profile smoke` passed on the single bounded retry:
  - 356 aggregate measured calls
  - 0 errors
  - 0 timeouts
  - complete scenario coverage
- the first smoke attempt encountered a transient Bridge plug-in discovery failure after restart; adjacent data contracts and subsequent health checks passed, so it was diagnosed and retried once according to the workflow

The frozen-candidate 1.5-hour release suite remains a release gate and was intentionally not run on this product branch.
