### PR TITLE
Sequence #88 ahead of #171

### DIFF
--- a/docs/roadmap-execution-plan.md
+++ b/docs/roadmap-execution-plan.md
@@ -7,19 +7,24 @@ records only current sequencing and cross-issue dependencies.
 
 ## Current Focus
 
-`v0.12.0-beta` shipped. IPC hardening (#197) and the plug-in diagnostic half
-of #200 have merged. The next slice is
-[#172 — bounded task-detail lookup](https://github.com/deverman/FocusRelayMCP/issues/172),
-returning to product capability work for terminal MCP clients.
+`v0.12.0-beta` shipped. IPC hardening (#197), the plug-in diagnostic half of
+#200, and bounded task-detail lookup (#172) have merged. The next slice is
+[#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88),
+which #171 now depends on.
 
 ## Delivery Order
 
-1. [#172 — bounded task-detail lookup](https://github.com/deverman/FocusRelayMCP/issues/172)
-   - Replace repeated one-task calls with one stable-ID query that returns only
-     the details needed for a workflow decision.
+1. [#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88)
+   - Moved ahead of #171. #171 requires path/parent information so duplicate
+     names stay distinguishable, and `ProjectItem` carries no folder or path
+     field today; tags already expose parent and path.
 2. [#171 — multi-name project and tag resolution](https://github.com/deverman/FocusRelayMCP/issues/171)
    - Resolve a bounded set of requested names through the existing catalog cache
-     instead of repeating full catalog queries.
+     instead of repeating full catalog queries. Depends on #88 for project
+     paths. Open question at start: whether batch mode accepts
+     `includeTaskCounts` — measured cost on a 392-project database is roughly
+     +1.3 s and about double the response bytes, and project health has its own
+     issue in #87.
 3. [#173 — atomic heterogeneous task edit plans](https://github.com/deverman/FocusRelayMCP/issues/173)
    - Design the larger approved-workflow batch only after #172 and #171 reduce
      its read-before-write query cost.
@@ -37,9 +42,10 @@ returning to product capability work for terminal MCP clients.
    [#128 — create and assign missing tags](https://github.com/deverman/FocusRelayMCP/issues/128)
    - Query direct project membership by stable ID before creating missing root
      or nested tags during assignment.
-8. [#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88), then
-   [#87 — project-health filters](https://github.com/deverman/FocusRelayMCP/issues/87)
-   - Reduce context before expanding project-review workflows.
+8. [#87 — project-health filters](https://github.com/deverman/FocusRelayMCP/issues/87)
+   - Reduce context before expanding project-review workflows. #88 moved to
+     the front of the order; this is the intended home for stalled/health
+     questions rather than widening batch resolution.
 9. [#85 — safe Forecast contract](https://github.com/deverman/FocusRelayMCP/issues/85), then
    [#125 — Forecast-based attention](https://github.com/deverman/FocusRelayMCP/issues/125), then
    [#126 — broader ranked task search](https://github.com/deverman/FocusRelayMCP/issues/126)


### PR DESCRIPTION
Docs-only. Impact: `docs` (`focusrelay-dev validate --impact docs` passes).

#171 requires batch results to retain path/parent information so duplicate names stay distinguishable, and its proposed input requests a `path` field. `TagItem` already exposes `parentID`, `parentName`, and `path`. **`ProjectItem` exposes no folder or path field at all** — that is exactly what #88 adds.

Shipping #171 first would return indistinguishable entries for same-named projects, which is the failure its acceptance criteria exist to prevent, and a partial contract is hard to tighten afterwards. So #88 moves to the front and #171 follows with its contract intact for both tools.

#87 keeps its slot, now noted as the intended home for stalled/health questions so batch resolution is not widened to answer them.

Also records the open `includeTaskCounts` question on #171 alongside its measured cost — roughly +1.3s and about double the response bytes on a 392-project database — so whoever picks it up starts from evidence rather than re-deriving it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)