### PR TITLE
Report installed plug-in copies from bridge-health-check (#200)

### DIFF
--- a/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
+++ b/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
@@ -1,3 +1,4 @@
+import FocusRelayVersion
 import Foundation
 import OmniFocusCore
 
@@ -237,11 +238,18 @@ public final class OmniFocusBridgeService: OmniFocusService {
                 // a binary upgrade; invalidate the IPC directory once.
                 self.client.recordObservedPluginVersion(version)
             }
+            let bundles = installedFocusRelayPluginBundles()
             return BridgeHealthResult(
                 ok: response.ok,
                 plugin: response.data?.plugin,
                 version: response.data?.version,
-                error: response.error?.message
+                error: response.error?.message,
+                installedPlugins: bundles,
+                pluginWarning: pluginConsistencyWarning(
+                    loadedVersion: response.data?.version,
+                    binaryVersion: FocusRelayBuildVersion.current,
+                    bundles: bundles
+                )
             )
         }
     }
@@ -252,4 +260,26 @@ public struct BridgeHealthResult: Codable, Sendable {
     public let plugin: String?
     public let version: String?
     public let error: String?
+    /// Every plug-in bundle found on disk, so a stale copy in a directory the
+    /// user did not update is visible without manual filesystem inspection.
+    public let installedPlugins: [InstalledPluginBundle]?
+    /// Set when the loaded plug-in disagrees with an installed copy or with
+    /// the binary; nil when everything lines up.
+    public let pluginWarning: String?
+
+    public init(
+        ok: Bool,
+        plugin: String?,
+        version: String?,
+        error: String?,
+        installedPlugins: [InstalledPluginBundle]? = nil,
+        pluginWarning: String? = nil
+    ) {
+        self.ok = ok
+        self.plugin = plugin
+        self.version = version
+        self.error = error
+        self.installedPlugins = installedPlugins
+        self.pluginWarning = pluginWarning
+    }
 }

