### PR TITLE
Harden bridge IPC directory (#197)

### DIFF
--- a/IPC-SPEC.md
+++ b/IPC-SPEC.md
@@ -11,20 +11,29 @@ This document defines a file-based IPC protocol between the Swift MCP server and
 
 ## Directories
 
-Default base directory (configurable):
+Fixed base directory (not configurable):
 
 ```
 ~/Library/Containers/com.omnigroup.OmniFocus4/Data/Documents/FocusRelayIPC
 ```
 
-Subdirectories:
+The bridge plug-in can only write inside OmniFocus's sandbox container, so
+there is no usable alternative location. When the OmniFocus 4 container is
+absent, path resolution fails fast with an actionable error instead of
+letting requests time out.
+
+Subdirectories and files:
 
 ```
 requests/
 responses/
 locks/
-logs/
+dispatch/
+bridge-version.json
 ```
+
+Any other top-level entry is out of policy and is deleted during startup
+maintenance (legacy examples: `logs/`, `pid-*/`, `default/`, `*.trace.json`).
 
 ## File Naming
 
@@ -117,8 +126,10 @@ Error response:
 
 1) MCP server writes request file.
 2) MCP server triggers OmniFocus plug-in with requestId.
-3) Plug-in reads request, creates lock, writes response.
-4) MCP server polls for response file, reads it, returns tool output.
+3) Plug-in reads request, creates lock, writes response, removes lock and request.
+4) MCP server polls for response file, reads it, deletes the response (plus
+   any remaining request/lock), and returns tool output. A successful round
+   trip leaves no artifacts on disk.
 
 ## Timeouts + Retries
 
@@ -126,25 +137,59 @@ Error response:
 - Poll interval: 100–200 ms
 - MCP server deletes request/lock if timeout exceeded (optional cleanup)
 
-## Cleanup
+## Retention
 
-- Stale request/response/lock files older than 10 minutes may be deleted by the MCP server.
+| Path | Policy | Enforced |
+| --- | --- | --- |
+| Non-allowlisted top-level entries | delete always | startup maintenance |
+| `requests/<id>.json` | plug-in deletes after response; client deletes after successful decode and on non-timeout error; else stale > 10 min | per-request + throttled sweep |
+| `responses/<id>.json` | client deletes immediately after successful decode; timeout artifacts kept for late-arrival recovery | per-request + throttled sweep |
+| `locks/<id>.lock` | plug-in deletes after response; client belt-and-braces after success; else stale > 10 min | per-request + throttled sweep |
+| `dispatch/request.json` | client deletes after response; else stale > 10 min | throttled sweep |
+| `bridge-version.json` | persistent; rewritten on version change | startup maintenance |
+
+The stale sweep runs at most once per stale interval (10 minutes), never on
+every request. Startup maintenance runs once per process before the first
+bridge request.
 
 ## Idempotency Rules
 
 - Plug-in must check for existing response file; if it exists, return without reprocessing.
 - MCP server should treat multiple identical responses as safe.
+- The response-exists check only matters during the in-flight window
+  (duplicate dispatch from stranded-request redispatch or late recovery).
+  The client deletes the response only after a successful decode and never
+  re-dispatches that request ID afterwards, so consumption does not affect
+  the check.
 
 ## Versioning
 
 - `schemaVersion` is required.
 - Incompatible versions should return a structured error response.
+- `bridge-version.json` records the binary version (and the last observed
+  plug-in version) that owns the directory:
+  `{"schemaVersion":1,"swiftVersion":"…","pluginVersion":"…","updatedAt":"…"}`.
+  A mismatch at startup — or a changed plug-in version observed during a
+  health check — clears the contents of all protocol directories once and
+  rewrites the marker, so no artifacts written by one version are ever read
+  by another.
 
 ## Security
 
