### PR TITLE
Fix release package output export

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,15 +61,17 @@ jobs:
       - name: Package Release
         id: package
         run: |
+          set -euo pipefail
+          ./scripts/test-release-package-outputs.sh
           if [ "$GITHUB_EVENT_NAME" = "push" ]; then
             VERSION="${GITHUB_REF_NAME#v}"
           else
             VERSION="${{ inputs.version }}"
           fi
 
-          PACKAGE_OUTPUT="$(./scripts/package-release.sh "$VERSION" "$PWD")"
-          printf '%s\n' "$PACKAGE_OUTPUT"
-          printf '%s\n' "$PACKAGE_OUTPUT" >> "$GITHUB_OUTPUT"
+          PACKAGE_OUTPUT_FILE="$RUNNER_TEMP/focusrelay-package-output.txt"
+          ./scripts/package-release.sh "$VERSION" "$PWD" | tee "$PACKAGE_OUTPUT_FILE"
+          ./scripts/write-github-package-outputs.sh "$PACKAGE_OUTPUT_FILE" "$GITHUB_OUTPUT"
           
       - name: Create Release
         uses: softprops/action-gh-release@v2
@@ -81,44 +83,7 @@ jobs:
             focusrelay-*.tar.gz
             focusrelay-*.sha256
           fail_on_unmatched_files: true
-          body: |
-            ## Installation
-
-            ### Homebrew (Recommended)
-            ```bash
-            brew tap deverman/focus-relay
-            brew install focusrelay
-            ```
-
-            ### Manual Installation
-            1. Download `focusrelay-X.X.X.tar.gz` from this release
-            2. Extract: `tar -xzf focusrelay-X.X.X.tar.gz`
-            3. Install the MCP server binary:
-               ```bash
-               sudo cp focusrelay-X.X.X/focusrelay /usr/local/bin/
-               ```
-            4. Install the OmniFocus plugin:
-                - Open OmniFocus
-                - Go to Automation > Plug-Ins > Show Plug-In Folder in Finder
-                - Copy the plugin to that folder:
-                  ```bash
-                  cp -r focusrelay-X.X.X/FocusRelayBridge.omnijs ~/Library/Containers/com.omnigroup.OmniFocus4/Data/Library/Application\ Support/Plug-Ins/
-                  ```
-                - Or if using iCloud: `~/Library/Mobile Documents/iCloud~com~omnigroup~OmniFocus/Documents/Plug-Ins/`
-            5. **Restart OmniFocus completely** (Cmd+Q, then reopen)
-            6. Configure your MCP client (see README.md in the package)
-
-            ### First Time Setup
-            ⚠️ When you run your first query, OmniFocus will show a security dialog.
-            You **MUST** click "Run Script" to allow the automation to work.
-
-            ## SHA256 Checksum
-            ```
-            ${{ steps.package.outputs.sha256 }}
-            ```
-
-            ## Changes
-            See [CHANGELOG.md](${{ github.server_url }}/${{ github.repository }}/blob/${{ steps.package.outputs.tag_name }}/CHANGELOG.md) for details.
+          body_path: docs/release-notes-v0.12.0-beta.md
           draft: false
           prerelease: ${{ contains(steps.package.outputs.version, '-') || contains(steps.package.outputs.version, 'alpha') || contains(steps.package.outputs.version, 'beta') || contains(steps.package.outputs.version, 'rc') }}
         env:

--- a/scripts/test-release-package-outputs.sh
+++ b/scripts/test-release-package-outputs.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+VALID_INPUT="$TEMP_DIR/valid.txt"
+VALID_OUTPUT="$TEMP_DIR/github-output.txt"
+cat > "$VALID_INPUT" <<'EOF'
+Minimum macOS: 26.0
+version=0.12.0-beta
+tag_name=v0.12.0-beta
+archive_name=focusrelay-0.12.0-beta.tar.gz
+checksum_name=focusrelay-0.12.0-beta.sha256
+sha256=48eba81d7aa1c5a1688915f60bc27bfcfb3ee57ec3bdf786870edb8e9ff625c5
+EOF
+
+"$ROOT_DIR/scripts/write-github-package-outputs.sh" "$VALID_INPUT" "$VALID_OUTPUT"
+if grep -Fq "Minimum macOS" "$VALID_OUTPUT"; then
+  echo "Human-readable diagnostics leaked into GitHub outputs." >&2
+  exit 1
+fi
+if [ "$(wc -l < "$VALID_OUTPUT" | tr -d ' ')" -ne 5 ]; then
+  echo "Expected exactly five GitHub outputs." >&2
+  exit 1
+fi
+
+DUPLICATE_INPUT="$TEMP_DIR/duplicate.txt"
+cp "$VALID_INPUT" "$DUPLICATE_INPUT"
+printf 'sha256=%s\n' "48eba81d7aa1c5a1688915f60bc27bfcfb3ee57ec3bdf786870edb8e9ff625c5" >> "$DUPLICATE_INPUT"
+if "$ROOT_DIR/scripts/write-github-package-outputs.sh" "$DUPLICATE_INPUT" "$TEMP_DIR/duplicate-output.txt"; then
+  echo "Duplicate package output unexpectedly passed." >&2
+  exit 1
+fi
+
+MISSING_INPUT="$TEMP_DIR/missing.txt"
+grep -v '^tag_name=' "$VALID_INPUT" > "$MISSING_INPUT"
+if "$ROOT_DIR/scripts/write-github-package-outputs.sh" "$MISSING_INPUT" "$TEMP_DIR/missing-output.txt"; then
+  echo "Missing package output unexpectedly passed." >&2
+  exit 1
+fi
+
+echo "Release package output tests passed."