--- a/Sources/OmniFocusAutomation/PluginInstallations.swift
+++ b/Sources/OmniFocusAutomation/PluginInstallations.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// One installed copy of the bridge plug-in bundle, as found on disk.
+public struct InstalledPluginBundle: Codable, Sendable, Equatable {
+    /// Short label for the directory family: `icloud`, `sandbox`, or `legacy`.
+    public let location: String
+    public let path: String
+    /// Version read from the bundle's `BridgeLibrary.js`; nil when unreadable.
+    public let version: String?
+}
+
+let focusRelayPluginBundleName = "FocusRelayBridge.omnijs"
+
+/// Extracts the version constant the plug-in reports at runtime. Reading the
+/// same constant the bridge returns keeps this comparison honest — the
+/// manifest carries only the numeric core (`0.12.0`) while the bridge reports
+/// the full tag (`0.12.0-beta`), so comparing manifests would produce
+/// spurious mismatches.
+func focusRelayPluginVersion(inBridgeLibrarySource source: String) -> String? {
+    guard let range = source.range(of: #"FOCUSRELAY_VERSION\s*=\s*"[^"]*""#, options: .regularExpression) else {
+        return nil
+    }
+    let match = source[range]
+    guard let open = match.range(of: "\"") else { return nil }
+    let rest = match[open.upperBound...]
+    guard let close = rest.range(of: "\"") else { return nil }
+    return String(rest[..<close.lowerBound])
+}
+
+/// Plug-in directories OmniFocus can load from, in the order OmniFocus
+/// prefers them. iCloud wins when plug-in sync is enabled, which is why a
+/// current copy in the sandbox container is not sufficient on its own.
+func focusRelayPluginSearchPaths(home: URL) -> [(location: String, url: URL)] {
+    [
+        (
+            "icloud",
+            home.appendingPathComponent(
+                "Library/Mobile Documents/iCloud~com~omnigroup~OmniFocus/Documents/Plug-Ins",
+                isDirectory: true
+            )
+        ),
+        (
+            "sandbox",
+            home.appendingPathComponent(
+                "Library/Containers/com.omnigroup.OmniFocus4/Data/Library/Application Support/Plug-Ins",
+                isDirectory: true
+            )
+        ),
+        (
+            "legacy",
+            home.appendingPathComponent("Library/Application Support/OmniFocus/Plug-Ins", isDirectory: true)
+        )
+    ]
+}
+
+func installedFocusRelayPluginBundles(
+    fileManager: FileManager = .default,
+    home: URL = FileManager.default.homeDirectoryForCurrentUser
+) -> [InstalledPluginBundle] {
+    focusRelayPluginSearchPaths(home: home).compactMap { entry in
+        let bundle = entry.url.appendingPathComponent(focusRelayPluginBundleName, isDirectory: true)
+        guard fileManager.fileExists(atPath: bundle.path) else { return nil }
+        let library = bundle.appendingPathComponent("Resources/BridgeLibrary.js")
+        let version = (try? String(contentsOf: library, encoding: .utf8)).flatMap(focusRelayPluginVersion(inBridgeLibrarySource:))
+        return InstalledPluginBundle(location: entry.location, path: bundle.path, version: version)
+    }
+}
+
+/// Explains a plug-in version disagreement, or nil when everything lines up.
+///
+/// The version alone cannot distinguish "correct plug-in" from "stale plug-in
+/// in a directory you did not update", which is exactly the failure this
+/// exists to surface: OmniFocus can keep running a bundle from another
+/// directory across reinstalls and restarts, with no other visible signal.
+func pluginConsistencyWarning(
+    loadedVersion: String?,
+    binaryVersion: String,
+    bundles: [InstalledPluginBundle]
+) -> String? {
+    guard let loadedVersion else { return nil }
+
+    if bundles.isEmpty {
+        return "OmniFocus is running plug-in \(loadedVersion), but no plug-in bundle was found in any known directory. "
+            + "Reinstall the plug-in so upgrades can reach it."
+    }
+
+    let stale = bundles.filter { $0.version != loadedVersion }
+    var problems: [String] = []
+
+    if !stale.isEmpty {
+        let detail = stale
+            .map { "\($0.location) (\($0.version ?? "unreadable"))" }
+            .joined(separator: ", ")
+        problems.append(
+            "OmniFocus is running plug-in \(loadedVersion), but these installed copies differ: \(detail). "
+                + "OmniFocus prefers the iCloud copy when plug-in sync is enabled, so updating only the sandbox copy has no effect."
+        )
+    }
+
+    if loadedVersion != binaryVersion {
+        problems.append(
+            "The loaded plug-in (\(loadedVersion)) does not match the FocusRelay binary (\(binaryVersion)). "
+                + "Reinstall the plug-in and restart OmniFocus completely."
+        )
+    }
+
+    return problems.isEmpty ? nil : problems.joined(separator: " ")
+}

