### PR TITLE
Refocus the roadmap on terminal MCP clients

### DIFF
--- a/docs/roadmap-execution-plan.md
+++ b/docs/roadmap-execution-plan.md
@@ -7,69 +7,60 @@ records only current sequencing and cross-issue dependencies.
 
 ## Current Focus
 
-`v0.12.0-beta` shipped (#188 closed). The next slice is
-[#197 — IPC directory hardening](https://github.com/deverman/FocusRelayMCP/issues/197):
-retention, owner-only permissions, and upgrade invalidation for the bridge
-IPC directory, which holds task data at rest.
+`v0.12.0-beta` shipped. IPC hardening (#197) and the plug-in diagnostic half
+of #200 have merged. The next slice is
+[#172 — bounded task-detail lookup](https://github.com/deverman/FocusRelayMCP/issues/172),
+returning to product capability work for terminal MCP clients.
 
 ## Delivery Order
 
-1. [#197 — harden bridge IPC directory](https://github.com/deverman/FocusRelayMCP/issues/197)
-   - Retention policy, owner-only permissions, upgrade invalidation, and
-     fail-fast container resolution. Security-motivated; ships regardless of
-     measured performance outcome.
-2. [#200 — plug-in loaded from the wrong directory](https://github.com/deverman/FocusRelayMCP/issues/200)
-   - Documentation fix shipped; the durable fix is reporting the loaded
-     plug-in path from the health check so a stale bundle is visible
-     without manual filesystem inspection.
-3. [#172 — bounded task-detail lookup](https://github.com/deverman/FocusRelayMCP/issues/172)
+1. [#172 — bounded task-detail lookup](https://github.com/deverman/FocusRelayMCP/issues/172)
    - Replace repeated one-task calls with one stable-ID query that returns only
      the details needed for a workflow decision.
-4. [#171 — multi-name project and tag resolution](https://github.com/deverman/FocusRelayMCP/issues/171)
+2. [#171 — multi-name project and tag resolution](https://github.com/deverman/FocusRelayMCP/issues/171)
    - Resolve a bounded set of requested names through the existing catalog cache
      instead of repeating full catalog queries.
-5. [#173 — atomic heterogeneous task edit plans](https://github.com/deverman/FocusRelayMCP/issues/173)
+3. [#173 — atomic heterogeneous task edit plans](https://github.com/deverman/FocusRelayMCP/issues/173)
    - Design the larger approved-workflow batch only after #172 and #171 reduce
      its read-before-write query cost.
-6. [#94 — discoverable MCP workflows](https://github.com/deverman/FocusRelayMCP/issues/94)
+4. [#94 — discoverable MCP workflows](https://github.com/deverman/FocusRelayMCP/issues/94)
    - Continue measured client research after the shipped `process_inbox`
      vertical; add another prompt only when UAT demonstrates a reliable benefit.
-7. [#82 — task/subtask creation](https://github.com/deverman/FocusRelayMCP/issues/82), then
+5. [#82 — task/subtask creation](https://github.com/deverman/FocusRelayMCP/issues/82), then
    [#83 — project creation/conversion](https://github.com/deverman/FocusRelayMCP/issues/83)
    - Build on the consolidated edit surface, support safe project folder
      destinations, and retain duplicate/write safety.
-8. [#93 — repetition support](https://github.com/deverman/FocusRelayMCP/issues/93)
+6. [#93 — repetition support](https://github.com/deverman/FocusRelayMCP/issues/93)
    - After task creation and truthful drop behavior stabilize, establish complete
      schedule readback before adding create, edit, and lifecycle mutation slices.
-9. [#130 — project tag membership and filtering](https://github.com/deverman/FocusRelayMCP/issues/130), then
+7. [#130 — project tag membership and filtering](https://github.com/deverman/FocusRelayMCP/issues/130), then
    [#128 — create and assign missing tags](https://github.com/deverman/FocusRelayMCP/issues/128)
    - Query direct project membership by stable ID before creating missing root
      or nested tags during assignment.
-10. [#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88), then
+8. [#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88), then
    [#87 — project-health filters](https://github.com/deverman/FocusRelayMCP/issues/87)
    - Reduce context before expanding project-review workflows.
-11. [#85 — safe Forecast contract](https://github.com/deverman/FocusRelayMCP/issues/85), then
+9. [#85 — safe Forecast contract](https://github.com/deverman/FocusRelayMCP/issues/85), then
    [#125 — Forecast-based attention](https://github.com/deverman/FocusRelayMCP/issues/125), then
    [#126 — broader ranked task search](https://github.com/deverman/FocusRelayMCP/issues/126)
    - Reuse one documented task-only Forecast classifier for attention ranking.
    - Keep search independent, broad, relevance-ranked, and lightweight.
-12. [#92 — guided Homebrew setup](https://github.com/deverman/FocusRelayMCP/issues/92)
+10. [#92 — guided Homebrew setup](https://github.com/deverman/FocusRelayMCP/issues/92)
     - Reduce installation friction after the next product capabilities settle.
-    - Do not finalize the installer flow before the #196 signing verdict
-      lands; a Developer ID pipeline or LaunchAgent directly shapes it.
-13. Measured transport and command experiments:
-    [#90 — command/session latency](https://github.com/deverman/FocusRelayMCP/issues/90) and
-    [#196 — multi-host transport spike](https://github.com/deverman/FocusRelayMCP/issues/196)
-    (decision-revisit: TCC diagnosis and Developer ID signing feasibility;
-    depends on #197 for the on-disk contract it would inherit).
-14. Small independent query improvements: #11, #22, #18, #59, #62, #65,
+    - Covers the plug-in directory discovery and partial-install reporting
+      left open by #200.
+11. [#90 — command/session latency](https://github.com/deverman/FocusRelayMCP/issues/90)
+    - The remaining measured command experiment.
+12. Small independent query improvements: #11, #22, #18, #59, #62, #65,
     #66, #67, and #68.
-15. Feasibility work for #10 custom perspectives and #16 planned-date writes.
+13. Feasibility work for #10 custom perspectives and #16 planned-date writes.
 
 ## Standing Decisions
 
 - Plugin URL dispatch through the Bridge plugin is the only architecture; #80
   removed the alternate runtime, development oracle, and dual-path benchmarks.
+- FocusRelay targets terminal-based MCP clients. Desktop-app hosts are out of
+  scope; #196 is parked and carries the evidence needed to resume it.
 - #170 established one process-wide FIFO Bridge lane: one request executes, six
   may queue, and excess or expired work returns structured retryable errors.
 - Query code uses documented Omni Automation APIs and native status semantics.


### PR DESCRIPTION
Docs-only. Impact: `docs` (`focusrelay-dev validate --impact docs` passes).

#197 and the diagnostic half of #200 have merged, so the delivery order returns to product capability work starting with #172.

Records the scope decision that FocusRelay targets terminal-based MCP clients. Desktop-app hosts are out of scope, so #196 is parked and drops out of the delivery order — the issue keeps the captured TCC evidence and states what a resumption would require. The README already scopes support to terminal clients, so nothing user-facing changes.

Two smaller cleanups: the plug-in directory discovery and partial-install reporting still open from #200 fold into #92 guided setup rather than standing alone, and #92 no longer waits on a signing verdict that is not coming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)