### PR TITLE
Expand a bounded set of tasks by stable ID in one read (#172)

### DIFF
--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -2229,7 +2229,41 @@
             !hasAdvancedFilters;
           const useCompletionTopKPath = requiresCompletionSort;
 
-          if (useStreamedSimplePath) {
+          // BOUNDED STABLE-ID SELECTION
+          // Progressive expansion of a few already-listed tasks. The pool is
+          // whatever the supplied scope selected, so every other filter still
+          // applies as an intersection and a scoped-out ID simply does not
+          // match. The client resolves requested order and unresolved IDs;
+          // this returns the in-scope matches only, never a fallback page.
+          const requestedTaskIDs = Array.isArray(filter.ids) ? filter.ids : null;
+          if (requestedTaskIDs && requestedTaskIDs.length > 0) {
+            const selectionStart = Date.now();
+            const wantedIDs = {};
+            for (let i = 0; i < requestedTaskIDs.length; i += 1) {
+              const wanted = String(requestedTaskIDs[i] || "");
+              if (wanted) { wantedIDs[wanted] = true; }
+            }
+
+            const selected = [];
+            for (let i = 0; i < tasks.length; i += 1) {
+              const candidate = tasks[i];
+              const candidateID = String(safe(() => candidate.id.primaryKey) || "");
+              if (!candidateID || wantedIDs[candidateID] !== true) { continue; }
+              if (!taskMatchesFilters(candidate, undefined, undefined)) { continue; }
+              selected.push(candidate);
+            }
+
+            const items = selected.map(t => taskToPayload(t, fields));
+            markListTasks("after_id_selection", {
+              requestedCount: requestedTaskIDs.length,
+              returnedCount: items.length,
+              durationMs: Date.now() - selectionStart
+            });
+            response.data = { items: items, nextCursor: null, returnedCount: items.length };
+            if (includeTotalCount) {
+              response.data.totalCount = items.length;
+            }
+          } else if (useStreamedSimplePath) {
             const fastPathStart = Date.now();
             const pageTasks = [];
             let matchedCount = 0;

--- a/Sources/FocusRelayCLI/CLIHelpers.swift
+++ b/Sources/FocusRelayCLI/CLIHelpers.swift
@@ -66,6 +66,9 @@ struct PageOptions: ParsableArguments {
 }
 
 struct TaskFilterOptions: ParsableArguments {
+    @Option(help: "Comma-separated stable task IDs (max \(TaskIDSelection.maximumCount)) to expand in one read. Other filters still apply.")
+    var ids: String? = nil
+
     @Option(help: "Filter by completion status (true/false).")
     var completed: Bool? = nil
 
@@ -128,7 +131,9 @@ struct TaskFilterOptions: ParsableArguments {
 
     func makeTaskFilter() throws -> TaskFilter {
         let tagList = FieldList.parse(tags)
+        let idList = FieldList.parse(ids)
         return TaskFilter(
+            ids: idList.isEmpty ? nil : idList,
             completed: completed,
             flagged: flagged,
             availableOnly: availableOnly,

--- a/Sources/FocusRelayCLI/FocusRelayCLI.swift
+++ b/Sources/FocusRelayCLI/FocusRelayCLI.swift
@@ -78,7 +78,7 @@ struct ListTasks: AsyncParsableCommand {
         let result = try await service.listTasks(filter: taskFilter, page: pageRequest, fields: selectedFields)
         let fieldSet = Set(selectedFields)
         let items = result.items.map { makeTaskOutput(from: $0, fields: fieldSet) }
-        let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount)
+        let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount, unresolvedIDs: result.unresolvedIDs)
         print(try encodeJSON(output))
     }
 }

--- a/Sources/FocusRelayOutput/OutputModels.swift
+++ b/Sources/FocusRelayOutput/OutputModels.swift
@@ -131,11 +131,13 @@ public struct PageOutput<T: Encodable>: Encodable {
     public let returnedCount: Int
     public let totalCount: Int?
     public let warnings: [String]?
+    public let unresolvedIDs: [String]?
 
-    public init(items: [T], nextCursor: String? = nil, returnedCount: Int, totalCount: Int? = nil, warnings: [String]? = nil) {
+    public init(items: [T], nextCursor: String? = nil, returnedCount: Int, totalCount: Int? = nil, warnings: [String]? = nil, unresolvedIDs: [String]? = nil) {
         self.items = items
         self.nextCursor = nextCursor
         self.returnedCount = returnedCount
+        self.unresolvedIDs = unresolvedIDs
         self.totalCount = totalCount
         self.warnings = warnings
     }

--- a/Sources/FocusRelayServer/FocusRelayServer.swift
+++ b/Sources/FocusRelayServer/FocusRelayServer.swift
@@ -202,9 +202,12 @@ public enum FocusRelayServer {
         "includeTotalCount"
     ]
 
-    static func makeTaskFilterSchema() -> Value {
+    /// `ids` is offered to `list_tasks` only. `get_task_counts` returns
+    /// scalars, so selecting specific tasks there has no meaning, and leaving
+    /// it out lets closed-property validation reject it with a clear message.
+    static func makeTaskFilterSchema(includeTaskIDSelection: Bool = false) -> Value {
         let dateExample = Value.string("2026-01-30T12:00:00Z")
-        let properties: [String: Value] = [
+        var properties: [String: Value] = [
             "completed": propertySchema(
                 type: "boolean",
                 description: "Match completed (true) or remaining (false) tasks. Omit to use the selected view's default."
@@ -271,8 +274,24 @@ public enum FocusRelayServer {
             )
         ]
 
+        if includeTaskIDSelection {
+            properties["ids"] = .object([
+                "type": .string("array"),
+                "description": .string(
+                    "Expand a bounded set of already-known tasks in one read instead of one get_task call each. "
+                        + "Supply 1-\(TaskIDSelection.maximumCount) stable task IDs. Other filters still apply as an "
+                        + "intersection, so an ID outside the supplied scope is reported in unresolvedIDs rather than "
+                        + "returned. Results follow the requested ID order and are never paginated: page.cursor is "
+                        + "rejected and page.limit must be at least the number of IDs."
+                ),
+                "items": .object(["type": .string("string")]),
+                "minItems": .int(1),
+                "maxItems": .int(TaskIDSelection.maximumCount)
+            ])
+        }
+
         precondition(
-            Set(properties.keys) == taskFilterPropertyNames,
+            Set(properties.keys) == (includeTaskIDSelection ? taskFilterPropertyNames.union(["ids"]) : taskFilterPropertyNames),
             "The shared MCP task filter schema must cover the intentional TaskFilter surface."
         )
 
@@ -344,7 +363,7 @@ public enum FocusRelayServer {
                     description: listTasksToolDescription,
                     inputSchema: toolSchema(
                         properties: [
-                            "filter": makeTaskFilterSchema(),
+                            "filter": makeTaskFilterSchema(includeTaskIDSelection: true),
                             "page": .object([
                                 "type": .string("object"),
                                 "properties": .object([
@@ -806,7 +825,7 @@ public enum FocusRelayServer {
                     let result = try await service.listTasks(filter: filter, page: page, fields: fields)
                     let fieldSet = Set(fields)
                     let items = result.items.map { makeTaskOutput(from: $0, fields: fieldSet) }
-                    let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount, warnings: result.warnings)
+                    let output = PageOutput(items: items, nextCursor: result.nextCursor, returnedCount: result.returnedCount, totalCount: result.totalCount, warnings: result.warnings, unresolvedIDs: result.unresolvedIDs)
                     return .init(content: [.text(text: try encodeJSON(output), annotations: nil, _meta: nil)])
                 case "get_task":
                     let id = try decodeArgument(String.self, from: params.arguments, key: "id") ?? ""
@@ -1135,7 +1154,10 @@ func discriminatedToolSchema(
     ]))
 }
 
-private func closingObjectSchemas(_ value: Value) -> Value {
+/// Marks every object schema closed so unknown properties are rejected at the
+/// wire boundary. Internal rather than private so tests can validate against
+/// the same closed shape clients receive.
+func closingObjectSchemas(_ value: Value) -> Value {
     switch value {
     case .object(var object):
         for (key, child) in object {

--- a/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
+++ b/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
@@ -25,10 +25,32 @@ public final class OmniFocusBridgeService: OmniFocusService {
     }
 
     public func listTasks(filter: TaskFilter, page: PageRequest, fields: [String]?) async throws -> Page<TaskItem> {
-        let identity = try QueryBoundCursor.taskIdentity(for: filter)
+        var normalizedFilter = filter
+        normalizedFilter.ids = try TaskIDSelection.normalize(filter.ids)
+        let resolvedFilter = normalizedFilter
+
+        if let ids = resolvedFilter.ids {
+            // A bounded ID selection is one complete response: no cursor in,
+            // no cursor out, and the caller's requested order is preserved.
+            try TaskIDSelection.validatePaging(idCount: ids.count, limit: page.limit, cursor: page.cursor)
+            let result = try await runtime.submit(category: .taskQuery) {
+                try self.client.listTasks(filter: resolvedFilter, page: PageRequest(limit: page.limit), fields: fields)
+            }
+            let (ordered, unresolved) = TaskIDSelection.order(result.items, by: ids) { $0.id }
+            return Page(
+                items: ordered,
+                nextCursor: nil,
+                returnedCount: ordered.count,
+                totalCount: result.totalCount,
+                warnings: result.warnings,
+                unresolvedIDs: unresolved
+            )
+        }
+
+        let identity = try QueryBoundCursor.taskIdentity(for: resolvedFilter)
         let bridgePage = try QueryBoundCursor.bridgePage(from: page, identity: identity)
         let result = try await runtime.submit(category: .taskQuery) {
-            try self.client.listTasks(filter: filter, page: bridgePage, fields: fields)
+            try self.client.listTasks(filter: resolvedFilter, page: bridgePage, fields: fields)
         }
         return try QueryBoundCursor.publicPage(from: result, identity: identity)
     }

--- a/Sources/OmniFocusAutomation/QueryBoundCursor.swift
+++ b/Sources/OmniFocusAutomation/QueryBoundCursor.swift
@@ -23,6 +23,7 @@ enum QueryBoundCursor {
         try queryIdentity(
             tool: "list_tasks",
             input: TaskFilter(
+                ids: filter.ids,
                 completed: filter.completed,
                 flagged: filter.flagged,
                 availableOnly: filter.availableOnly,
@@ -123,7 +124,8 @@ enum QueryBoundCursor {
             nextCursor: nextCursor,
             returnedCount: page.returnedCount,
             totalCount: page.totalCount,
-            warnings: page.warnings
+            warnings: page.warnings,
+            unresolvedIDs: page.unresolvedIDs
         )
     }
 

--- a/Sources/OmniFocusCore/OmniFocusCore.swift
+++ b/Sources/OmniFocusCore/OmniFocusCore.swift
@@ -238,11 +238,15 @@ public struct Page<T: Codable & Sendable>: Codable, Sendable {
     public let returnedCount: Int
     public let totalCount: Int?
     public let warnings: [String]?
+    /// Requested IDs that produced no in-scope task. Only set for bounded
+    /// stable-ID selections.
+    public let unresolvedIDs: [String]?
 
-    public init(items: [T], nextCursor: String? = nil, returnedCount: Int, totalCount: Int? = nil, warnings: [String]? = nil) {
+    public init(items: [T], nextCursor: String? = nil, returnedCount: Int, totalCount: Int? = nil, warnings: [String]? = nil, unresolvedIDs: [String]? = nil) {
         self.items = items
         self.nextCursor = nextCursor
         self.returnedCount = returnedCount
+        self.unresolvedIDs = unresolvedIDs
         self.totalCount = totalCount
         self.warnings = warnings
     }
@@ -299,6 +303,8 @@ public struct ProjectFilter: Codable, Sendable {
 }
 
 public struct TaskFilter: Codable, Sendable {
+    /// Bounded stable-ID selection for progressive expansion; list_tasks only.
+    public var ids: [String]?
     public var completed: Bool?
     public var flagged: Bool?
     public var availableOnly: Bool?
@@ -321,6 +327,7 @@ public struct TaskFilter: Codable, Sendable {
     public var includeTotalCount: Bool?
 
     public init(
+        ids: [String]? = nil,
         completed: Bool? = nil,
         flagged: Bool? = nil,
         availableOnly: Bool? = nil,
@@ -342,6 +349,7 @@ public struct TaskFilter: Codable, Sendable {
         minEstimatedMinutes: Int? = nil,
         includeTotalCount: Bool? = nil
     ) {
+        self.ids = ids
         self.completed = completed
         self.flagged = flagged
         self.availableOnly = availableOnly

--- a/Sources/OmniFocusCore/TaskIDSelection.swift
+++ b/Sources/OmniFocusCore/TaskIDSelection.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Bounded stable-ID selection for `list_tasks`.
+///
+/// Progressive expansion — read a compact page, then fetch notes for the few
+/// ambiguous items — otherwise turns into one `get_task` call per item. This
+/// keeps that expansion to a single bounded read without opening a
+/// name-based or unbounded lookup surface.
+public enum TaskIDSelection {
+    /// Upper bound on IDs per request. Bounded so a selection can never
+    /// degenerate into an unpaginated full-database read.
+    public static let maximumCount = 20
+
+    /// Trims, rejects blanks, and de-duplicates while preserving the order the
+    /// caller asked for. Returns nil when no selection was supplied.
+    public static func normalize(_ ids: [String]?) throws -> [String]? {
+        guard let ids else { return nil }
+
+        guard !ids.isEmpty else {
+            throw MutationValidationError(
+                "list_tasks.filter.ids must contain at least one task ID when supplied."
+            )
+        }
+
+        var seen = Set<String>()
+        var normalized: [String] = []
+        for (index, id) in ids.enumerated() {
+            let trimmed = id.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                throw MutationValidationError(
+                    "list_tasks.filter.ids[\(index)] must be a non-empty task ID."
+                )
+            }
+            if seen.insert(trimmed).inserted {
+                normalized.append(trimmed)
+            }
+        }
+
+        guard normalized.count <= maximumCount else {
+            throw MutationValidationError(
+                "list_tasks.filter.ids accepts at most \(maximumCount) distinct task IDs; received \(normalized.count)."
+            )
+        }
+
+        return normalized
+    }
+
+    /// Paging rules for a bounded ID selection: the response is the whole
+    /// answer, so a cursor is meaningless and a limit must not be able to
+    /// truncate it.
+    public static func validatePaging(idCount: Int, limit: Int, cursor: String?) throws {
+        guard cursor == nil else {
+            throw MutationValidationError(
+                "list_tasks.filter.ids cannot be combined with page.cursor. "
+                    + "A bounded ID selection returns one complete response."
+            )
+        }
+        guard limit >= idCount else {
+            throw MutationValidationError(
+                "page.limit (\(limit)) must be at least the number of requested task IDs (\(idCount))."
+            )
+        }
+    }
+
+    /// Orders resolved items by the order the caller requested, and reports
+    /// which IDs produced nothing. An ID can be absent because it does not
+    /// exist or because the supplied scope excluded it; the two are not
+    /// distinguished, because guessing why would require reading outside the
+    /// caller's own scope.
+    public static func order<Item>(
+        _ items: [Item],
+        by requestedIDs: [String],
+        id: (Item) -> String
+    ) -> (ordered: [Item], unresolvedIDs: [String]) {
+        var byID: [String: Item] = [:]
+        for item in items where byID[id(item)] == nil {
+            byID[id(item)] = item
+        }
+        var ordered: [Item] = []
+        var unresolved: [String] = []
+        for requested in requestedIDs {
+            if let item = byID[requested] {
+                ordered.append(item)
+            } else {
+                unresolved.append(requested)
+            }
+        }
+        return (ordered, unresolved)
+    }
+}

--- a/Tests/FocusRelayServerTests/TaskIDSelectionWireTests.swift
+++ b/Tests/FocusRelayServerTests/TaskIDSelectionWireTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import MCP
+import OmniFocusCore
+import Testing
+@testable import FocusRelayServer
+
+/// Direct MCP wire coverage for the bounded stable-ID selection surface:
+/// the schema clients actually read, and the closed-property validation that
+/// rejects misuse before any Bridge dispatch.
+@Suite("filter.ids MCP wire contract")
+struct TaskIDSelectionWireTests {
+    private func filterProperties(includeTaskIDSelection: Bool) throws -> [String: Value] {
+        guard case let .object(schema) = FocusRelayServer.makeTaskFilterSchema(
+            includeTaskIDSelection: includeTaskIDSelection
+        ),
+        case let .object(properties)? = schema["properties"] else {
+            Issue.record("Expected an object task-filter schema with object properties")
+            return [:]
+        }
+        return properties
+    }
+
+    @Test func listTasksFilterExposesBoundedIDSelection() throws {
+        let properties = try filterProperties(includeTaskIDSelection: true)
+        guard case let .object(idsSchema)? = properties["ids"] else {
+            Issue.record("list_tasks filter must expose ids")
+            return
+        }
+        #expect(idsSchema["type"] == .string("array"))
+        #expect(idsSchema["items"] == .object(["type": .string("string")]))
+        #expect(idsSchema["minItems"] == .int(1))
+        #expect(idsSchema["maxItems"] == .int(TaskIDSelection.maximumCount),
+                "the advertised bound must match the enforced bound")
+    }
+
+    @Test func idSelectionDescriptionStatesTheContractClientsDependOn() throws {
+        let properties = try filterProperties(includeTaskIDSelection: true)
+        guard case let .object(idsSchema)? = properties["ids"],
+              case let .string(description)? = idsSchema["description"] else {
+            Issue.record("ids must document its contract")
+            return
+        }
+        #expect(description.contains("unresolvedIDs"), "clients must know how absent IDs are reported")
+        #expect(description.contains("intersection"), "other filters still apply")
+        #expect(description.contains("cursor"), "pagination is rejected, not silently ignored")
+        #expect(description.contains("get_task"), "the point is replacing per-item get_task calls")
+    }
+
+    @Test func countsFilterDoesNotOfferIDSelection() throws {
+        let properties = try filterProperties(includeTaskIDSelection: false)
+        #expect(properties["ids"] == nil,
+                "get_task_counts returns scalars; selecting specific tasks there has no meaning")
+    }
+
+    @Test func countsRejectsIDSelectionAtTheWireBoundary() throws {
+        // Close the schema the way the tool definition does, so this asserts
+        // the shape clients are actually validated against.
+        let schema = closingObjectSchemas(FocusRelayServer.makeTaskFilterSchema(includeTaskIDSelection: false))
+        #expect(throws: MutationValidationError.self) {
+            try FocusRelayServer.validateToolArguments(
+                toolName: "get_task_counts.filter",
+                arguments: ["ids": .array([.string("some-id")])],
+                schema: schema
+            )
+        }
+    }
+
+    @Test func listTasksAcceptsIDSelectionAtTheWireBoundary() throws {
+        let schema = closingObjectSchemas(FocusRelayServer.makeTaskFilterSchema(includeTaskIDSelection: true))
+        try FocusRelayServer.validateToolArguments(
+            toolName: "list_tasks.filter",
+            arguments: [
+                "ids": .array([.string("id-1"), .string("id-2")]),
+                "inboxOnly": .bool(true),
+                "inboxView": .string("remaining")
+            ],
+            schema: schema
+        )
+    }
+
+    @Test func idSelectionDecodesIntoTheSharedTaskFilter() throws {
+        let arguments: [String: Value] = [
+            "filter": .object([
+                "ids": .array([.string("id-1"), .string("id-2")]),
+                "inboxOnly": .bool(true)
+            ])
+        ]
+        let filter = try FocusRelayServer.decodeArgument(TaskFilter.self, from: arguments, key: "filter")
+        #expect(filter?.ids == ["id-1", "id-2"])
+        #expect(filter?.inboxOnly == true)
+    }
+
+    @Test func ordinaryFilterDecodingLeavesIDSelectionAbsent() throws {
+        let arguments: [String: Value] = ["filter": .object(["inboxOnly": .bool(true)])]
+        let filter = try FocusRelayServer.decodeArgument(TaskFilter.self, from: arguments, key: "filter")
+        #expect(filter?.ids == nil, "existing list_tasks callers must be unaffected")
+    }
+}

--- a/Tests/OmniFocusCoreTests/TaskIDSelectionTests.swift
+++ b/Tests/OmniFocusCoreTests/TaskIDSelectionTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+import Testing
+@testable import OmniFocusCore
+
+@Suite("Bounded task-ID selection: normalization")
+struct TaskIDSelectionNormalizationTests {
+    @Test func absentSelectionStaysAbsent() throws {
+        #expect(try TaskIDSelection.normalize(nil) == nil)
+    }
+
+    @Test func emptyArrayIsRejected() {
+        #expect(throws: MutationValidationError.self) {
+            _ = try TaskIDSelection.normalize([])
+        }
+    }
+
+    @Test func blankAndWhitespaceOnlyIDsAreRejected() {
+        for invalid in ["", "   ", "\t", "\n"] {
+            #expect(throws: MutationValidationError.self, "\(invalid.debugDescription) must be rejected") {
+                _ = try TaskIDSelection.normalize(["valid-id", invalid])
+            }
+        }
+    }
+
+    @Test func surroundingWhitespaceIsTrimmed() throws {
+        #expect(try TaskIDSelection.normalize(["  abc  ", "\tdef\n"]) == ["abc", "def"])
+    }
+
+    @Test func duplicatesCollapseAndKeepFirstRequestedOrder() throws {
+        let normalized = try TaskIDSelection.normalize(["c", "a", "c", "b", "a"])
+        #expect(normalized == ["c", "a", "b"])
+    }
+
+    @Test func duplicatesThatDifferOnlyByWhitespaceAlsoCollapse() throws {
+        #expect(try TaskIDSelection.normalize(["a", " a ", "b"]) == ["a", "b"])
+    }
+
+    @Test func maximumDistinctCountIsAccepted() throws {
+        let ids = (1...TaskIDSelection.maximumCount).map { "id-\($0)" }
+        #expect(try TaskIDSelection.normalize(ids)?.count == TaskIDSelection.maximumCount)
+    }
+
+    @Test func exceedingMaximumDistinctCountIsRejected() {
+        let ids = (1...(TaskIDSelection.maximumCount + 1)).map { "id-\($0)" }
+        #expect(throws: MutationValidationError.self) {
+            _ = try TaskIDSelection.normalize(ids)
+        }
+    }
+
+    @Test func duplicatesAreCountedAfterCollapsing() throws {
+        // 21 entries, 20 distinct: the bound applies to distinct IDs.
+        var ids = (1...TaskIDSelection.maximumCount).map { "id-\($0)" }
+        ids.append("id-1")
+        #expect(try TaskIDSelection.normalize(ids)?.count == TaskIDSelection.maximumCount)
+    }
+}
+
+@Suite("Bounded task-ID selection: paging rules")
+struct TaskIDSelectionPagingTests {
+    @Test func cursorIsRejected() {
+        #expect(throws: MutationValidationError.self) {
+            try TaskIDSelection.validatePaging(idCount: 3, limit: 50, cursor: "eyJvZmZzZXQiOiIzIn0")
+        }
+    }
+
+    @Test func limitBelowRequestedCountIsRejected() {
+        #expect(throws: MutationValidationError.self) {
+            try TaskIDSelection.validatePaging(idCount: 5, limit: 4, cursor: nil)
+        }
+    }
+
+    @Test func limitEqualToRequestedCountIsAccepted() throws {
+        try TaskIDSelection.validatePaging(idCount: 5, limit: 5, cursor: nil)
+    }
+
+    @Test func generousLimitIsAccepted() throws {
+        try TaskIDSelection.validatePaging(idCount: 2, limit: 50, cursor: nil)
+    }
+}
+
+private struct StubItem: Equatable {
+    let id: String
+}
+
+@Suite("Bounded task-ID selection: ordering and unresolved IDs")
+struct TaskIDSelectionOrderingTests {
+    @Test func resultsFollowRequestedOrderNotBridgeOrder() {
+        let bridgeOrder = [StubItem(id: "b"), StubItem(id: "c"), StubItem(id: "a")]
+        let (ordered, unresolved) = TaskIDSelection.order(bridgeOrder, by: ["a", "b", "c"]) { $0.id }
+        #expect(ordered.map(\.id) == ["a", "b", "c"])
+        #expect(unresolved.isEmpty)
+    }
+
+    @Test func missingIDsAreReportedAndNeverSubstituted() {
+        let resolved = [StubItem(id: "a"), StubItem(id: "c")]
+        let (ordered, unresolved) = TaskIDSelection.order(resolved, by: ["a", "missing", "c"]) { $0.id }
+        #expect(ordered.map(\.id) == ["a", "c"], "an unresolved ID must not be replaced by another task")
+        #expect(unresolved == ["missing"])
+    }
+
+    @Test func scopedOutIDsSurfaceAsUnresolved() {
+        // The bridge applies other filters as an intersection, so a task
+        // excluded by scope simply does not come back.
+        let (ordered, unresolved) = TaskIDSelection.order([StubItem(id: "in-scope")], by: ["in-scope", "out-of-scope"]) { $0.id }
+        #expect(ordered.map(\.id) == ["in-scope"])
+        #expect(unresolved == ["out-of-scope"])
+    }
+
+    @Test func everyIDUnresolvedYieldsNoItemsRatherThanAFallbackPage() {
+        let (ordered, unresolved) = TaskIDSelection.order([StubItem]([]), by: ["x", "y"]) { $0.id }
+        #expect(ordered.isEmpty)
+        #expect(unresolved == ["x", "y"])
+    }
+
+    @Test func unresolvedListPreservesRequestedOrder() {
+        let (_, unresolved) = TaskIDSelection.order([StubItem(id: "b")], by: ["z", "b", "a"]) { $0.id }
+        #expect(unresolved == ["z", "a"])
+    }
+
+    @Test func duplicateBridgeItemsDoNotDuplicateOutput() {
+        let withDuplicate = [StubItem(id: "a"), StubItem(id: "a")]
+        let (ordered, _) = TaskIDSelection.order(withDuplicate, by: ["a"]) { $0.id }
+        #expect(ordered.count == 1)
+    }
+}


### PR DESCRIPTION
Closes #172.

## User outcome

An inbox workflow can read a compact page, pick the few ambiguous captures, and expand their notes in **one** bounded read instead of one `get_task` call each. The observed cost this addresses: one inbox-zero UAT made 28 scalar detail calls for a 32-item inbox.

## Contract

`list_tasks.filter` gains an optional `ids` array:

```json
{
  "filter": { "ids": ["id-1", "id-2"], "inboxOnly": true, "inboxView": "remaining" },
  "fields": ["id", "name", "note"],
  "page": { "limit": 20 }
}
```

- 1-20 stable IDs, trimmed and de-duplicated preserving first-requested order.
- Other filters apply as an **intersection** — an ID outside the supplied scope is reported in `unresolvedIDs`, never returned, and never replaced by an unrelated task.
- Results follow requested-ID order.
- One complete response: `page.cursor` is rejected, `page.limit` must cover the requested IDs, and no `nextCursor` is issued.
- `get_task_counts` does **not** offer `ids`. It returns scalars, so selecting specific tasks there has no meaning; omitting it from that schema lets closed-property validation reject it with a clear message rather than silently ignoring it.

Plugin-side selection reuses the existing scoped pool and the shared filter predicate, so parent, project, and status semantics stay native and documented. Ordering and unresolved reporting happen client-side, keeping the plug-in change small.

## Measured result

10 selected detail reads on a live database, one server process, same fields:

| | round trips | elapsed | items | field keys |
| --- | --- | --- | --- | --- |
| `get_task` × 10 | 10 | 1042 ms | 10 | `id, name, note` |
| one bounded query | **1** | **406 ms** | 10 | `id, name, note` |

**10× fewer Bridge round trips, 61% lower elapsed time, identical items and identical field keys** — so the reduction does not come with broader data exposure. The bounded response is larger in raw bytes only because it is one indented envelope rather than ten bare objects.

## Validation

Impact: `query`, per `focusrelay-dev classify`.

- All semantic gates pass; canary rotation passes (8/8).
- 272 tests pass, including 26 new ones: normalization (blank, whitespace, duplicate, over-bound, duplicates-counted-after-collapsing), paging rules, ordering determinism, unresolved reporting, and the MCP schema/wire surface.
- Direct MCP stdio probes against a live database confirmed: reversed-order request returns requested order; a bogus ID lands in `unresolvedIDs` with no substitution; blank ID, `cursor`, and insufficient `limit` are each rejected before Bridge dispatch; `get_task_counts.filter.ids is unsupported`; and ordinary paginated `list_tasks` still issues a query-bound cursor.
- Scope behavior verified live: the same IDs resolve 5/5 under `inboxOnly + remaining`, and 0/5 with 5 unresolved under `completed=true`, with no unrelated tasks returned.

One incidental change: `closingObjectSchemas` became internal so wire tests can validate against the same closed schema clients receive, rather than a raw shape production never serves.

## Non-goals

Unchanged: name-based lookup, fuzzy matching, task caching, mutations, and `get_task` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)