--- a/Tests/OmniFocusIntegrationTests/PluginInstallationsTests.swift
+++ b/Tests/OmniFocusIntegrationTests/PluginInstallationsTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+@testable import OmniFocusAutomation
+
+@Suite("Plug-in version extraction")
+struct PluginVersionExtractionTests {
+    @Test func readsTheRuntimeVersionConstant() {
+        let source = """
+        (function() {
+          const FOCUSRELAY_VERSION = "0.12.0-beta";
+          return FOCUSRELAY_VERSION;
+        })();
+        """
+        #expect(focusRelayPluginVersion(inBridgeLibrarySource: source) == "0.12.0-beta")
+    }
+
+    @Test func toleratesSpacingVariants() {
+        #expect(focusRelayPluginVersion(inBridgeLibrarySource: #"const FOCUSRELAY_VERSION="1.2.3";"#) == "1.2.3")
+        #expect(focusRelayPluginVersion(inBridgeLibrarySource: #"var FOCUSRELAY_VERSION   =   "1.2.3" ;"#) == "1.2.3")
+    }
+
+    @Test func returnsNilWhenAbsent() {
+        #expect(focusRelayPluginVersion(inBridgeLibrarySource: "const OTHER = \"1.0.0\";") == nil)
+        #expect(focusRelayPluginVersion(inBridgeLibrarySource: "") == nil)
+    }
+}
+
+@Suite("Plug-in consistency warning")
+struct PluginConsistencyWarningTests {
+    private func bundle(_ location: String, _ version: String?) -> InstalledPluginBundle {
+        InstalledPluginBundle(location: location, path: "/tmp/\(location)/FocusRelayBridge.omnijs", version: version)
+    }
+
+    @Test func silentWhenEverythingAgrees() {
+        let warning = pluginConsistencyWarning(
+            loadedVersion: "0.12.0-beta",
+            binaryVersion: "0.12.0-beta",
+            bundles: [bundle("icloud", "0.12.0-beta"), bundle("sandbox", "0.12.0-beta")]
+        )
+        #expect(warning == nil)
+    }
+
+    @Test func flagsTheStaleCopyScenarioFromIssue200() {
+        // The real failure: the sandbox copy was updated, OmniFocus kept
+        // loading the iCloud copy, and every version check looked fine.
+        let warning = pluginConsistencyWarning(
+            loadedVersion: "0.12.0-beta",
+            binaryVersion: "0.0.0-dev",
+            bundles: [bundle("icloud", "0.12.0-beta"), bundle("sandbox", "0.0.0-dev")]
+        )
+        let text = try! #require(warning)
+        #expect(text.contains("sandbox"))
+        #expect(text.contains("0.0.0-dev"))
+        #expect(text.contains("iCloud"), "must explain why updating only the sandbox copy has no effect")
+        #expect(!text.contains("icloud (0.12.0-beta)"), "the copy matching the loaded plug-in is not stale")
+    }
+
+    @Test func flagsBinaryMismatchEvenWhenBundlesAgree() {
+        let warning = pluginConsistencyWarning(
+            loadedVersion: "0.11.0-beta",
+            binaryVersion: "0.12.0-beta",
+            bundles: [bundle("icloud", "0.11.0-beta")]
+        )
+        let text = try! #require(warning)
+        #expect(text.contains("0.11.0-beta") && text.contains("0.12.0-beta"))
+        #expect(text.contains("Reinstall"))
+    }
+
+    @Test func flagsMissingBundles() {
+        let warning = pluginConsistencyWarning(
+            loadedVersion: "0.12.0-beta",
+            binaryVersion: "0.12.0-beta",
+            bundles: []
+        )
+        #expect(try! #require(warning).contains("no plug-in bundle was found"))
+    }
+
+    @Test func flagsUnreadableBundle() {
+        let warning = pluginConsistencyWarning(
+            loadedVersion: "0.12.0-beta",
+            binaryVersion: "0.12.0-beta",
+            bundles: [bundle("sandbox", nil)]
+        )
+        #expect(try! #require(warning).contains("unreadable"))
+    }
+
+    @Test func silentWhenBridgeReportedNoVersion() {
+        // A failed bridge already reports its own error; do not pile on.
+        #expect(pluginConsistencyWarning(loadedVersion: nil, binaryVersion: "0.12.0-beta", bundles: []) == nil)
+    }
+}
+
+@Suite("Plug-in bundle discovery")
+struct PluginBundleDiscoveryTests {
+    @Test func searchOrderPutsICloudFirst() {
+        let home = URL(fileURLWithPath: "/tmp/fakehome")
+        let locations = focusRelayPluginSearchPaths(home: home).map(\.location)
+        #expect(locations == ["icloud", "sandbox", "legacy"],
+                "iCloud must be listed first: OmniFocus prefers it when plug-in sync is enabled")
+    }
+
+    @Test func findsBundlesAndReadsVersionsFromDisk() throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("focusrelay-plugin-scan-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        for (location, dir) in focusRelayPluginSearchPaths(home: home) where location != "legacy" {
+            let resources = dir
+                .appendingPathComponent(focusRelayPluginBundleName, isDirectory: true)
+                .appendingPathComponent("Resources", isDirectory: true)
+            try FileManager.default.createDirectory(at: resources, withIntermediateDirectories: true)
+            let version = location == "icloud" ? "0.12.0-beta" : "0.0.0-dev"
+            try #"const FOCUSRELAY_VERSION = "\#(version)";"#
+                .write(to: resources.appendingPathComponent("BridgeLibrary.js"), atomically: true, encoding: .utf8)
+        }
+
+        let bundles = installedFocusRelayPluginBundles(home: home)
+        #expect(bundles.count == 2, "legacy directory was not created and must not be reported")
+        #expect(bundles.first?.location == "icloud")
+        #expect(bundles.first?.version == "0.12.0-beta")
+        #expect(bundles.last?.version == "0.0.0-dev")
+    }
+}


