### PR TITLE
Prepare v0.12.0-beta release documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### What’s new
 
-- FocusRelay now requires macOS 26 or later so local builds, CI, release
-  packages, and Homebrew installation share one supported platform baseline.
+- Process your inbox in manageable batches with a guided workflow that starts
+  with unresolved captures, asks before changing anything, and verifies
+  approved updates.
+- Keep ordinary inbox cleanup focused on unfinished captures instead of
+  unexpectedly mixing in completed or dropped history.
+- Resolve nested tags more confidently by seeing the parent path for matching
+  tags.
+- Trust compact and multi-page results: unsupported fields and mismatched page
+  cursors now fail clearly instead of returning misleading data.
+- Keep OmniFocus updates reliable during busy conversations and client
+  restarts—work is handled in order, overload is reported clearly, and
+  disconnected FocusRelay processes exit cleanly.
+
+### Before upgrading
+
+- FocusRelay now requires macOS 26 or later.
+- Reinstall the packaged OmniFocus plugin and restart OmniFocus so the plugin
+  and FocusRelay binary stay in sync.
 
 ## [0.11.0-beta] - 2026-07-24
 

--- a/README.md
+++ b/README.md
@@ -22,18 +22,23 @@ assistant does not need your entire OmniFocus database for routine requests.
 
 Try prompts like:
 
+- “Help me process my OmniFocus inbox in a small batch.”
 - “How many flagged items do I have?”
 - “Show me the first three available tasks in my inbox.”
 - “Find my task called [task name], flag it, and verify the change.”
 - “Set [task name] due tomorrow at 5 PM in my local timezone and verify the
   change.”
 
-These workflows were tested with Kimi K2.7 Code and another MCP-capable model.
+In clients that expose MCP server prompts, select `process_inbox`. In OpenCode,
+run `/process_inbox` to start the guided workflow.
+
+These workflows were tested with multiple MCP-capable models in OpenCode.
 Updates target stable OmniFocus IDs and can verify the saved result. If names
 are duplicated, ask to see the candidates before changing anything.
 
 The current release can:
 
+- guide supported MCP clients through a bounded, approval-first inbox workflow;
 - find and count tasks using dates, flags, tags, projects, availability, inbox
   state, completion, estimates, and text search;
 - review projects, folders, tags, task counts, and stalled work;
@@ -82,10 +87,13 @@ Edit tools target stable IDs and support previews, per-item results, compact
 return fields, and optional verification. A failed save, update, or verification
 is reported as a failure—not success.
 
-Validation covered thousands of tasks and thousands of measured calls without
-errors or timeouts in the final benchmark runs. See the
-[0.10.0-beta release notes](docs/release-notes-v0.10.0-beta.md) for evidence and
-limits.
+FocusRelay handles OmniFocus work in order, tells assistants to wait for each
+update, and reports overload clearly instead of letting requests collide.
+When an MCP client disconnects, its FocusRelay process exits cleanly rather
+than remaining in the background.
+
+See the [latest release notes](docs/release-notes-v0.12.0-beta.md) for the
+user-facing changes and upgrade requirements.
 
 ## Privacy and security
 

--- a/docs/release-notes-v0.12.0-beta.md
+++ b/docs/release-notes-v0.12.0-beta.md
@@ -1,0 +1,28 @@
+# FocusRelay 0.12.0-beta
+
+This release makes it easier for an AI assistant to help you reach inbox zero
+without losing control of what changes.
+
+## What’s new
+
+- Process your inbox in manageable batches with a guided workflow that starts
+  with unresolved captures, asks before changing anything, and verifies
+  approved updates.
+- Keep ordinary inbox cleanup focused on unfinished captures instead of
+  unexpectedly mixing in completed or dropped history.
+- Resolve nested tags more confidently by seeing the parent path for matching
+  tags.
+- Trust compact and multi-page results: unsupported fields and mismatched page
+  cursors now fail clearly instead of returning misleading data.
+- Keep OmniFocus updates reliable during busy conversations and client
+  restarts—work is handled in order, overload is reported clearly, and
+  disconnected FocusRelay processes exit cleanly.
+
+In OpenCode, run `/process_inbox` to start the guided workflow.
+
+## Before upgrading
+
+FocusRelay now requires macOS 26 or later.
+
+After upgrading, reinstall the packaged OmniFocus plugin and restart OmniFocus
+so the plugin and FocusRelay binary stay in sync.

