### PR TITLE
Expose project folder membership and root filtering (#88)

### DIFF
--- a/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
+++ b/Plugin/FocusRelayBridge.omnijs/Resources/BridgeLibrary.js
@@ -2523,6 +2523,13 @@
             );
           }
 
+          // Library-root scoping. Omni Automation documents project.parentFolder
+          // as the containing Folder or null at the root, so membership is read
+          // directly rather than reconstructed by scanning every folder.
+          if (filter.rootOnly === true) {
+            projects = projects.filter(project => !safe(() => project.parentFolder));
+          }
+
           if (reviewCutoff || reviewDueAfter) {
             projects = projects.filter(p => {
               const nextReview = getProjectDateTimestamp(p, project => project.nextReviewDate);
@@ -2600,6 +2607,43 @@
             
             const completionDate = hasField("completionDate") ? safe(() => p.completionDate) : null;
 
+            // Folder membership from the documented parentFolder relationship.
+            // null parentFolder means the project sits at the library root.
+            const wantsFolderID = hasField("folderID");
+            const wantsFolderName = hasField("folderName");
+            const wantsFolderPath = hasField("folderPath");
+            let folderID = null;
+            let folderName = null;
+            let folderPath = null;
+            if (wantsFolderID || wantsFolderName || wantsFolderPath) {
+              const parentFolder = safe(() => p.parentFolder);
+              if (parentFolder) {
+                if (wantsFolderID) {
+                  folderID = String(safe(() => parentFolder.id.primaryKey) || "") || null;
+                }
+                if (wantsFolderName) {
+                  folderName = String(safe(() => parentFolder.name) || "") || null;
+                }
+                if (wantsFolderPath) {
+                  // Walk documented parent links, root first, so repeated
+                  // folder names stay distinguishable. Depth-capped so a
+                  // malformed cycle cannot spin here.
+                  const chain = [];
+                  let cursor = parentFolder;
+                  let depth = 0;
+                  while (cursor && depth < 32) {
+                    chain.unshift({
+                      id: String(safe(() => cursor.id.primaryKey) || "") || null,
+                      name: String(safe(() => cursor.name) || "") || null
+                    });
+                    cursor = safe(() => cursor.parent);
+                    depth += 1;
+                  }
+                  folderPath = chain;
+                }
+              }
+            }
+
             const item = {
               id: hasField("id") ? String(safe(() => p.id.primaryKey) || "") : null,
               name: hasField("name") ? String(safe(() => p.name) || "") : null,
@@ -2609,7 +2653,10 @@
               lastReviewDate: hasField("lastReviewDate") && lastReviewDate ? lastReviewDate.toISOString() : null,
               nextReviewDate: hasField("nextReviewDate") && nextReviewDate ? nextReviewDate.toISOString() : null,
               reviewInterval: hasField("reviewInterval") ? reviewIntervalPayload : null,
-              completionDate: hasField("completionDate") && completionDate ? completionDate.toISOString() : null
+              completionDate: hasField("completionDate") && completionDate ? completionDate.toISOString() : null,
+              folderID: folderID,
+              folderName: folderName,
+              folderPath: folderPath
             };
             
             // Calculate task counts from flattenedTasks

--- a/Sources/FocusRelayCLI/FocusRelayCLI.swift
+++ b/Sources/FocusRelayCLI/FocusRelayCLI.swift
@@ -125,6 +125,9 @@ struct ListProjects: AsyncParsableCommand {
     @Flag(name: .customLong("include-task-counts"), help: "Include task counts for each project.")
     var includeTaskCounts: Bool = false
 
+    @Flag(name: .customLong("root-only"), help: "Only projects at the library root (not inside any folder).")
+    var rootOnly: Bool = false
+
     @Flag(name: .customLong("review-perspective"), help: "Apply Review due-date defaults while honoring --status (active, onHold, or all reviewable projects).")
     var reviewPerspective: Bool = false
 
@@ -165,6 +168,7 @@ struct ListProjects: AsyncParsableCommand {
             statusFilter: statusFilter,
             includeTaskCounts: includeTaskCounts,
             search: search,
+            rootOnly: rootOnly,
             reviewDueBefore: reviewBeforeDate,
             reviewDueAfter: reviewAfterDate,
             reviewPerspective: reviewPerspective,

--- a/Sources/FocusRelayOutput/OutputModels.swift
+++ b/Sources/FocusRelayOutput/OutputModels.swift
@@ -11,7 +11,8 @@ public enum OutputFieldCatalog {
     public static let project = [
         "id", "name", "note", "status", "flagged", "lastReviewDate",
         "nextReviewDate", "reviewInterval", "hasChildren", "nextTask",
-        "containsSingletonActions", "isStalled", "completionDate"
+        "containsSingletonActions", "isStalled", "completionDate",
+        "folderID", "folderName", "folderPath"
     ]
 
     public static let folder = [
@@ -162,6 +163,9 @@ public struct ProjectOutput: Encodable {
     public let containsSingletonActions: Bool?
     public let isStalled: Bool?
     public let completionDate: Date?
+    public let folderID: String?
+    public let folderName: String?
+    public let folderPath: [FolderPathElement]?
 
     public init(
         id: String?,
@@ -181,7 +185,10 @@ public struct ProjectOutput: Encodable {
         nextTask: ProjectTaskSummary?,
         containsSingletonActions: Bool?,
         isStalled: Bool?,
-        completionDate: Date?
+        completionDate: Date?,
+        folderID: String? = nil,
+        folderName: String? = nil,
+        folderPath: [FolderPathElement]? = nil
     ) {
         self.id = id
         self.name = name
@@ -201,6 +208,9 @@ public struct ProjectOutput: Encodable {
         self.containsSingletonActions = containsSingletonActions
         self.isStalled = isStalled
         self.completionDate = completionDate
+        self.folderID = folderID
+        self.folderName = folderName
+        self.folderPath = folderPath
     }
 }
 
@@ -306,7 +316,10 @@ public func makeProjectOutput(from project: ProjectItem, fields: Set<String>, in
         nextTask: fields.contains("nextTask") ? project.nextTask : nil,
         containsSingletonActions: fields.contains("containsSingletonActions") ? project.containsSingletonActions : nil,
         isStalled: fields.contains("isStalled") ? project.isStalled : nil,
-        completionDate: fields.contains("completionDate") ? project.completionDate : nil
+        completionDate: fields.contains("completionDate") ? project.completionDate : nil,
+        folderID: fields.contains("folderID") ? project.folderID : nil,
+        folderName: fields.contains("folderName") ? project.folderName : nil,
+        folderPath: fields.contains("folderPath") ? project.folderPath : nil
     )
 }
 

--- a/Sources/FocusRelayServer/FocusRelayServer.swift
+++ b/Sources/FocusRelayServer/FocusRelayServer.swift
@@ -422,6 +422,11 @@ public enum FocusRelayServer {
                                 "enum": .array([.string("active"), .string("onHold"), .string("dropped"), .string("done"), .string("all")]),
                                 "default": .string("active")
                             ]),
+                            "rootOnly": .object([
+                                "type": .string("boolean"),
+                                "description": .string("When true, return only projects at the library root — those whose parent folder is null. This is the efficient path for reviewing unfiled projects: request it with compact fields instead of listing the whole catalogue and inferring membership. Composes with statusFilter and pagination."),
+                                "default": .bool(false)
+                            ]),
                             "search": .object([
                                 "type": .string("string"),
                                 "description": .string("Trimmed, literal, case-insensitive substring match against project names only. Empty or whitespace-only values are rejected.")
@@ -844,6 +849,7 @@ public enum FocusRelayServer {
                     let statusFilter = try decodeArgument(String.self, from: params.arguments, key: "statusFilter") ?? "active"
                     let includeTaskCounts = try decodeArgument(Bool.self, from: params.arguments, key: "includeTaskCounts") ?? false
                     let search = try decodeArgument(String.self, from: params.arguments, key: "search")
+                    let rootOnly = try decodeArgument(Bool.self, from: params.arguments, key: "rootOnly") ?? false
                     let reviewDueBefore = try decodeArgument(Date.self, from: params.arguments, key: "reviewDueBefore")
                     let reviewDueAfter = try decodeArgument(Date.self, from: params.arguments, key: "reviewDueAfter")
                     let reviewPerspective = try decodeArgument(Bool.self, from: params.arguments, key: "reviewPerspective") ?? false
@@ -862,6 +868,7 @@ public enum FocusRelayServer {
                         statusFilter: statusFilter,
                         includeTaskCounts: includeTaskCounts,
                         search: search,
+                        rootOnly: rootOnly,
                         reviewDueBefore: reviewDueBefore,
                         reviewDueAfter: reviewDueAfter,
                         reviewPerspective: reviewPerspective,

--- a/Sources/OmniFocusAutomation/BridgeClient.swift
+++ b/Sources/OmniFocusAutomation/BridgeClient.swift
@@ -136,6 +136,7 @@ final class BridgeClient: @unchecked Sendable {
         statusFilter: String?,
         includeTaskCounts: Bool,
         search: String? = nil,
+        rootOnly: Bool = false,
         reviewDueBefore: Date?,
         reviewDueAfter: Date?,
         reviewPerspective: Bool,
@@ -146,6 +147,7 @@ final class BridgeClient: @unchecked Sendable {
     ) throws -> Page<ProjectItem> {
         let requestId = UUID().uuidString
         let projectFilter = ProjectFilter(
+            rootOnly: rootOnly ? true : nil,
             statusFilter: statusFilter,
             includeTaskCounts: includeTaskCounts,
             search: search,
@@ -194,7 +196,12 @@ final class BridgeClient: @unchecked Sendable {
                     nextTask: nextTask,
                     containsSingletonActions: payload.containsSingletonActions,
                     isStalled: payload.isStalled,
-                    completionDate: payload.completionDate
+                    completionDate: payload.completionDate,
+                    folderID: payload.folderID,
+                    folderName: payload.folderName,
+                    folderPath: payload.folderPath.map { elements in
+                        elements.map { FolderPathElement(id: $0.id ?? "", name: $0.name ?? "") }
+                    }
                 )
             }
             return Page(items: items, nextCursor: payloadPage.nextCursor, returnedCount: payloadPage.returnedCount, totalCount: payloadPage.totalCount, warnings: response.warnings)

--- a/Sources/OmniFocusAutomation/CatalogCache.swift
+++ b/Sources/OmniFocusAutomation/CatalogCache.swift
@@ -8,6 +8,7 @@ struct CacheKey: Hashable {
     let statusFilter: String?
     let includeTaskCounts: Bool
     let search: String?
+    let rootOnly: Bool
 
     private init(
         limit: Int,
@@ -15,7 +16,8 @@ struct CacheKey: Hashable {
         fieldsKey: String,
         statusFilter: String?,
         includeTaskCounts: Bool,
-        search: String?
+        search: String?,
+        rootOnly: Bool = false
     ) {
         self.limit = limit
         self.cursor = cursor
@@ -23,6 +25,7 @@ struct CacheKey: Hashable {
         self.statusFilter = statusFilter
         self.includeTaskCounts = includeTaskCounts
         self.search = search
+        self.rootOnly = rootOnly
     }
 
     static func projects(
@@ -30,7 +33,8 @@ struct CacheKey: Hashable {
         fields: [String]?,
         statusFilter: String?,
         includeTaskCounts: Bool,
-        search: String? = nil
+        search: String? = nil,
+        rootOnly: Bool = false
     ) -> CacheKey {
         CacheKey(
             limit: page.limit,
@@ -38,7 +42,8 @@ struct CacheKey: Hashable {
             fieldsKey: (fields ?? []).joined(separator: ","),
             statusFilter: statusFilter,
             includeTaskCounts: includeTaskCounts,
-            search: search
+            search: search,
+            rootOnly: rootOnly
         )
     }
 

--- a/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
+++ b/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
@@ -66,6 +66,7 @@ public final class OmniFocusBridgeService: OmniFocusService {
         statusFilter: String?,
         includeTaskCounts: Bool,
         search: String? = nil,
+        rootOnly: Bool,
         reviewDueBefore: Date?,
         reviewDueAfter: Date?,
         reviewPerspective: Bool,
@@ -76,6 +77,7 @@ public final class OmniFocusBridgeService: OmniFocusService {
     ) async throws -> Page<ProjectItem> {
         let normalizedSearch = try Self.normalizeProjectSearch(search)
         let projectFilter = ProjectFilter(
+            rootOnly: rootOnly ? true : nil,
             statusFilter: statusFilter,
             includeTaskCounts: includeTaskCounts,
             search: normalizedSearch,
@@ -98,7 +100,8 @@ public final class OmniFocusBridgeService: OmniFocusService {
                 fields: fields,
                 statusFilter: statusFilter,
                 includeTaskCounts: includeTaskCounts,
-                search: normalizedSearch
+                search: normalizedSearch,
+                rootOnly: rootOnly
             )
             if let cached = await cache.getProjects(key: key) {
                 return try QueryBoundCursor.publicPage(from: cached, identity: identity)
@@ -111,6 +114,7 @@ public final class OmniFocusBridgeService: OmniFocusService {
                         statusFilter: statusFilter,
                         includeTaskCounts: includeTaskCounts,
                         search: normalizedSearch,
+                        rootOnly: rootOnly,
                         reviewDueBefore: reviewDueBefore,
                         reviewDueAfter: reviewDueAfter,
                         reviewPerspective: reviewPerspective,
@@ -134,6 +138,7 @@ public final class OmniFocusBridgeService: OmniFocusService {
                 statusFilter: statusFilter,
                 includeTaskCounts: includeTaskCounts,
                 search: normalizedSearch,
+                rootOnly: rootOnly,
                 reviewDueBefore: reviewDueBefore,
                 reviewDueAfter: reviewDueAfter,
                 reviewPerspective: reviewPerspective,

--- a/Sources/OmniFocusAutomation/PayloadModels.swift
+++ b/Sources/OmniFocusAutomation/PayloadModels.swift
@@ -49,6 +49,14 @@ struct ProjectItemPayload: Codable {
     let containsSingletonActions: Bool?
     let isStalled: Bool?
     let completionDate: Date?
+    let folderID: String?
+    let folderName: String?
+    let folderPath: [FolderPathElementPayload]?
+}
+
+struct FolderPathElementPayload: Codable {
+    let id: String?
+    let name: String?
 }
 
 struct TagItemPayload: Codable {

--- a/Sources/OmniFocusCore/OmniFocusCore.swift
+++ b/Sources/OmniFocusCore/OmniFocusCore.swift
@@ -94,6 +94,12 @@ public struct ProjectItem: Codable, Sendable {
     public let containsSingletonActions: Bool?
     public let isStalled: Bool?
     public let completionDate: Date?
+    /// Direct parent folder, or nil for a project at the library root.
+    public let folderID: String?
+    public let folderName: String?
+    /// Ancestor folders root-first, so repeated folder names remain
+    /// distinguishable. nil at the library root.
+    public let folderPath: [FolderPathElement]?
 
     public init(
         id: String,
@@ -113,7 +119,10 @@ public struct ProjectItem: Codable, Sendable {
         nextTask: ProjectTaskSummary? = nil,
         containsSingletonActions: Bool? = nil,
         isStalled: Bool? = nil,
-        completionDate: Date? = nil
+        completionDate: Date? = nil,
+        folderID: String? = nil,
+        folderName: String? = nil,
+        folderPath: [FolderPathElement]? = nil
     ) {
         self.id = id
         self.name = name
@@ -133,6 +142,21 @@ public struct ProjectItem: Codable, Sendable {
         self.containsSingletonActions = containsSingletonActions
         self.isStalled = isStalled
         self.completionDate = completionDate
+        self.folderID = folderID
+        self.folderName = folderName
+        self.folderPath = folderPath
+    }
+}
+
+/// One ancestor in a folder chain, root first. Mirrors `TagPathElement` so
+/// nested folders with repeated names stay distinguishable.
+public struct FolderPathElement: Codable, Sendable, Equatable {
+    public let id: String
+    public let name: String
+
+    public init(id: String, name: String) {
+        self.id = id
+        self.name = name
     }
 }
 
@@ -269,6 +293,8 @@ public struct TagFilter: Codable, Sendable {
 }
 
 public struct ProjectFilter: Codable, Sendable {
+    /// When true, return only projects whose documented parentFolder is null.
+    public var rootOnly: Bool?
     public var statusFilter: String?
     public var includeTaskCounts: Bool?
     public var search: String?
@@ -280,6 +306,7 @@ public struct ProjectFilter: Codable, Sendable {
     public var completedAfter: Date?
 
     public init(
+        rootOnly: Bool? = nil,
         statusFilter: String? = nil,
         includeTaskCounts: Bool? = nil,
         search: String? = nil,
@@ -290,6 +317,7 @@ public struct ProjectFilter: Codable, Sendable {
         completedBefore: Date? = nil,
         completedAfter: Date? = nil
     ) {
+        self.rootOnly = rootOnly
         self.statusFilter = statusFilter
         self.includeTaskCounts = includeTaskCounts
         self.search = search
@@ -391,6 +419,7 @@ public protocol OmniFocusService: Sendable {
         statusFilter: String?,
         includeTaskCounts: Bool,
         search: String?,
+        rootOnly: Bool,
         reviewDueBefore: Date?,
         reviewDueAfter: Date?,
         reviewPerspective: Bool,

--- a/Tests/FocusRelayServerTests/MCPCancellationBoundaryTests.swift
+++ b/Tests/FocusRelayServerTests/MCPCancellationBoundaryTests.swift
@@ -87,6 +87,7 @@ private actor CancellationBoundaryService: OmniFocusService {
         statusFilter: String?,
         includeTaskCounts: Bool,
         search: String?,
+        rootOnly: Bool,
         reviewDueBefore: Date?,
         reviewDueAfter: Date?,
         reviewPerspective: Bool,

--- a/Tests/OmniFocusIntegrationTests/ProjectFolderMembershipTests.swift
+++ b/Tests/OmniFocusIntegrationTests/ProjectFolderMembershipTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import OmniFocusCore
+import Testing
+@testable import OmniFocusAutomation
+
+/// Cache correctness for the rootOnly scope. A cached full-catalogue page must
+/// never satisfy a root-only request (or the reverse): the two ask different
+/// questions of the same status filter, and #88's whole point is not having to
+/// fetch the full catalogue to find unfiled projects.
+@Suite("rootOnly cache keying")
+struct RootOnlyCacheKeyTests {
+    private func key(rootOnly: Bool, statusFilter: String = "active") -> CacheKey {
+        CacheKey.projects(
+            page: PageRequest(limit: 150),
+            fields: ["id", "name"],
+            statusFilter: statusFilter,
+            includeTaskCounts: false,
+            search: nil,
+            rootOnly: rootOnly
+        )
+    }
+
+    @Test func rootOnlyChangesTheCacheKey() {
+        #expect(key(rootOnly: true) != key(rootOnly: false),
+                "a root-only page must not be served from the full-catalogue cache entry")
+    }
+
+    @Test func matchingRootOnlyReusesTheSameKey() {
+        #expect(key(rootOnly: true) == key(rootOnly: true))
+    }
+
+    @Test func rootOnlyComposesWithStatusFilterInTheKey() {
+        #expect(key(rootOnly: true, statusFilter: "active") != key(rootOnly: true, statusFilter: "all"))
+    }
+
+    @Test func cachedRootOnlyPageIsNotReturnedForAFullCatalogueRequest() async {
+        let cache = CatalogCache()
+        let rootPage = Page(
+            items: [ProjectItem(id: "root-1", name: "Root project", status: "active", flagged: false)],
+            returnedCount: 1
+        )
+        await cache.setProjects(rootPage, key: key(rootOnly: true), ttl: 300)
+
+        let leaked = await cache.getProjects(key: key(rootOnly: false))
+        #expect(leaked == nil, "the full-catalogue request must miss and fetch its own page")
+
+        let hit = await cache.getProjects(key: key(rootOnly: true))
+        #expect(hit?.items.first?.id == "root-1")
+    }
+}
+
+/// Folder membership shape. A root project reports null membership; a filed
+/// project reports its direct parent plus a root-first ancestor chain so
+/// repeated folder names stay distinguishable.
+@Suite("Project folder membership modelling")
+struct ProjectFolderMembershipTests {
+    private func project(
+        id: String,
+        folderID: String? = nil,
+        folderName: String? = nil,
+        folderPath: [FolderPathElement]? = nil
+    ) -> ProjectItem {
+        ProjectItem(
+            id: id,
+            name: "Project \(id)",
+            status: "active",
+            flagged: false,
+            folderID: folderID,
+            folderName: folderName,
+            folderPath: folderPath
+        )
+    }
+
+    @Test func rootProjectReportsNoFolderMembership() {
+        let item = project(id: "p1")
+        #expect(item.folderID == nil)
+        #expect(item.folderName == nil)
+        #expect(item.folderPath == nil)
+    }
+
+    @Test func filedProjectCarriesDirectParentAndAncestorChain() {
+        let item = project(
+            id: "p2",
+            folderID: "f-child",
+            folderName: "Clients",
+            folderPath: [
+                FolderPathElement(id: "f-root", name: "Work"),
+                FolderPathElement(id: "f-child", name: "Clients")
+            ]
+        )
+        #expect(item.folderID == "f-child")
+        #expect(item.folderPath?.first?.name == "Work", "path is root-first")
+        #expect(item.folderPath?.last?.id == item.folderID, "path ends at the direct parent")
+    }
+
+    @Test func duplicateFolderNamesRemainDistinguishableByPath() {
+        // Two folders both named "Archive" under different roots: the direct
+        // name alone is ambiguous, the path is not.
+        let underWork = project(
+            id: "a",
+            folderID: "f-1",
+            folderName: "Archive",
+            folderPath: [FolderPathElement(id: "w", name: "Work"), FolderPathElement(id: "f-1", name: "Archive")]
+        )
+        let underHome = project(
+            id: "b",
+            folderID: "f-2",
+            folderName: "Archive",
+            folderPath: [FolderPathElement(id: "h", name: "Home"), FolderPathElement(id: "f-2", name: "Archive")]
+        )
+        #expect(underWork.folderName == underHome.folderName)
+        #expect(underWork.folderID != underHome.folderID)
+        #expect(underWork.folderPath != underHome.folderPath,
+                "path must disambiguate identically named folders")
+    }
+
+    @Test func rootOnlyIsCarriedOnTheProjectFilter() {
+        #expect(ProjectFilter(rootOnly: true).rootOnly == true)
+        #expect(ProjectFilter().rootOnly == nil, "absent means unscoped, not false")
+    }
+
+    @Test func rootOnlyChangesTheQueryIdentitySoCursorsCannotCross() throws {
+        let unscoped = try QueryBoundCursor.queryIdentity(tool: "list_projects", input: ProjectFilter(statusFilter: "active"))
+        let scoped = try QueryBoundCursor.queryIdentity(tool: "list_projects", input: ProjectFilter(rootOnly: true, statusFilter: "active"))
+        #expect(unscoped.fingerprint != scoped.fingerprint,
+                "a cursor issued for the full catalogue must not resume a root-only query")
+    }
+}


### PR DESCRIPTION
Closes #88. Unblocks #171, which needs project paths so batch-resolved duplicate names stay distinguishable.

## Problem

A model asked which projects sit outside folders and could not answer it. `folderID` and `folderName` were dropped because `ProjectItem` carried no membership at all, so the model could only sum folder `projectCount` values to infer that ~91 of 379 projects were unfiled — never identify *which*.

## Change

`list_projects` returns `folderID`, `folderName`, and `folderPath`, read from the documented `project.parentFolder` relationship rather than reconstructed by scanning folders. `folderPath` lists ancestors root-first so repeated folder names stay distinguishable, and is depth-capped so a malformed parent cycle cannot spin. A project at the library root reports `null` for all three.

A `rootOnly` filter scopes the query server-side to projects whose `parentFolder` is null.

**`rootOnly` is part of the projects cache key.** Without that, a cached full-catalogue page would satisfy a root-only request and vice versa — returning filed projects to a query asking for unfiled ones, which is exactly the confusion this feature exists to remove. It also enters the query identity, so a cursor issued for one scope cannot resume the other. Both are pinned by tests.

## Measured against the UAT baseline

On a 392-project database:

| | items | payload | latency |
| --- | --- | --- | --- |
| full catalogue (UAT approach) | 392 | 27024 B | 413 ms |
| `rootOnly=true` | **102** | **8765 B** | 416 ms |

Model-visible items **74% fewer**, payload **68% smaller**. **Per-call latency is unchanged** — the bridge still walks `flattenedProjects`, so the filter simply runs there instead of in the model. The win is that the question becomes answerable at all, and answerable compactly; it is not a latency optimisation and is not presented as one.

## Live verification

| check | result |
| --- | --- |
| `rootOnly` count vs `folderID == null` in full catalogue | 102 = 102, exact |
| filed projects missing `folderName` | 0 of 290 |
| `folderPath` tail ≠ `folderID` | 0 |
| root projects leaking folder data | 0 |
| projects with nested path (depth > 1) | 62 |
| composes with status filter | active 73/275, all 102/392, done 10/16 |
| composes with pagination | 40-item page issues a cursor |

Direct MCP probes confirmed the same through the wire, including that unsupported field names are rejected (`list_projects.fields contains unsupported field(s): bogusField`) — that acceptance criterion turned out to be already satisfied before this work.

## Validation

Impact: `transport-reliability` per `focusrelay-dev classify` (it flags `BridgeClient`, whose only change here is threading a `rootOnly` parameter).

- 281 tests pass, including 9 new ones covering root/filed/nested/duplicate-name membership, cache keying, and cursor identity.
- All semantic gates pass; `validate --impact query` clean.
- **The 10-minute smoke run failed closed**, and I am not claiming otherwise: 1 timeout in 66 measured calls (1.52%), on `get_project_counts` / `project_view_everything`, `pickupState=bridge_processing` at the 45 s deadline.

  Attribution: **this change cannot reach that path.** Every JS edit lies between lines 2526-2660, inside the `list_projects` branch; `get_project_counts` begins at line 3177 and is untouched, and the new code is gated behind `hasField(...)` and `rootOnly === true`. The run's own baseline was already slow — p50 9.4 s, p95 15.1 s, p99 17.4 s — on a machine that had been running benchmarks and heavy OmniFocus work for hours.

  A re-run is in progress and this PR will be updated with the result. **Do not merge on the strength of the failed run alone.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)