### PR TITLE
Correct the OpenCode process inbox command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Try prompts like:
   change.”
 
 In clients that expose MCP server prompts, select `process_inbox`. In OpenCode,
-run `/process_inbox` to start the guided workflow.
+run `/focusrelay:process_inbox` to start the guided workflow.
 
 These workflows were tested with multiple MCP-capable models in OpenCode.
 Updates target stable OmniFocus IDs and can verify the saved result. If names

--- a/docs/release-notes-v0.12.0-beta.md
+++ b/docs/release-notes-v0.12.0-beta.md
@@ -18,7 +18,7 @@ without losing control of what changes.
   restarts—work is handled in order, overload is reported clearly, and
   disconnected FocusRelay processes exit cleanly.
 
-In OpenCode, run `/process_inbox` to start the guided workflow.
+In OpenCode, run `/focusrelay:process_inbox` to start the guided workflow.
 
 ## Before upgrading
 

--- a/docs/workflow-prompt-research-2026-07-23.md
+++ b/docs/workflow-prompt-research-2026-07-23.md
@@ -71,7 +71,7 @@ This gives the implementation spike three exact regression assertions:
 | Client | Current documented evidence | Research conclusion |
 | --- | --- | --- |
 | Claude Code | Anthropic documents dynamically discovered MCP prompts as `/mcp__servername__promptname`, including positional arguments. | Suitable for the first discovery UAT, but invocation still needs a live FocusRelay test. |
-| OpenCode | Public MCP docs do not describe prompt discovery, but a versioned OpenCode 1.18.7 live test exposed `process_inbox` as `/process_inbox`, inserted the server prompt, and completed its instructed bounded count/list workflow. | Supported for the argument-free `process_inbox` prompt in OpenCode 1.18.7; do not generalize this result to prompt arguments or other versions without another live test. |
+| OpenCode | Public MCP docs do not describe prompt discovery, but a versioned OpenCode 1.18.7 live test exposed `process_inbox` as `/focusrelay:process_inbox`, inserted the server prompt, and completed its instructed bounded count/list workflow. | Supported for the argument-free `process_inbox` prompt in OpenCode 1.18.7; do not generalize this result to prompt arguments or other versions without another live test. |
 | Codex | Current official Codex material documents configuring MCP servers and consuming MCP tools. It does not document MCP prompt discovery or invocation. | Unsupported until a versioned live test proves otherwise. Codex custom prompts/skills are not evidence of MCP server-prompt support. |
 
 Primary sources:


### PR DESCRIPTION
Related to #188.

Frozen-candidate UAT showed that OpenCode namespaces the MCP prompt command as `/focusrelay:process_inbox`; bare `/process_inbox` fails before contacting FocusRelay.

This corrects the README, v0.12 release notes, and versioned client-research record. It is documentation-only and does not change the certified production fingerprint.

Validation impact: `docs`

- `swift run focusrelay-dev validate --impact docs`
- `git diff --check`

No OmniFocus content or identifiers are included.