-- Files are local only.
-- No secrets should be written unless explicitly required.
-- Requests/responses are readable by the current user.
+- Files are local only and hold OmniFocus content (task and project data) in
+  cleartext while they exist; retention keeps that window minimal (successful
+  round trips leave no artifacts).
+- The Swift side is authoritative for permissions: directories are created
+  and repaired to `0700`; Swift-written files are set to `0600` after each
+  atomic write (atomic replace discards modes, so this is chmod-after-write —
+  the directory is the enforcement boundary, not file creation modes).
+- Plug-in-written files may carry the default mode; they live inside `0700`
+  directories and are deleted as soon as they are consumed.
+- The plug-in writes no log files; plug-in diagnostics return as response
+  data only.
+- `dispatch/request.json` is one shared file, which assumes a single active
+  server per user account; concurrent servers are serialized by the
+  process-wide Bridge lane, not by the file protocol.
 
 ## Notes
 

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
         ),
         .target(
             name: "OmniFocusAutomation",
-            dependencies: ["OmniFocusCore"]
+            dependencies: ["OmniFocusCore", "FocusRelayVersion"]
         ),
         .executableTarget(
             name: "FocusRelayCLI",

--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -1740,7 +1740,6 @@
         ensureDir(basePath + "/requests");
         ensureDir(basePath + "/responses");
         ensureDir(basePath + "/locks");
-        ensureDir(basePath + "/logs");
       if (fileExists(responsePath)) { return; }
       writeLock(lockPath);
       const request = readJSON(requestPath);
@@ -2017,13 +2016,10 @@
           }
         } else if (request.op === "list_inbox" || request.op === "list_tasks") {
           const filter = request.filter || {};
-          const debugListTasks = filter.search === "__debug_list_tasks__";
-          const searchQuery = debugListTasks ? null : normalizeTaskSearchQuery(filter.search);
-          const listTasksDebug = debugListTasks ? {
-            requestId: requestId,
-            op: request.op,
-            marks: []
-          } : null;
+          const searchQuery = normalizeTaskSearchQuery(filter.search);
+          // File-based debug logging was removed: diagnostics return as
+          // response data, never as files (see IPC-SPEC.md Security).
+          const listTasksDebug = null;
           const markListTasks = (label, extra) => {
             if (!listTasksDebug) { return; }
             const entry = Object.assign({ label: label, ms: Date.now() - start }, extra || {});
@@ -2226,8 +2222,7 @@
             filterState.maxEstimatedMinutes !== undefined ||
             filterState.minEstimatedMinutes !== undefined ||
             Boolean(filterState.tags) ||
-            Boolean(filterState.searchQuery) ||
-            debugListTasks;
+            Boolean(filterState.searchQuery);
           const useStreamedSimplePath =
             !requiresCompletionSort &&
             filterState.availableOnly &&
@@ -2316,12 +2311,6 @@
             if (includeTotalCount) {
               response.data.totalCount = totalCount;
             }
-            if (listTasksDebug) {
-              listTasksDebug.totalTimingMs = Date.now() - start;
-              try {
-                writeJSON(basePath + "/logs/list_tasks_debug_" + requestId + ".json", listTasksDebug);
-              } catch (debugError) {}
-            }
           } else if (useCompletionTopKPath) {
             const completionPathStart = Date.now();
             const windowSize = Math.max(limit + 1, safeOffset + limit + 1);
@@ -2399,12 +2388,6 @@
             if (includeTotalCount) {
               response.data.totalCount = totalCount;
             }
-            if (listTasksDebug) {
-              listTasksDebug.totalTimingMs = Date.now() - start;
-              try {
-                writeJSON(basePath + "/logs/list_tasks_debug_" + requestId + ".json", listTasksDebug);
-              } catch (debugError) {}
-            }
           } else {
 
             // Filter first, then apply pagination. Cursor semantics are based on the
@@ -2458,12 +2441,6 @@
             response.data = { items: items, nextCursor: nextCursor, returnedCount: returnedCount };
             if (includeTotalCount) {
               response.data.totalCount = totalCount;
-            }
-            if (listTasksDebug) {
-              listTasksDebug.totalTimingMs = Date.now() - start;
-              try {
-                writeJSON(basePath + "/logs/list_tasks_debug_" + requestId + ".json", listTasksDebug);
-              } catch (debugError) {}
             }
           }
         } else if (request.op === "list_projects") {
@@ -2777,13 +2754,9 @@
           }
         } else if (request.op === "get_task_counts") {
           const filter = request.filter || {};
-          const debugTaskCounts = filter.search === "__debug_task_counts__";
-          const searchQuery = debugTaskCounts ? null : normalizeTaskSearchQuery(filter.search);
-          const taskCountsDebug = debugTaskCounts ? {
-            requestId: requestId,
-            op: request.op,
-            marks: []
-          } : null;
+          const searchQuery = normalizeTaskSearchQuery(filter.search);
+          // File-based debug logging was removed (see IPC-SPEC.md Security).
+          const taskCountsDebug = null;
           const markTaskCounts = (label, extra) => {
             if (!taskCountsDebug) { return; }
             const entry = Object.assign({ label: label, ms: Date.now() - start }, extra || {});
@@ -2847,13 +2820,7 @@
           let tasks = selectTaskPool();
           const projectRootCandidates = selectProjectRootCandidates();
           tasks = appendTaggedProjectRootTasks(tasks, projectRootCandidates, filter.tags);
-          const debugInfo = debugTaskCounts ? {
-            requestId: requestId,
-            availableOnly: availableOnly,
-            inboxView: inboxView,
-            projectView: projectView,
-            initialPoolCount: tasks.length
-          } : null;
+          const debugInfo = null;
           markTaskCounts("selected_base_pool", {
             count: tasks.length,
             durationMs: Date.now() - poolStart,
@@ -2915,8 +2882,7 @@
             Boolean(filterState.tags) ||
             filterState.maxEstimatedMinutes !== undefined ||
             filterState.minEstimatedMinutes !== undefined ||
-            Boolean(filterState.searchQuery) ||
-            debugTaskCounts;
+            Boolean(filterState.searchQuery);
           const useSimpleAvailableFastPath =
             filterState.availableOnly &&
             filterState.completed !== true &&
@@ -3126,24 +3092,11 @@
             debugInfo.afterAllFiltersCount = counts.total;
             debugInfo.afterAllFiltersSample = finalSample;
           }
-          if (debugInfo) {
-            debugInfo.counts = counts;
-            taskCountsDebug.debugInfo = debugInfo;
-            taskCountsDebug.totalTimingMs = Date.now() - start;
-            try {
-              writeJSON(basePath + "/logs/get_task_counts_debug_" + requestId + ".json", taskCountsDebug);
-            } catch (debugError) {}
-          }
-
           response.data = counts;
 } else if (request.op === "get_project_counts") {
           const filter = request.filter || {};
-          const debugProjectCounts = filter.search === "__debug_project_counts__";
-          const projectCountsDebug = debugProjectCounts ? {
-            requestId: requestId,
-            op: request.op,
-            marks: []
-          } : null;
+          // File-based debug logging was removed (see IPC-SPEC.md Security).
+          const projectCountsDebug = null;
           const markProjectCounts = (label, extra) => {
             if (!projectCountsDebug) { return; }
             const entry = Object.assign({ label: label, ms: Date.now() - start }, extra || {});
@@ -3368,13 +3321,6 @@
             });
 
             response.data = { projects: projectIds.size, actions: actionCount };
-          }
-          if (projectCountsDebug) {
-            projectCountsDebug.totalTimingMs = Date.now() - start;
-            projectCountsDebug.responseData = response.data;
-            try {
-              writeJSON(basePath + "/logs/get_project_counts_debug_" + requestId + ".json", projectCountsDebug);
-            } catch (debugError) {}
           }
         } else {
           response.ok = false;

--- a/Sources/FocusRelayCLI/BenchmarkSupport.swift
+++ b/Sources/FocusRelayCLI/BenchmarkSupport.swift
@@ -70,7 +70,7 @@ struct BenchmarkTimeoutDiagnostic: Codable {
     let latencyMs: Double
     let error: String
     let requestId: String?
-    let queue: BenchmarkTimeoutQueueSnapshot
+    let queue: BenchmarkTimeoutQueueSnapshot?
     let omniFocus: BenchmarkTimeoutProcessSnapshot
     let focusrelay: BenchmarkTimeoutProcessSnapshot
     let bridgeHealth: BenchmarkTimeoutBridgeHealthSnapshot?
@@ -381,7 +381,29 @@ func captureBenchmarkTimeoutDiagnostic(
     errorMessage: String
 ) async -> BenchmarkTimeoutDiagnostic {
     let requestID = extractBenchmarkRequestID(from: errorMessage)
-    let baseURL = defaultBenchmarkIPCBaseURL()
+    guard let baseURL = try? IPCEnvironment.defaultBaseURL() else {
+        return BenchmarkTimeoutDiagnostic(
+            timestamp: benchmarkISO8601Now(),
+            transport: benchmarkTransport,
+            scenario: scenario,
+            phase: phase,
+            callIndex: callIndex,
+            latencyMs: latencyMs,
+            error: errorMessage,
+            requestId: requestID,
+            queue: nil,
+            omniFocus: BenchmarkTimeoutProcessSnapshot(process: "OmniFocus", pid: nil, rssKB: nil),
+            focusrelay: BenchmarkTimeoutProcessSnapshot(
+                process: "focusrelay",
+                pid: ProcessInfo.processInfo.processIdentifier,
+                rssKB: nil
+            ),
+            bridgeHealth: BenchmarkTimeoutBridgeHealthSnapshot(
+                ok: false,
+                detail: "OmniFocus 4 container not found; IPC diagnostics unavailable"
+            )
+        )
+    }
     let requestsURL = baseURL.appendingPathComponent("requests", isDirectory: true)
     let locksURL = baseURL.appendingPathComponent("locks", isDirectory: true)
     let responsesURL = baseURL.appendingPathComponent("responses", isDirectory: true)
@@ -453,24 +475,6 @@ private func benchmarkDirectoryEntryCount(_ url: URL) -> Int {
 private func benchmarkDirectoryEntrySamples(_ url: URL, limit: Int = 5) -> [String] {
     guard let contents = try? FileManager.default.contentsOfDirectory(atPath: url.path) else { return [] }
     return Array(contents.sorted().prefix(limit))
-}
-
-private func defaultBenchmarkIPCBaseURL() -> URL {
-    let home = FileManager.default.homeDirectoryForCurrentUser
-    let container = home
-        .appendingPathComponent("Library", isDirectory: true)
-        .appendingPathComponent("Containers", isDirectory: true)
-        .appendingPathComponent("com.omnigroup.OmniFocus4", isDirectory: true)
-        .appendingPathComponent("Data", isDirectory: true)
-        .appendingPathComponent("Documents", isDirectory: true)
-        .appendingPathComponent("FocusRelayIPC", isDirectory: true)
-    if FileManager.default.fileExists(atPath: container.deletingLastPathComponent().path) {
-        return container
-    }
-    return home
-        .appendingPathComponent("Library", isDirectory: true)
-        .appendingPathComponent("Caches", isDirectory: true)
-        .appendingPathComponent("focusrelay", isDirectory: true)
 }
 
 func renderCountBenchmarkSummary(

--- a/Sources/OmniFocusAutomation/BridgeClient.swift
+++ b/Sources/OmniFocusAutomation/BridgeClient.swift
@@ -1,22 +1,34 @@
 import Foundation
+import FocusRelayVersion
 import OmniFocusCore
 
 final class BridgeClient: @unchecked Sendable {
-    private let paths: IPCPaths
+    // Mutable state below is safe without locking: the #170 Bridge lane
+    // serializes every request through one FIFO coordinator, so BridgeClient
+    // never runs two requests concurrently.
+    private var resolvedPaths: IPCPaths?
+    private let injectedPaths: IPCPaths?
     private let fileManager: FileManager
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
     private let staleInterval: TimeInterval
     private let configuration: BridgeClientConfiguration
+    private var didEnsureDirectories = false
+    private var didRunStartupMaintenance = false
+    private var lastStaleSweep: Date?
     var onResponseWarnings: (@Sendable (_ warnings: [String], _ op: String) -> Void)?
+    /// Test seam: replaces the OmniFocus URL dispatch so unit tests can
+    /// exercise the full request/response file lifecycle without launching
+    /// OmniFocus. Production code never sets this.
+    var dispatchHandlerForTesting: ((_ requestId: String) throws -> Void)?
 
     init(
-        paths: IPCPaths = .default(),
+        paths: IPCPaths? = nil,
         fileManager: FileManager = .default,
         staleInterval: TimeInterval = 600,
         configuration: BridgeClientConfiguration = .fromEnvironment(ProcessInfo.processInfo.environment)
     ) {
-        self.paths = paths
+        self.injectedPaths = paths
         self.fileManager = fileManager
         self.staleInterval = staleInterval
         self.configuration = configuration
@@ -24,6 +36,32 @@ final class BridgeClient: @unchecked Sendable {
         encoder.dateEncodingStrategy = .iso8601
         self.encoder = encoder
         self.decoder = BridgeDateDecoding.makeJSONDecoder()
+    }
+
+    /// Resolution is deferred to first use so the MCP server starts on
+    /// machines without OmniFocus and tool calls fail fast with an actionable
+    /// error instead of timing out.
+    private func requirePaths() throws -> IPCPaths {
+        if let resolvedPaths { return resolvedPaths }
+        let paths = try injectedPaths ?? IPCPaths.resolve(fileManager: fileManager)
+        resolvedPaths = paths
+        return paths
+    }
+
+    private func makeMaintenance(paths: IPCPaths) -> IPCMaintenance {
+        IPCMaintenance(
+            fileManager: fileManager,
+            paths: paths,
+            staleInterval: staleInterval,
+            currentSwiftVersion: FocusRelayBuildVersion.current
+        )
+    }
+
+    /// Called by the health check when the plugin reports its version, so a
+    /// plugin-only reinstall invalidates the IPC directory once.
+    func recordObservedPluginVersion(_ version: String) {
+        guard let paths = try? requirePaths() else { return }
+        makeMaintenance(paths: paths).recordObservedPluginVersion(version)
     }
 
     func listTasks(filter: TaskFilter, page: PageRequest, fields: [String]?) throws -> Page<TaskItem> {
@@ -377,35 +415,52 @@ final class BridgeClient: @unchecked Sendable {
     }
 
     private func ensureDirectories() throws {
-        try [paths.baseURL, paths.requestsURL, paths.responsesURL, paths.locksURL, paths.logsURL].forEach { url in
-            try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+        let paths = try requirePaths()
+        if !didEnsureDirectories {
+            let ownerOnly: [FileAttributeKey: Any] = [.posixPermissions: 0o700]
+            try [paths.baseURL, paths.requestsURL, paths.responsesURL, paths.locksURL, paths.dispatchURL].forEach { url in
+                try fileManager.createDirectory(at: url, withIntermediateDirectories: true, attributes: ownerOnly)
+            }
+            didEnsureDirectories = true
         }
-        cleanupStaleFiles()
+        if !didRunStartupMaintenance {
+            makeMaintenance(paths: paths).performStartupMaintenance()
+            didRunStartupMaintenance = true
+            lastStaleSweep = Date()
+        } else if shouldRunStaleSweep(lastSweep: lastStaleSweep, now: Date(), minimumInterval: staleInterval) {
+            makeMaintenance(paths: paths).sweepStaleFiles()
+            lastStaleSweep = Date()
+        }
     }
 
     private func writeRequest(_ request: BridgeRequest, requestId: String) throws {
-        let requestURL = paths.requestsURL.appendingPathComponent("\(requestId).json")
+        let requestURL = try requirePaths().requestsURL.appendingPathComponent("\(requestId).json")
         let data = try encoder.encode(request)
         try data.write(to: requestURL, options: .atomic)
+        // Atomic replace discards custom modes, so tighten after the write.
+        try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: requestURL.path)
     }
 
-    private var dispatchDirectoryURL: URL {
-        paths.baseURL.appendingPathComponent("dispatch", isDirectory: true)
-    }
-
-    private var dispatchRequestURL: URL {
-        dispatchDirectoryURL.appendingPathComponent("request.json")
+    private func dispatchRequestURL() throws -> URL {
+        try requirePaths().dispatchURL.appendingPathComponent("request.json")
     }
 
     private func writeDispatchRequestId(_ requestId: String) throws {
-        try fileManager.createDirectory(at: dispatchDirectoryURL, withIntermediateDirectories: true)
+        let paths = try requirePaths()
+        try fileManager.createDirectory(at: paths.dispatchURL, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
         let payload = ["requestId": requestId]
         let data = try JSONSerialization.data(withJSONObject: payload, options: [])
-        try data.write(to: dispatchRequestURL, options: .atomic)
+        let url = paths.dispatchURL.appendingPathComponent("request.json")
+        try data.write(to: url, options: .atomic)
+        try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
     }
 
     private func triggerOmniFocus(requestId: String) throws {
-        let script = bridgeScript(basePath: paths.baseURL.path, requestId: requestId)
+        if let dispatchHandlerForTesting {
+            try dispatchHandlerForTesting(requestId)
+            return
+        }
+        let script = bridgeScript(basePath: try requirePaths().baseURL.path, requestId: requestId)
         var allowed = CharacterSet.urlQueryAllowed
         allowed.remove(charactersIn: "&+=?")
         let encodedScript = script.addingPercentEncoding(withAllowedCharacters: allowed) ?? ""
@@ -424,6 +479,7 @@ final class BridgeClient: @unchecked Sendable {
 
     private func sendRequest<T: Decodable>(_ request: BridgeRequest, responseType: T.Type) throws -> BridgeResponse<T> {
         try ensureDirectories()
+        let paths = try requirePaths()
         let responseURL = paths.responsesURL.appendingPathComponent("\(request.requestId).json")
         let requestURL = paths.requestsURL.appendingPathComponent("\(request.requestId).json")
         let lockURL = paths.locksURL.appendingPathComponent("\(request.requestId).lock")
@@ -439,7 +495,15 @@ final class BridgeClient: @unchecked Sendable {
                 timeout: configuration.responseTimeout,
                 responseType: responseType
             )
-            removeIfExists(url: dispatchRequestURL)
+            // Response payloads carry task data; remove them as soon as they
+            // are consumed. Request and lock are belt-and-braces: the plugin
+            // also deletes them but swallows its own removal errors. Request
+            // IDs are never re-dispatched after success, so the plugin's
+            // duplicate-processing check is unaffected.
+            removeIfExists(url: responseURL)
+            removeIfExists(url: requestURL)
+            removeIfExists(url: lockURL)
+            removeIfExists(url: try dispatchRequestURL())
             if let warnings = response.warnings, !warnings.isEmpty {
                 onResponseWarnings?(warnings, request.op)
             }
@@ -448,7 +512,7 @@ final class BridgeClient: @unchecked Sendable {
             if !isTimeoutError(error) {
                 removeIfExists(url: requestURL)
                 removeIfExists(url: lockURL)
-                removeIfExists(url: dispatchRequestURL)
+                removeIfExists(url: (try? dispatchRequestURL()))
             }
             throw error
         }
@@ -558,28 +622,9 @@ final class BridgeClient: @unchecked Sendable {
         return nil
     }
 
-    private func cleanupStaleFiles() {
-        let now = Date()
-        [paths.requestsURL, paths.responsesURL, paths.locksURL].forEach { dir in
-            guard let items = try? fileManager.contentsOfDirectory(at: dir, includingPropertiesForKeys: [.contentModificationDateKey]) else {
-                return
-            }
-            for url in items {
-                guard let values = try? url.resourceValues(forKeys: [.contentModificationDateKey]),
-                      let modified = values.contentModificationDate else {
-                    continue
-                }
-                if now.timeIntervalSince(modified) > staleInterval {
-                    removeIfExists(url: url)
-                }
-            }
-        }
-    }
-
-    private func removeIfExists(url: URL) {
-        if fileManager.fileExists(atPath: url.path) {
-            try? fileManager.removeItem(at: url)
-        }
+    private func removeIfExists(url: URL?) {
+        guard let url, fileManager.fileExists(atPath: url.path) else { return }
+        try? fileManager.removeItem(at: url)
     }
 
     private func shouldRedispatchStrandedRequest(
@@ -693,7 +738,6 @@ private func bridgeScript(basePath: String, requestId: String) -> String {
         ensureDir(basePath + "/requests");
         ensureDir(basePath + "/responses");
         ensureDir(basePath + "/locks");
-        ensureDir(basePath + "/logs");
         var plugin = PlugIn.find("com.focusrelay.bridge");
         if (!plugin) {
           writeJSON(responsePath, { schemaVersion: 1, requestId: requestId, ok: false, error: { code: "PLUGIN_MISSING", message: "FocusRelay Bridge plug-in not installed" } });

--- a/Sources/OmniFocusAutomation/IPCMaintenance.swift
+++ b/Sources/OmniFocusAutomation/IPCMaintenance.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+/// Names allowed at the top level of the IPC base directory. Anything else is
+/// debris from an older build and is purged during startup maintenance.
+let ipcAllowedTopLevelNames: Set<String> = [
+    "requests",
+    "responses",
+    "locks",
+    "dispatch",
+    ipcVersionMarkerFileName
+]
+
+let ipcVersionMarkerFileName = "bridge-version.json"
+
+func isOutOfPolicyIPCEntry(name: String) -> Bool {
+    !ipcAllowedTopLevelNames.contains(name)
+}
+
+func shouldDeleteStaleIPCFile(modified: Date, now: Date, staleInterval: TimeInterval) -> Bool {
+    now.timeIntervalSince(modified) > staleInterval
+}
+
+func shouldRunStaleSweep(lastSweep: Date?, now: Date, minimumInterval: TimeInterval) -> Bool {
+    guard let lastSweep else { return true }
+    return now.timeIntervalSince(lastSweep) >= minimumInterval
+}
+
+func bridgeVersionMarkerMatches(marker: IPCVersionMarker?, currentSwiftVersion: String) -> Bool {
+    marker?.swiftVersion == currentSwiftVersion
+}
+
+struct IPCVersionMarker: Codable, Equatable {
+    var schemaVersion: Int
+    var swiftVersion: String
+    var pluginVersion: String?
+    var updatedAt: Date
+}
+
+/// Owns the impure IPC directory operations: one-time startup purge, throttled
+/// stale sweeps, permission repair, and the upgrade-invalidation marker.
+/// Pure decision logic stays in the free functions above so it is testable
+/// without a filesystem.
+struct IPCMaintenance {
+    let fileManager: FileManager
+    let paths: IPCPaths
+    let staleInterval: TimeInterval
+    let currentSwiftVersion: String
+
+    private static var ownerOnlyDirectory: [FileAttributeKey: Any] { [.posixPermissions: 0o700] }
+    private static var ownerOnlyFile: [FileAttributeKey: Any] { [.posixPermissions: 0o600] }
+
+    private var protocolDirectories: [URL] {
+        [paths.requestsURL, paths.responsesURL, paths.locksURL, paths.dispatchURL]
+    }
+
+    private var markerURL: URL {
+        paths.baseURL.appendingPathComponent(ipcVersionMarkerFileName)
+    }
+
+    /// Runs once per process before the first bridge request: purges debris,
+    /// resets the protocol directories when the binary version changed, and
+    /// repairs permissions.
+    func performStartupMaintenance(now: Date = Date()) {
+        purgeOutOfPolicyEntries()
+        if !bridgeVersionMarkerMatches(marker: readMarker(), currentSwiftVersion: currentSwiftVersion) {
+            resetProtocolDirectories()
+            writeMarker(pluginVersion: nil, now: now)
+        }
+        sweepStaleFiles(now: now)
+        assertOwnerOnlyPermissions()
+    }
+
+    /// Called when a bridge health check observes the plugin version. Resets
+    /// the protocol directories once when the plugin changed underneath us.
+    func recordObservedPluginVersion(_ pluginVersion: String, now: Date = Date()) {
+        let marker = readMarker()
+        guard marker?.pluginVersion != pluginVersion else { return }
+        if marker?.pluginVersion != nil {
+            resetProtocolDirectories()
+        }
+        writeMarker(pluginVersion: pluginVersion, now: now)
+    }
+
+    /// Deletes protocol files older than `staleInterval` in every protocol
+    /// directory, including `dispatch/`.
+    func sweepStaleFiles(now: Date = Date()) {
+        for directory in protocolDirectories {
+            guard let items = try? fileManager.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.contentModificationDateKey]
+            ) else { continue }
+            for url in items {
+                guard let values = try? url.resourceValues(forKeys: [.contentModificationDateKey]),
+                      let modified = values.contentModificationDate else { continue }
+                if shouldDeleteStaleIPCFile(modified: modified, now: now, staleInterval: staleInterval) {
+                    try? fileManager.removeItem(at: url)
+                }
+            }
+        }
+    }
+
+    /// Removes every top-level entry that is not part of the IPC protocol:
+    /// legacy `pid-*` trees, `default/`, trace files, and the retired `logs/`
+    /// directory. Never touches the protocol directories themselves.
+    private func purgeOutOfPolicyEntries() {
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: paths.baseURL,
+            includingPropertiesForKeys: nil
+        ) else { return }
+        for url in entries where isOutOfPolicyIPCEntry(name: url.lastPathComponent) {
+            try? fileManager.removeItem(at: url)
+        }
+    }
+
+    /// Clears the contents of the protocol directories without removing the
+    /// directories themselves, so in-flight path handles stay valid.
+    private func resetProtocolDirectories() {
+        for directory in protocolDirectories {
+            guard let items = try? fileManager.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: nil
+            ) else { continue }
+            for url in items {
+                try? fileManager.removeItem(at: url)
+            }
+        }
+    }
+
+    private func assertOwnerOnlyPermissions() {
+        for url in [paths.baseURL] + protocolDirectories {
+            try? fileManager.setAttributes(Self.ownerOnlyDirectory, ofItemAtPath: url.path)
+        }
+        if fileManager.fileExists(atPath: markerURL.path) {
+            try? fileManager.setAttributes(Self.ownerOnlyFile, ofItemAtPath: markerURL.path)
+        }
+    }
+
+    func readMarker() -> IPCVersionMarker? {
+        guard let data = try? Data(contentsOf: markerURL) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(IPCVersionMarker.self, from: data)
+    }
+
+    private func writeMarker(pluginVersion: String?, now: Date) {
+        let preservedPluginVersion = pluginVersion ?? readMarker()?.pluginVersion
+        let marker = IPCVersionMarker(
+            schemaVersion: 1,
+            swiftVersion: currentSwiftVersion,
+            pluginVersion: preservedPluginVersion,
+            updatedAt: now
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(marker) else { return }
+        try? data.write(to: markerURL, options: .atomic)
+        try? fileManager.setAttributes(Self.ownerOnlyFile, ofItemAtPath: markerURL.path)
+    }
+}

--- a/Sources/OmniFocusAutomation/IPCPaths.swift
+++ b/Sources/OmniFocusAutomation/IPCPaths.swift
@@ -5,34 +5,48 @@ struct IPCPaths {
     let requestsURL: URL
     let responsesURL: URL
     let locksURL: URL
-    let logsURL: URL
+    let dispatchURL: URL
 
     init(baseURL: URL) {
         self.baseURL = baseURL
         self.requestsURL = baseURL.appendingPathComponent("requests", isDirectory: true)
         self.responsesURL = baseURL.appendingPathComponent("responses", isDirectory: true)
         self.locksURL = baseURL.appendingPathComponent("locks", isDirectory: true)
-        self.logsURL = baseURL.appendingPathComponent("logs", isDirectory: true)
+        self.dispatchURL = baseURL.appendingPathComponent("dispatch", isDirectory: true)
     }
 
-    static func `default`() -> IPCPaths {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        let container = home
+    /// Resolves the fixed IPC location inside the OmniFocus 4 container.
+    /// The bridge plug-in can only write inside that container, so there is no
+    /// usable fallback location: when the container is absent the bridge can
+    /// never answer, and failing fast beats a silent response timeout.
+    static func resolve(
+        fileManager: FileManager = .default,
+        home: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) throws -> IPCPaths {
+        let containerData = home
             .appendingPathComponent("Library", isDirectory: true)
             .appendingPathComponent("Containers", isDirectory: true)
             .appendingPathComponent("com.omnigroup.OmniFocus4", isDirectory: true)
             .appendingPathComponent("Data", isDirectory: true)
-            .appendingPathComponent("Documents", isDirectory: true)
-            .appendingPathComponent("FocusRelayIPC", isDirectory: true)
 
-        if FileManager.default.fileExists(atPath: container.deletingLastPathComponent().path) {
-            return IPCPaths(baseURL: container)
+        guard fileManager.fileExists(atPath: containerData.path) else {
+            throw AutomationError.executionFailed(
+                "OmniFocus 4 container not found at ~/Library/Containers/com.omnigroup.OmniFocus4. "
+                    + "Install OmniFocus 4 and launch it once, then retry."
+            )
         }
 
-        let fallback = home
-            .appendingPathComponent("Library", isDirectory: true)
-            .appendingPathComponent("Caches", isDirectory: true)
-            .appendingPathComponent("focusrelay", isDirectory: true)
-        return IPCPaths(baseURL: fallback)
+        let base = containerData
+            .appendingPathComponent("Documents", isDirectory: true)
+            .appendingPathComponent("FocusRelayIPC", isDirectory: true)
+        return IPCPaths(baseURL: base)
+    }
+}
+
+/// Public view of the IPC location for tooling (benchmark diagnostics) that
+/// must not duplicate the container path.
+public enum IPCEnvironment {
+    public static func defaultBaseURL() throws -> URL {
+        try IPCPaths.resolve().baseURL
     }
 }

--- a/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
+++ b/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
@@ -232,6 +232,11 @@ public final class OmniFocusBridgeService: OmniFocusService {
     public func healthCheck() async throws -> BridgeHealthResult {
         try await runtime.submit(category: .health) {
             let response = try self.client.ping()
+            if response.ok, let version = response.data?.version {
+                // A plugin-only reinstall changes the observed version without
+                // a binary upgrade; invalidate the IPC directory once.
+                self.client.recordObservedPluginVersion(version)
+            }
             return BridgeHealthResult(
                 ok: response.ok,
                 plugin: response.data?.plugin,

--- a/Tests/OmniFocusIntegrationTests/IPCMaintenanceTests.swift
+++ b/Tests/OmniFocusIntegrationTests/IPCMaintenanceTests.swift
@@ -1,0 +1,301 @@
+import Foundation
+import Testing
+@testable import OmniFocusAutomation
+
+private func makeTemporaryIPCPaths() throws -> IPCPaths {
+    let base = FileManager.default.temporaryDirectory
+        .appendingPathComponent("focusrelay-ipc-tests", isDirectory: true)
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let paths = IPCPaths(baseURL: base)
+    for url in [paths.baseURL, paths.requestsURL, paths.responsesURL, paths.locksURL, paths.dispatchURL] {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+    return paths
+}
+
+private func makeMaintenance(
+    paths: IPCPaths,
+    staleInterval: TimeInterval = 600,
+    swiftVersion: String = "1.0.0-test"
+) -> IPCMaintenance {
+    IPCMaintenance(
+        fileManager: .default,
+        paths: paths,
+        staleInterval: staleInterval,
+        currentSwiftVersion: swiftVersion
+    )
+}
+
+private func write(_ text: String, to url: URL, modified: Date? = nil) throws {
+    try text.data(using: .utf8)!.write(to: url)
+    if let modified {
+        try FileManager.default.setAttributes([.modificationDate: modified], ofItemAtPath: url.path)
+    }
+}
+
+private func posixPermissions(at url: URL) -> Int? {
+    (try? FileManager.default.attributesOfItem(atPath: url.path))?[.posixPermissions] as? Int
+}
+
+@Suite("IPC maintenance policy")
+struct IPCMaintenancePolicyTests {
+    @Test func outOfPolicyClassificationPurgesOrphansAndKeepsProtocolDirs() {
+        #expect(!isOutOfPolicyIPCEntry(name: "requests"))
+        #expect(!isOutOfPolicyIPCEntry(name: "responses"))
+        #expect(!isOutOfPolicyIPCEntry(name: "locks"))
+        #expect(!isOutOfPolicyIPCEntry(name: "dispatch"))
+        #expect(!isOutOfPolicyIPCEntry(name: "bridge-version.json"))
+        #expect(isOutOfPolicyIPCEntry(name: "logs"))
+        #expect(isOutOfPolicyIPCEntry(name: "pid-12345"))
+        #expect(isOutOfPolicyIPCEntry(name: "default"))
+        #expect(isOutOfPolicyIPCEntry(name: "ABC123.trace.json"))
+        #expect(isOutOfPolicyIPCEntry(name: "anything-unknown"))
+    }
+
+    @Test func staleFileDecisionRespectsInterval() {
+        let now = Date()
+        #expect(shouldDeleteStaleIPCFile(modified: now.addingTimeInterval(-601), now: now, staleInterval: 600))
+        #expect(!shouldDeleteStaleIPCFile(modified: now.addingTimeInterval(-599), now: now, staleInterval: 600))
+    }
+
+    @Test func staleSweepThrottleSkipsRecentSweep() {
+        let now = Date()
+        #expect(shouldRunStaleSweep(lastSweep: nil, now: now, minimumInterval: 600))
+        #expect(shouldRunStaleSweep(lastSweep: now.addingTimeInterval(-600), now: now, minimumInterval: 600))
+        #expect(!shouldRunStaleSweep(lastSweep: now.addingTimeInterval(-1), now: now, minimumInterval: 600))
+    }
+
+    @Test func versionMarkerMismatchDetection() {
+        let marker = IPCVersionMarker(
+            schemaVersion: 1,
+            swiftVersion: "0.12.0-beta",
+            pluginVersion: "0.12.0-beta",
+            updatedAt: Date()
+        )
+        #expect(bridgeVersionMarkerMatches(marker: marker, currentSwiftVersion: "0.12.0-beta"))
+        #expect(!bridgeVersionMarkerMatches(marker: marker, currentSwiftVersion: "0.13.0-beta"))
+        #expect(!bridgeVersionMarkerMatches(marker: nil, currentSwiftVersion: "0.12.0-beta"))
+    }
+}
+
+@Suite("IPC maintenance filesystem behavior")
+struct IPCMaintenanceBehaviorTests {
+    @Test func startupPurgeRemovesOrphansAndPreservesFreshInFlightFiles() throws {
+        let paths = try makeTemporaryIPCPaths()
+        defer { try? FileManager.default.removeItem(at: paths.baseURL) }
+        let fm = FileManager.default
+
+        // Establish the marker first so this run exercises the steady state,
+        // not the first-run upgrade reset (covered by the version test).
+        makeMaintenance(paths: paths).performStartupMaintenance()
+
+        // Orphans at the top level.
+        try fm.createDirectory(at: paths.baseURL.appendingPathComponent("pid-9999"), withIntermediateDirectories: true)
+        try fm.createDirectory(at: paths.baseURL.appendingPathComponent("default"), withIntermediateDirectories: true)
+        try fm.createDirectory(at: paths.baseURL.appendingPathComponent("logs"), withIntermediateDirectories: true)
+        try write("{}", to: paths.baseURL.appendingPathComponent("ABC.trace.json"))
+        // Fresh in-flight protocol file.
+        let inflight = paths.requestsURL.appendingPathComponent("fresh.json")
+        try write("{}", to: inflight)
+
+        makeMaintenance(paths: paths).performStartupMaintenance()
+
+        let remaining = Set(try fm.contentsOfDirectory(atPath: paths.baseURL.path))
+        #expect(!remaining.contains("pid-9999"))
+        #expect(!remaining.contains("default"))
+        #expect(!remaining.contains("logs"))
+        #expect(!remaining.contains("ABC.trace.json"))
+        #expect(fm.fileExists(atPath: inflight.path),
+                "fresh in-flight files must survive maintenance when the version matches")
+        #expect(remaining.contains("bridge-version.json"), "startup maintenance writes the version marker")
+    }
+
+    @Test func startupResetOnVersionMismatchClearsProtocolDirs() throws {
+        let paths = try makeTemporaryIPCPaths()
+        defer { try? FileManager.default.removeItem(at: paths.baseURL) }
+        let fm = FileManager.default
+
+        // A missing marker means the directory predates hardening — treated
+        // as an upgrade, so the first run resets the protocol dirs.
+        let preHardening = paths.responsesURL.appendingPathComponent("old.json")
+        try write("{}", to: preHardening)
+        makeMaintenance(paths: paths, swiftVersion: "1.0.0").performStartupMaintenance()
+        #expect(!fm.fileExists(atPath: preHardening.path),
+                "missing marker must be treated as an upgrade and reset protocol dirs")
+
+        // Same version again: fresh protocol files survive.
+        let kept = paths.responsesURL.appendingPathComponent("kept.json")
+        try write("{}", to: kept)
+        makeMaintenance(paths: paths, swiftVersion: "1.0.0").performStartupMaintenance()
+        #expect(fm.fileExists(atPath: kept.path), "matching version must not reset protocol dirs")
+
+        // Version bump: protocol dirs are cleared exactly once.
+        makeMaintenance(paths: paths, swiftVersion: "2.0.0").performStartupMaintenance()
+        #expect(!fm.fileExists(atPath: kept.path), "version mismatch must clear protocol dirs")
+
+        let maintenance = makeMaintenance(paths: paths, swiftVersion: "2.0.0")
+        #expect(maintenance.readMarker()?.swiftVersion == "2.0.0")
+    }
+
+    @Test func pluginVersionChangeResetsProtocolDirsOnce() throws {
+        let paths = try makeTemporaryIPCPaths()
+        defer { try? FileManager.default.removeItem(at: paths.baseURL) }
+        let fm = FileManager.default
+        let maintenance = makeMaintenance(paths: paths)
+        maintenance.performStartupMaintenance()
+
+        // First observation records the version without a reset.
+        let beforeFirst = paths.responsesURL.appendingPathComponent("a.json")
+        try write("{}", to: beforeFirst)
+        maintenance.recordObservedPluginVersion("1.0.0")
+        #expect(fm.fileExists(atPath: beforeFirst.path), "first plugin observation must not reset")
+        #expect(maintenance.readMarker()?.pluginVersion == "1.0.0")
+
+        // Same version again: no reset.
+        maintenance.recordObservedPluginVersion("1.0.0")
+        #expect(fm.fileExists(atPath: beforeFirst.path))
+
+        // Changed version: reset once.
+        maintenance.recordObservedPluginVersion("2.0.0")
+        #expect(!fm.fileExists(atPath: beforeFirst.path), "plugin version change must reset protocol dirs")
+        #expect(maintenance.readMarker()?.pluginVersion == "2.0.0")
+    }
+
+    @Test func maintenanceAssertsOwnerOnlyDirectoryPermissions() throws {
+        let paths = try makeTemporaryIPCPaths()
+        defer { try? FileManager.default.removeItem(at: paths.baseURL) }
+        // Simulate pre-hardening world-readable directories.
+        for url in [paths.baseURL, paths.requestsURL, paths.responsesURL, paths.locksURL, paths.dispatchURL] {
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        }
+
+        makeMaintenance(paths: paths).performStartupMaintenance()
+
+        for url in [paths.baseURL, paths.requestsURL, paths.responsesURL, paths.locksURL, paths.dispatchURL] {
+            #expect(posixPermissions(at: url) == 0o700, "\(url.lastPathComponent) must be owner-only")
+        }
+        let marker = paths.baseURL.appendingPathComponent(ipcVersionMarkerFileName)
+        #expect(posixPermissions(at: marker) == 0o600, "marker must be owner-only")
+    }
+
+    @Test func sweepIncludesDispatchDirectory() throws {
+        let paths = try makeTemporaryIPCPaths()
+        defer { try? FileManager.default.removeItem(at: paths.baseURL) }
+        let fm = FileManager.default
+        let old = Date().addingTimeInterval(-3600)
+
+        let staleDispatch = paths.dispatchURL.appendingPathComponent("request.json")
+        let staleResponse = paths.responsesURL.appendingPathComponent("stale.json")
+        let freshRequest = paths.requestsURL.appendingPathComponent("fresh.json")
+        try write("{}", to: staleDispatch, modified: old)
+        try write("{}", to: staleResponse, modified: old)
+        try write("{}", to: freshRequest)
+
+        makeMaintenance(paths: paths).sweepStaleFiles()
+
+        #expect(!fm.fileExists(atPath: staleDispatch.path), "dispatch/ must be swept")
+        #expect(!fm.fileExists(atPath: staleResponse.path))
+        #expect(fm.fileExists(atPath: freshRequest.path))
+    }
+
+    @Test func resolveThrowsActionableErrorWithoutOmniFocusContainer() throws {
+        let fakeHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("focusrelay-fake-home-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: fakeHome, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: fakeHome) }
+
+        #expect {
+            _ = try IPCPaths.resolve(home: fakeHome)
+        } throws: { error in
+            guard case let AutomationError.executionFailed(message) = error else { return false }
+            return message.contains("OmniFocus 4") && message.contains("Install")
+        }
+    }
+
+    @Test func resolveReturnsContainerPathWhenPresent() throws {
+        let fakeHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("focusrelay-fake-home-\(UUID().uuidString)", isDirectory: true)
+        let containerData = fakeHome
+            .appendingPathComponent("Library/Containers/com.omnigroup.OmniFocus4/Data", isDirectory: true)
+        try FileManager.default.createDirectory(at: containerData, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: fakeHome) }
+
+        let paths = try IPCPaths.resolve(home: fakeHome)
+        #expect(paths.baseURL.path.hasSuffix("Data/Documents/FocusRelayIPC"))
+    }
+}
+
+@Suite("BridgeClient response consumption")
+struct BridgeClientResponseConsumptionTests {
+    @Test func successfulDecodeRemovesResponseRequestAndLock() throws {
+        let paths = try makeTemporaryIPCPaths()
+        defer { try? FileManager.default.removeItem(at: paths.baseURL) }
+        let fm = FileManager.default
+
+        let client = BridgeClient(paths: paths)
+        // Simulated plugin: answer every dispatched request with a valid ping
+        // response, exercising the real sendRequest/waitForResponse path
+        // without launching OmniFocus.
+        client.dispatchHandlerForTesting = { requestId in
+            let response = #"{"schemaVersion":1,"requestId":"\#(requestId)","ok":true,"data":{"ok":true,"plugin":"FocusRelay Bridge","version":"1.0.0-test"}}"#
+            try response.data(using: .utf8)!.write(
+                to: paths.responsesURL.appendingPathComponent("\(requestId).json")
+            )
+        }
+
+        let response = try client.ping()
+        #expect(response.ok)
+        #expect(response.data?.version == "1.0.0-test")
+
+        for directory in [paths.requestsURL, paths.responsesURL, paths.locksURL] {
+            let entries = try fm.contentsOfDirectory(atPath: directory.path)
+            #expect(entries.isEmpty, "\(directory.lastPathComponent) must hold no artifacts after a successful call")
+        }
+        let dispatchEntries = try fm.contentsOfDirectory(atPath: paths.dispatchURL.path)
+        #expect(dispatchEntries.isEmpty, "dispatch/request.json must be removed after a successful call")
+    }
+
+    @Test func timeoutPathRetainsArtifacts() throws {
+        let paths = try makeTemporaryIPCPaths()
+        defer { try? FileManager.default.removeItem(at: paths.baseURL) }
+        let fm = FileManager.default
+
+        let client = BridgeClient(
+            paths: paths,
+            configuration: BridgeClientConfiguration(responseTimeout: 0.3, responsePollInterval: 0.02)
+        )
+        // Simulated stuck plugin: write the lock so redispatch/late-recovery
+        // stay off, then never answer.
+        client.dispatchHandlerForTesting = { requestId in
+            let lockURL = paths.locksURL.appendingPathComponent("\(requestId).lock")
+            if !fm.fileExists(atPath: lockURL.path) {
+                try Data("{}".utf8).write(to: lockURL)
+            }
+        }
+
+        #expect(throws: AutomationError.self) {
+            _ = try client.ping()
+        }
+        let requestEntries = try fm.contentsOfDirectory(atPath: paths.requestsURL.path)
+        #expect(!requestEntries.isEmpty, "timeout must retain the request for late-arrival recovery")
+    }
+
+    @Test func requestFilesAreWrittenOwnerOnly() throws {
+        let paths = try makeTemporaryIPCPaths()
+        defer { try? FileManager.default.removeItem(at: paths.baseURL) }
+
+        let client = BridgeClient(paths: paths)
+        var observedRequestMode: Int?
+        client.dispatchHandlerForTesting = { requestId in
+            let requestURL = paths.requestsURL.appendingPathComponent("\(requestId).json")
+            observedRequestMode = posixPermissions(at: requestURL)
+            let response = #"{"schemaVersion":1,"requestId":"\#(requestId)","ok":true,"data":{"ok":true,"plugin":"FocusRelay Bridge","version":"1.0.0-test"}}"#
+            try response.data(using: .utf8)!.write(
+                to: paths.responsesURL.appendingPathComponent("\(requestId).json")
+            )
+        }
+
+        _ = try client.ping()
+        #expect(observedRequestMode == 0o600, "request payloads must be owner-only on disk")
+    }
+}


### PR DESCRIPTION
Closes #197.

## What changed

**Retention.** Responses, requests, and locks are deleted immediately after a successful decode, so a successful round trip now leaves nothing on disk. The stale sweep is throttled to once per stale interval instead of running on every request, and it finally covers `dispatch/`. Startup maintenance purges every non-allowlisted top-level entry.

**Permissions.** The Swift side is authoritative: protocol directories are created and repaired to `0700`, and Swift-written files are chmod'd to `0600` after each atomic write (atomic replace discards custom modes, so it has to be chmod-after-write — the directory is the enforcement boundary).

**Upgrade invalidation.** A `bridge-version.json` marker records the owning binary version and the last observed plug-in version. A mismatch — or a missing marker, meaning the directory predates hardening — clears the protocol directories once. No ping and no OmniFocus launch are needed for the binary-version path.

**Fail-fast.** The `~/Library/Caches/focusrelay` fallback is removed: sandboxed OmniFocus can never write there, so that branch could only ever deadlock. Path resolution is now lazy and throws an actionable "install and launch OmniFocus 4" error, letting the server start without OmniFocus while tool calls fail fast instead of hanging for the full timeout. `IPCEnvironment.defaultBaseURL()` replaces the container path duplicated in benchmark diagnostics.

**Plug-in.** All file-based debug logging is removed; `logs/` is no longer created by either side. Nothing read those files programmatically.

## Validation

Impact: `transport-reliability`.

- `swift test` — 235 tests pass, including 14 new ones in `IPCMaintenanceTests`.
- `focusrelay-dev validate --impact transport-reliability` — all semantic gates pass; every count contract matches its list total.
- Live verification after plug-in reinstall and a full OmniFocus restart: health check OK, query burst clean, IPC directory went from ~44 MB / ~11k files to ~44 KB, all directories `drwx------`, marker written, no artifacts left by successful calls.

## Not included

Latency evidence. The first canary attempt ran against a debug build while four stale `focusrelay serve` processes contended for the single Bridge lane, producing meaningless numbers. A clean release-build before/after belongs with #73, which owns performance measurement; this PR ships the retention behavior for data-hygiene reasons regardless of the perf outcome.

## Risks accepted (documented in IPC-SPEC.md)

Late-arriving responses after a client timeout now persist up to the stale interval rather than being swept on the next request — bounded, and request IDs are never reused. A version-mismatch reset can fail at most one in-flight request of a concurrently running old server, surfaced as retryable. Dev builds all report `0.0.0-dev`, so dev-to-dev upgrades don't trigger a reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)