--- a/docs/roadmap-execution-plan.md
+++ b/docs/roadmap-execution-plan.md
@@ -10,56 +10,53 @@ records only current sequencing and cross-issue dependencies.
 [`v0.12.0-beta`](https://github.com/deverman/FocusRelayMCP/milestone/1)
 packages the merged reliable-inbox workflow and bounded Bridge architecture.
 [#188](https://github.com/deverman/FocusRelayMCP/issues/188) owns its release
-gates. [#187](https://github.com/deverman/FocusRelayMCP/issues/187) is the only
-remaining production blocker; after it passes client-restart UAT, freeze the
-candidate and run the release validation once.
+gates. The final production blocker and client-restart UAT are complete; freeze
+the candidate and run the release validation once.
 
 ## Delivery Order
 
-1. [#187 — exit on MCP stdio disconnect](https://github.com/deverman/FocusRelayMCP/issues/187)
-   - Prevent client restarts from leaving orphaned FocusRelay processes.
-2. [#188 — release v0.12.0-beta](https://github.com/deverman/FocusRelayMCP/issues/188)
+1. [#188 — release v0.12.0-beta](https://github.com/deverman/FocusRelayMCP/issues/188)
    - Complete headline UAT, freeze one production fingerprint, and run the
      fail-closed release gates before tagging.
-3. [#172 — bounded task-detail lookup](https://github.com/deverman/FocusRelayMCP/issues/172)
+2. [#172 — bounded task-detail lookup](https://github.com/deverman/FocusRelayMCP/issues/172)
    - Replace repeated one-task calls with one stable-ID query that returns only
      the details needed for a workflow decision.
-4. [#171 — multi-name project and tag resolution](https://github.com/deverman/FocusRelayMCP/issues/171)
+3. [#171 — multi-name project and tag resolution](https://github.com/deverman/FocusRelayMCP/issues/171)
    - Resolve a bounded set of requested names through the existing catalog cache
      instead of repeating full catalog queries.
-5. [#173 — atomic heterogeneous task edit plans](https://github.com/deverman/FocusRelayMCP/issues/173)
+4. [#173 — atomic heterogeneous task edit plans](https://github.com/deverman/FocusRelayMCP/issues/173)
    - Design the larger approved-workflow batch only after #172 and #171 reduce
      its read-before-write query cost.
-6. [#94 — discoverable MCP workflows](https://github.com/deverman/FocusRelayMCP/issues/94)
+5. [#94 — discoverable MCP workflows](https://github.com/deverman/FocusRelayMCP/issues/94)
    - Continue measured client research after the shipped `process_inbox`
      vertical; add another prompt only when UAT demonstrates a reliable benefit.
-7. [#82 — task/subtask creation](https://github.com/deverman/FocusRelayMCP/issues/82), then
+6. [#82 — task/subtask creation](https://github.com/deverman/FocusRelayMCP/issues/82), then
    [#83 — project creation/conversion](https://github.com/deverman/FocusRelayMCP/issues/83)
    - Build on the consolidated edit surface, support safe project folder
      destinations, and retain duplicate/write safety.
-8. [#93 — repetition support](https://github.com/deverman/FocusRelayMCP/issues/93)
+7. [#93 — repetition support](https://github.com/deverman/FocusRelayMCP/issues/93)
    - After task creation and truthful drop behavior stabilize, establish complete
      schedule readback before adding create, edit, and lifecycle mutation slices.
-9. [#130 — project tag membership and filtering](https://github.com/deverman/FocusRelayMCP/issues/130), then
+8. [#130 — project tag membership and filtering](https://github.com/deverman/FocusRelayMCP/issues/130), then
    [#128 — create and assign missing tags](https://github.com/deverman/FocusRelayMCP/issues/128)
    - Query direct project membership by stable ID before creating missing root
      or nested tags during assignment.
-10. [#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88), then
+9. [#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88), then
    [#87 — project-health filters](https://github.com/deverman/FocusRelayMCP/issues/87)
    - Reduce context before expanding project-review workflows.
-11. [#85 — safe Forecast contract](https://github.com/deverman/FocusRelayMCP/issues/85), then
+10. [#85 — safe Forecast contract](https://github.com/deverman/FocusRelayMCP/issues/85), then
    [#125 — Forecast-based attention](https://github.com/deverman/FocusRelayMCP/issues/125), then
    [#126 — broader ranked task search](https://github.com/deverman/FocusRelayMCP/issues/126)
    - Reuse one documented task-only Forecast classifier for attention ranking.
    - Keep search independent, broad, relevance-ranked, and lightweight.
-12. [#92 — guided Homebrew setup](https://github.com/deverman/FocusRelayMCP/issues/92)
+11. [#92 — guided Homebrew setup](https://github.com/deverman/FocusRelayMCP/issues/92)
     - Reduce installation friction after the next product capabilities settle.
-13. Measured transport and command experiments:
+12. Measured transport and command experiments:
     [#90](https://github.com/deverman/FocusRelayMCP/issues/90) and
     [#73](https://github.com/deverman/FocusRelayMCP/issues/73).
-14. Small independent query improvements: #11, #22, #18, #59, #62, #65,
+13. Small independent query improvements: #11, #22, #18, #59, #62, #65,
     #66, #67, and #68.
-15. Feasibility work for #10 custom perspectives and #16 planned-date writes.
+14. Feasibility work for #10 custom perspectives and #16 planned-date writes.
 
 ## Standing Decisions
 

--- a/docs/workflow-prompt-research-2026-07-23.md
+++ b/docs/workflow-prompt-research-2026-07-23.md
@@ -71,7 +71,7 @@ This gives the implementation spike three exact regression assertions:
 | Client | Current documented evidence | Research conclusion |
 | --- | --- | --- |
 | Claude Code | Anthropic documents dynamically discovered MCP prompts as `/mcp__servername__promptname`, including positional arguments. | Suitable for the first discovery UAT, but invocation still needs a live FocusRelay test. |
-| OpenCode | Current public MCP docs describe local/remote MCP tools and automatic tool availability. They do not document `prompts/list`, `prompts/get`, or MCP prompt discovery. | Unsupported until a versioned live protocol/UI test proves otherwise. Do not describe OpenCode slash-command support. |
+| OpenCode | Public MCP docs do not describe prompt discovery, but a versioned OpenCode 1.18.7 live test exposed `process_inbox` as `/process_inbox`, inserted the server prompt, and completed its instructed bounded count/list workflow. | Supported for the argument-free `process_inbox` prompt in OpenCode 1.18.7; do not generalize this result to prompt arguments or other versions without another live test. |
 | Codex | Current official Codex material documents configuring MCP servers and consuming MCP tools. It does not document MCP prompt discovery or invocation. | Unsupported until a versioned live test proves otherwise. Codex custom prompts/skills are not evidence of MCP server-prompt support. |
 
 Primary sources:
@@ -154,8 +154,8 @@ research summary. Record only library-size bands and aggregate measures.
 
 ## Research Status
 
-Gate 1 remains open: no new participant sessions were conducted for this
-research branch. Protocol feasibility, SDK feasibility, the current server
-baseline, the first prototype contract, and the measurement plan are complete.
-Client UI compatibility beyond Claude Code's documented behavior remains a
-live-test question.
+Gate 1 remains open: the participant threshold has not been reached. Protocol
+feasibility, SDK feasibility, the server implementation, and a versioned
+OpenCode 1.18.7 live test of the argument-free `process_inbox` workflow are
+complete. Broader client compatibility, prompt arguments, and reuse preference
+remain research questions.


### PR DESCRIPTION
Related to #188.

## User journey

A user considering or installing v0.12.0-beta can quickly understand how the release helps them reach inbox zero, how to start the guided OpenCode workflow, and what must be done before upgrading.

## Changes

- rewrite the unreleased changelog as five concise user-benefit bullets
- add focused v0.12.0-beta release notes
- document `/process_inbox`, ordered updates, and clean client disconnects in the README
- record the completed OpenCode 1.18.7 prompt-compatibility UAT without generalizing beyond the tested contract
- advance the concise roadmap to the release tracker

## Validation

Impact: `docs`

- `swift run focusrelay-dev validate --impact docs`
- `git diff --check`

No OmniFocus content, identifiers, or client transcript details are included.