--- a/scripts/write-github-package-outputs.sh
+++ b/scripts/write-github-package-outputs.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PACKAGE_OUTPUT_FILE="${1:-}"
+GITHUB_OUTPUT_FILE="${2:-}"
+
+if [ -z "$PACKAGE_OUTPUT_FILE" ] || [ -z "$GITHUB_OUTPUT_FILE" ]; then
+  echo "Usage: $0 <package-output-file> <github-output-file>" >&2
+  exit 1
+fi
+
+test -f "$PACKAGE_OUTPUT_FILE"
+
+required_keys="version tag_name archive_name checksum_name sha256"
+for key in $required_keys; do
+  matches="$(awk -F= -v key="$key" '$1 == key { print }' "$PACKAGE_OUTPUT_FILE")"
+  match_count="$(printf '%s\n' "$matches" | awk 'NF { count += 1 } END { print count + 0 }')"
+  if [ "$match_count" -ne 1 ]; then
+    echo "Expected exactly one package output for $key, found $match_count." >&2
+    exit 1
+  fi
+done
+
+version="$(awk -F= '$1 == "version" { sub(/^[^=]*=/, ""); print }' "$PACKAGE_OUTPUT_FILE")"
+tag_name="$(awk -F= '$1 == "tag_name" { sub(/^[^=]*=/, ""); print }' "$PACKAGE_OUTPUT_FILE")"
+archive_name="$(awk -F= '$1 == "archive_name" { sub(/^[^=]*=/, ""); print }' "$PACKAGE_OUTPUT_FILE")"
+checksum_name="$(awk -F= '$1 == "checksum_name" { sub(/^[^=]*=/, ""); print }' "$PACKAGE_OUTPUT_FILE")"
+sha256="$(awk -F= '$1 == "sha256" { sub(/^[^=]*=/, ""); print }' "$PACKAGE_OUTPUT_FILE")"
+
+if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?(\+[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$ ]]; then
+  echo "Invalid package version output: $version" >&2
+  exit 1
+fi
+if [ "$tag_name" != "v$version" ]; then
+  echo "Package tag does not match version: $tag_name" >&2
+  exit 1
+fi
+if [ "$archive_name" != "focusrelay-$version.tar.gz" ]; then
+  echo "Package archive does not match version: $archive_name" >&2
+  exit 1
+fi
+if [ "$checksum_name" != "focusrelay-$version.sha256" ]; then
+  echo "Package checksum does not match version: $checksum_name" >&2
+  exit 1
+fi
+if ! [[ "$sha256" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "Invalid package SHA-256 output." >&2
+  exit 1
+fi
+
+for key in $required_keys; do
+  awk -F= -v key="$key" '$1 == key { print }' "$PACKAGE_OUTPUT_FILE" >> "$GITHUB_OUTPUT_FILE"
+done


### PR DESCRIPTION
Closes #194.

## Outcome

- keeps human-readable package diagnostics in the Actions log without treating them as GitHub output metadata
- validates the exact required metadata keys before exporting anything
- fails closed for missing, duplicate, inconsistent, or malformed values
- publishes the prepared concise user-facing release notes, including the macOS 26 requirement

## Validation impact

`package`

## Acceptance journey

Push a certified beta tag and receive a prerelease with its archive, checksum, and concise user-facing notes rather than a package-output format failure.

## Validation

- `./scripts/test-release-package-outputs.sh`
- compatible YAML parse of `.github/workflows/release.yml`
- `swift run focusrelay-dev validate --impact package`
  - 221 Swift tests passed
  - release binary built
  - minimum macOS 26.0 verified

No runtime, Bridge, query, mutation, or benchmark code changed. The certified production fingerprint remains reusable.