### PR DESCRIPTION
Addresses the durable half of #200. The documentation fix shipped in #199; this is the part that makes the failure self-diagnosing.

## Problem

OmniFocus can load a plug-in bundle from a directory the user never updated, and keep doing so across reinstalls and full restarts. The version the bridge reports cannot distinguish "the plug-in I just installed" from "a stale plug-in in a folder I forgot about" — both look like a plain version string. Diagnosing it means manually enumerating up to four locations and reading a JS constant out of each.

That is not hypothetical: it happened on a development machine today and took roughly an hour to track down, after a version check had already reported everything as fine.

## Change

`bridge-health-check` now reports every installed bundle it can find, and warns when they disagree:

```json
{
  "ok": true,
  "plugin": "FocusRelay Bridge",
  "version": "0.12.0-beta",
  "installedPlugins": [
    { "location": "icloud",  "version": "0.12.0-beta", "path": ".../iCloud~com~omnigroup~OmniFocus/Documents/Plug-Ins/FocusRelayBridge.omnijs" },
    { "location": "sandbox", "version": "0.0.0-dev",   "path": ".../com.omnigroup.OmniFocus4/Data/.../Plug-Ins/FocusRelayBridge.omnijs" }
  ],
  "pluginWarning": "OmniFocus is running plug-in 0.12.0-beta, but these installed copies differ: sandbox (0.0.0-dev). OmniFocus prefers the iCloud copy when plug-in sync is enabled, so updating only the sandbox copy has no effect. ..."
}
```

The warning names iCloud precedence explicitly, because "I updated the plug-in and nothing changed" is the symptom users actually report.

Two implementation notes:

- Versions come from the `FOCUSRELAY_VERSION` constant, not `manifest.json`. The manifest carries only the numeric core (`0.12.0`) while the bridge reports the full tag (`0.12.0-beta`), so comparing manifests would produce spurious mismatches on every prerelease.
- `BridgeHealthResult` gains two optional fields. It has **no MCP surface** — `bridge-health-check` is CLI-only, confirmed by grep — so the tool wire contract is unchanged and the additions are decode-compatible.

## Validation

Impact: `query`, per `focusrelay-dev classify` (conservative: the change lives in `OmniFocusAutomation`). Ran that tier rather than arguing for a narrower one.

- All semantic gates pass — bridge health plus every task/project count contract matching its list total.
- 246 tests pass, including 11 new ones covering version extraction, the warning matrix (agreement, stale copy, binary mismatch, missing bundles, unreadable bundle, no-version), search order, and on-disk discovery against a temporary home.
- **Verified live by reproducing #200**: with only the sandbox copy updated — exactly what the old README instructed — the health check named the stale copy and explained why the update had no effect. Machine restored afterwards.

## Not included

The installer-side half of #200: `install-plugin.sh` silently skips a plug-in directory that is not materialised at that instant (`create_if_missing=False`), so an evicted iCloud folder produces a partial install that reports success and exits 0. That is tracked in the issue and left for a follow-up, since it is installer behavior rather than diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)