### PR TITLE
Document Claude Code setup, scope support to terminal clients, resequence roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,57 @@ Configure a local stdio MCP server with:
 - arguments: `serve`
 
 <details>
+<summary>Claude Code configuration</summary>
+
+Claude Code registers MCP servers from the command line, so no file editing is
+required:
+
+```bash
+claude mcp add --scope user focusrelay /opt/homebrew/bin/focusrelay serve
+```
+
+`--scope user` makes FocusRelay available in every project on your Mac. Use
+`--scope project` instead to share the server with collaborators through a
+checked-in `.mcp.json`, or omit the flag to enable it only in the current
+directory.
+
+Confirm the server is registered and reachable:
+
+```bash
+claude mcp list
+```
+
+FocusRelay should report `✔ Connected`. Remove it later with
+`claude mcp remove --scope user focusrelay`.
+
+</details>
+
+<details>
+<summary>Claude Desktop configuration</summary>
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` and add
+FocusRelay to `mcpServers`, keeping any servers already listed:
+
+```json
+{
+  "mcpServers": {
+    "focusrelay": {
+      "command": "/opt/homebrew/bin/focusrelay",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+Quit and reopen Claude Desktop; it reads this file only at launch. FocusRelay
+then appears in the app's MCP server list.
+
+Use the absolute path. Claude Desktop does not inherit your shell `PATH`, so a
+bare `focusrelay` command fails to launch.
+
+</details>
+
+<details>
 <summary>OpenCode configuration example</summary>
 
 ```json
@@ -301,6 +352,28 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
 The plugin JavaScript is cached by OmniFocus. Reinstall the plugin and restart
 OmniFocus completely. Project and tag catalogs cache for five minutes; task
 queries are always fresh.
+
+### The plugin and binary versions do not match
+
+Upgrading the Homebrew formula replaces the binary but leaves the copy of the
+plugin already inside OmniFocus untouched, so a skipped step 2 can strand the
+plugin many releases behind. Compare the two versions:
+
+```bash
+focusrelay --version
+grep -o '"version": "[^"]*"' \
+  "$HOME/Library/Containers/com.omnigroup.OmniFocus4/Data/Library/Application Support/Plug-Ins/FocusRelayBridge.omnijs/manifest.json"
+```
+
+If they differ, repeat step 2 and step 3, then confirm the bridge reports the
+new version:
+
+```bash
+focusrelay bridge-health-check
+```
+
+A healthy bridge returns `"ok":true` with the same version as
+`focusrelay --version`.
 
 ### A time-based result looks wrong after travel
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ open -a "OmniFocus"
 
 ### 4. Add FocusRelay to your AI assistant
 
+FocusRelay currently supports terminal-based MCP clients: Claude Code,
+OpenCode, Codex CLI, and other clients launched from a terminal. Desktop
+applications such as Claude Desktop and ChatGPT's desktop app are not yet
+supported: macOS restricts their access to the OmniFocus data FocusRelay
+relies on. Desktop-app support is tracked in
+[#196](https://github.com/deverman/FocusRelayMCP/issues/196).
+
 Configure a local stdio MCP server with:
 
 - command: `/opt/homebrew/bin/focusrelay`
@@ -181,31 +188,6 @@ claude mcp list
 
 FocusRelay should report `✔ Connected`. Remove it later with
 `claude mcp remove --scope user focusrelay`.
-
-</details>
-
-<details>
-<summary>Claude Desktop configuration</summary>
-
-Edit `~/Library/Application Support/Claude/claude_desktop_config.json` and add
-FocusRelay to `mcpServers`, keeping any servers already listed:
-
-```json
-{
-  "mcpServers": {
-    "focusrelay": {
-      "command": "/opt/homebrew/bin/focusrelay",
-      "args": ["serve"]
-    }
-  }
-}
-```
-
-Quit and reopen Claude Desktop; it reads this file only at launch. FocusRelay
-then appears in the app's MCP server list.
-
-Use the absolute path. Claude Desktop does not inherit your shell `PATH`, so a
-bare `focusrelay` command fails to launch.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -132,14 +132,28 @@ future formula in the tap. See Homebrew’s
 
 ### 2. Install the OmniFocus plugin
 
+OmniFocus reads plug-ins from more than one folder, and **if you have OmniFocus
+plug-in sync turned on it prefers the iCloud folder**. Install into every folder
+that exists on your Mac, so OmniFocus cannot load a stale copy:
+
 ```bash
-mkdir -p "$HOME/Library/Containers/com.omnigroup.OmniFocus4/Data/Library/Application Support/Plug-Ins"
-cp -R "$(brew --prefix focusrelay)/share/focusrelay/Plugin/FocusRelayBridge.omnijs" \
-  "$HOME/Library/Containers/com.omnigroup.OmniFocus4/Data/Library/Application Support/Plug-Ins/"
+SRC="$(brew --prefix focusrelay)/share/focusrelay/Plugin/FocusRelayBridge.omnijs"
+
+# Sandbox container (always present)
+DEST="$HOME/Library/Containers/com.omnigroup.OmniFocus4/Data/Library/Application Support/Plug-Ins"
+mkdir -p "$DEST" && cp -R "$SRC" "$DEST/"
+
+# iCloud plug-in folder (only when plug-in sync is enabled)
+ICLOUD="$HOME/Library/Mobile Documents/iCloud~com~omnigroup~OmniFocus/Documents/Plug-Ins"
+[ -d "$ICLOUD" ] && cp -R "$SRC" "$ICLOUD/" && echo "also installed to iCloud"
 ```
 
-The plugin and binary must stay on the same version. Repeat this copy step after
-upgrading FocusRelay.
+The plugin and binary must stay on the same version. Repeat this step after
+upgrading FocusRelay — a skipped reinstall leaves OmniFocus running the old
+plug-in with no visible error.
+
+Building from source? Use `./scripts/install-plugin.sh` instead; it detects and
+updates every plug-in folder for you, including custom ones.
 
 ### 3. Restart OmniFocus
 
@@ -337,25 +351,35 @@ queries are always fresh.
 
 ### The plugin and binary versions do not match
 
-Upgrading the Homebrew formula replaces the binary but leaves the copy of the
-plugin already inside OmniFocus untouched, so a skipped step 2 can strand the
-plugin many releases behind. Compare the two versions:
+Upgrading the Homebrew formula replaces the binary but leaves the copies of the
+plugin already installed for OmniFocus untouched, so a skipped step 2 can
+strand the plugin many releases behind.
+
+Ask the bridge what it is actually running, and compare it against the binary:
 
 ```bash
 focusrelay --version
-grep -o '"version": "[^"]*"' \
-  "$HOME/Library/Containers/com.omnigroup.OmniFocus4/Data/Library/Application Support/Plug-Ins/FocusRelayBridge.omnijs/manifest.json"
-```
-
-If they differ, repeat step 2 and step 3, then confirm the bridge reports the
-new version:
-
-```bash
 focusrelay bridge-health-check
 ```
 
 A healthy bridge returns `"ok":true` with the same version as
-`focusrelay --version`.
+`focusrelay --version`. If the versions differ, repeat step 2 and step 3.
+
+**If the reported version still does not change**, OmniFocus is loading a
+different copy of the plug-in than the one you updated. List every copy on your
+Mac and check each one:
+
+```bash
+find ~/Library -name "FocusRelayBridge.omnijs" -maxdepth 8 2>/dev/null | while read -r p; do
+  printf '%s\n    %s\n' "$p" "$(grep -m1 -o 'FOCUSRELAY_VERSION = "[^"]*"' "$p/Resources/BridgeLibrary.js")"
+done
+```
+
+Every copy must report the same version as the binary. The iCloud folder
+(`~/Library/Mobile Documents/iCloud~com~omnigroup~OmniFocus/Documents/Plug-Ins`)
+takes priority when OmniFocus plug-in sync is enabled, so a current copy in the
+sandbox container is not enough on its own. Update the stale copies, then quit
+and reopen OmniFocus completely.
 
 ### A time-based result looks wrong after travel
 

--- a/docs/roadmap-execution-plan.md
+++ b/docs/roadmap-execution-plan.md
@@ -18,9 +18,10 @@ IPC directory, which holds task data at rest.
    - Retention policy, owner-only permissions, upgrade invalidation, and
      fail-fast container resolution. Security-motivated; ships regardless of
      measured performance outcome.
-2. [#73 — IPC cleanup performance measurement](https://github.com/deverman/FocusRelayMCP/issues/73)
-   - Rescoped as #197's measurement sibling; runs immediately after #197
-     merges. Its revert-if-no-win rule applies to perf tuning only.
+2. [#200 — plug-in loaded from the wrong directory](https://github.com/deverman/FocusRelayMCP/issues/200)
+   - Documentation fix shipped; the durable fix is reporting the loaded
+     plug-in path from the health check so a stale bundle is visible
+     without manual filesystem inspection.
 3. [#172 — bounded task-detail lookup](https://github.com/deverman/FocusRelayMCP/issues/172)
    - Replace repeated one-task calls with one stable-ID query that returns only
      the details needed for a workflow decision.

--- a/docs/roadmap-execution-plan.md
+++ b/docs/roadmap-execution-plan.md
@@ -1,62 +1,69 @@
 # FocusRelay Roadmap Execution Plan
 
-Last updated: 2026-07-29
+Last updated: 2026-08-01
 
 GitHub issues own requirements, discussion, and validation evidence. This file
 records only current sequencing and cross-issue dependencies.
 
-## Next Beta
+## Current Focus
 
-[`v0.12.0-beta`](https://github.com/deverman/FocusRelayMCP/milestone/1)
-packages the merged reliable-inbox workflow and bounded Bridge architecture.
-[#188](https://github.com/deverman/FocusRelayMCP/issues/188) owns its release
-gates. The final production blocker and client-restart UAT are complete; freeze
-the candidate and run the release validation once.
+`v0.12.0-beta` shipped (#188 closed). The next slice is
+[#197 — IPC directory hardening](https://github.com/deverman/FocusRelayMCP/issues/197):
+retention, owner-only permissions, and upgrade invalidation for the bridge
+IPC directory, which holds task data at rest.
 
 ## Delivery Order
 
-1. [#188 — release v0.12.0-beta](https://github.com/deverman/FocusRelayMCP/issues/188)
-   - Complete headline UAT, freeze one production fingerprint, and run the
-     fail-closed release gates before tagging.
-2. [#172 — bounded task-detail lookup](https://github.com/deverman/FocusRelayMCP/issues/172)
+1. [#197 — harden bridge IPC directory](https://github.com/deverman/FocusRelayMCP/issues/197)
+   - Retention policy, owner-only permissions, upgrade invalidation, and
+     fail-fast container resolution. Security-motivated; ships regardless of
+     measured performance outcome.
+2. [#73 — IPC cleanup performance measurement](https://github.com/deverman/FocusRelayMCP/issues/73)
+   - Rescoped as #197's measurement sibling; runs immediately after #197
+     merges. Its revert-if-no-win rule applies to perf tuning only.
+3. [#172 — bounded task-detail lookup](https://github.com/deverman/FocusRelayMCP/issues/172)
    - Replace repeated one-task calls with one stable-ID query that returns only
      the details needed for a workflow decision.
-3. [#171 — multi-name project and tag resolution](https://github.com/deverman/FocusRelayMCP/issues/171)
+4. [#171 — multi-name project and tag resolution](https://github.com/deverman/FocusRelayMCP/issues/171)
    - Resolve a bounded set of requested names through the existing catalog cache
      instead of repeating full catalog queries.
-4. [#173 — atomic heterogeneous task edit plans](https://github.com/deverman/FocusRelayMCP/issues/173)
+5. [#173 — atomic heterogeneous task edit plans](https://github.com/deverman/FocusRelayMCP/issues/173)
    - Design the larger approved-workflow batch only after #172 and #171 reduce
      its read-before-write query cost.
-5. [#94 — discoverable MCP workflows](https://github.com/deverman/FocusRelayMCP/issues/94)
+6. [#94 — discoverable MCP workflows](https://github.com/deverman/FocusRelayMCP/issues/94)
    - Continue measured client research after the shipped `process_inbox`
      vertical; add another prompt only when UAT demonstrates a reliable benefit.
-6. [#82 — task/subtask creation](https://github.com/deverman/FocusRelayMCP/issues/82), then
+7. [#82 — task/subtask creation](https://github.com/deverman/FocusRelayMCP/issues/82), then
    [#83 — project creation/conversion](https://github.com/deverman/FocusRelayMCP/issues/83)
    - Build on the consolidated edit surface, support safe project folder
      destinations, and retain duplicate/write safety.
-7. [#93 — repetition support](https://github.com/deverman/FocusRelayMCP/issues/93)
+8. [#93 — repetition support](https://github.com/deverman/FocusRelayMCP/issues/93)
    - After task creation and truthful drop behavior stabilize, establish complete
      schedule readback before adding create, edit, and lifecycle mutation slices.
-8. [#130 — project tag membership and filtering](https://github.com/deverman/FocusRelayMCP/issues/130), then
+9. [#130 — project tag membership and filtering](https://github.com/deverman/FocusRelayMCP/issues/130), then
    [#128 — create and assign missing tags](https://github.com/deverman/FocusRelayMCP/issues/128)
    - Query direct project membership by stable ID before creating missing root
      or nested tags during assignment.
-9. [#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88), then
+10. [#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88), then
    [#87 — project-health filters](https://github.com/deverman/FocusRelayMCP/issues/87)
    - Reduce context before expanding project-review workflows.
-10. [#85 — safe Forecast contract](https://github.com/deverman/FocusRelayMCP/issues/85), then
+11. [#85 — safe Forecast contract](https://github.com/deverman/FocusRelayMCP/issues/85), then
    [#125 — Forecast-based attention](https://github.com/deverman/FocusRelayMCP/issues/125), then
    [#126 — broader ranked task search](https://github.com/deverman/FocusRelayMCP/issues/126)
    - Reuse one documented task-only Forecast classifier for attention ranking.
    - Keep search independent, broad, relevance-ranked, and lightweight.
-11. [#92 — guided Homebrew setup](https://github.com/deverman/FocusRelayMCP/issues/92)
+12. [#92 — guided Homebrew setup](https://github.com/deverman/FocusRelayMCP/issues/92)
     - Reduce installation friction after the next product capabilities settle.
-12. Measured transport and command experiments:
-    [#90](https://github.com/deverman/FocusRelayMCP/issues/90) and
-    [#73](https://github.com/deverman/FocusRelayMCP/issues/73).
-13. Small independent query improvements: #11, #22, #18, #59, #62, #65,
+    - Do not finalize the installer flow before the #196 signing verdict
+      lands; a Developer ID pipeline or LaunchAgent directly shapes it.
+13. Measured transport and command experiments:
+    [#90 — command/session latency](https://github.com/deverman/FocusRelayMCP/issues/90) and
+    [#196 — multi-host transport spike](https://github.com/deverman/FocusRelayMCP/issues/196)
+    (decision-revisit: TCC diagnosis and Developer ID signing feasibility;
+    depends on #197 for the on-disk contract it would inherit).
+14. Small independent query improvements: #11, #22, #18, #59, #62, #65,
     #66, #67, and #68.
-14. Feasibility work for #10 custom perspectives and #16 planned-date writes.
+15. Feasibility work for #10 custom perspectives and #16 planned-date writes.
 
 ## Standing Decisions
 
@@ -85,8 +92,8 @@ the candidate and run the release validation once.
 
 ## Release Reference
 
-- Current release: [`v0.11.0-beta`](https://github.com/deverman/FocusRelayMCP/releases/tag/v0.11.0-beta)
-- Planned release: [`v0.12.0-beta`](https://github.com/deverman/FocusRelayMCP/issues/188)
+- Current release: [`v0.12.0-beta`](https://github.com/deverman/FocusRelayMCP/releases/tag/v0.12.0-beta)
+- Release notes: [`release-notes-v0.12.0-beta.md`](release-notes-v0.12.0-beta.md)
 - Release engineering: [`release-engineering-checklist.md`](release-engineering-checklist.md)
 - Development validation: [`development-workflow.md`](development-workflow.md)
 - User-facing changes: [`../CHANGELOG.md`](../CHANGELOG.md)


### PR DESCRIPTION
Documentation-only. Impact: `docs` (`focusrelay-dev validate --impact docs` passes — local Markdown links valid).

## Claude Code setup

The README covered OpenCode but gave no Claude-specific instructions. Adds a `claude mcp add` block with scope guidance (`--scope user` vs `project` vs local), `claude mcp list` verification, and the removal command. Verified end to end against a live OmniFocus database.

## Terminal-only support statement

The Claude Desktop setup block is removed. Claude Desktop cannot complete a bridge round trip: macOS TCC App Data protection blocks desktop-app-hosted processes from the OmniFocus container that holds the IPC rendezvous. The README now states which clients are supported (Claude Code, OpenCode, Codex CLI, and other terminal-launched clients) and links #196, which tracks desktop-app support.

This corrects an earlier commit on this branch that documented Desktop setup before the limitation was understood.

## Version-mismatch troubleshooting

Adds a troubleshooting entry for the plug-in/binary version mismatch. Upgrading via Homebrew replaces the binary but leaves the copy of the plug-in already inside OmniFocus untouched, so a skipped reinstall strands the plug-in silently — observed in the field at a 0.1.0 plug-in against a 0.12.0-beta binary. Includes the exact commands to compare both versions and confirm the bridge reports the new one.

## Roadmap resequencing

`docs/roadmap-execution-plan.md` still listed the closed #188 as step 1. Retires it, puts #197 (IPC hardening) at the top as the next slice, adds #73 as its rescoped performance-measurement sibling, and slots the #196 spike into the transport-experiments step. Notes that #92's installer flow should not be finalized before #196's signing verdict lands, since a Developer ID pipeline or LaunchAgent would shape it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)