### PR TITLE
Add #206 benchmark methodology and #207 cache-key derivation to the roadmap

### DIFF
--- a/docs/roadmap-execution-plan.md
+++ b/docs/roadmap-execution-plan.md
@@ -1,6 +1,6 @@
 # FocusRelay Roadmap Execution Plan
 
-Last updated: 2026-08-01
+Last updated: 2026-08-02
 
 GitHub issues own requirements, discussion, and validation evidence. This file
 records only current sequencing and cross-issue dependencies.
@@ -8,58 +8,65 @@ records only current sequencing and cross-issue dependencies.
 ## Current Focus
 
 `v0.12.0-beta` shipped. IPC hardening (#197), the plug-in diagnostic half of
-#200, and bounded task-detail lookup (#172) have merged. The next slice is
-[#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88),
-which #171 now depends on.
+#200, bounded task-detail lookup (#172), and project folder membership (#88)
+have merged. The next slice is
+[#171 — multi-name project and tag resolution](https://github.com/deverman/FocusRelayMCP/issues/171),
+now unblocked by #88.
 
 ## Delivery Order
 
-1. [#88 — project folder membership](https://github.com/deverman/FocusRelayMCP/issues/88)
-   - Moved ahead of #171. #171 requires path/parent information so duplicate
-     names stay distinguishable, and `ProjectItem` carries no folder or path
-     field today; tags already expose parent and path.
-2. [#171 — multi-name project and tag resolution](https://github.com/deverman/FocusRelayMCP/issues/171)
-   - Resolve a bounded set of requested names through the existing catalog cache
-     instead of repeating full catalog queries. Depends on #88 for project
-     paths. Open question at start: whether batch mode accepts
-     `includeTaskCounts` — measured cost on a 392-project database is roughly
-     +1.3 s and about double the response bytes, and project health has its own
-     issue in #87.
-3. [#173 — atomic heterogeneous task edit plans](https://github.com/deverman/FocusRelayMCP/issues/173)
+1. [#171 — multi-name project and tag resolution](https://github.com/deverman/FocusRelayMCP/issues/171)
+   - Resolve a bounded set of requested names in one call instead of repeating
+     scalar catalog searches. Unblocked by #88, which supplies project paths.
+     Settled: batch mode rejects `includeTaskCounts` — measured cost is roughly
+     +1.3 s and about double the response bytes, and project health belongs to
+     #87.
+2. [#206 — benchmark the changed path and state a merge verdict](https://github.com/deverman/FocusRelayMCP/issues/206)
+   - Validating #88 spent four smoke suites on a gate that never benchmarks
+     `list_projects`, while host variance ran 3-4x and flipped the pass/fail
+     twice on noise. Coverage checks, interleaved baseline comparison, explicit
+     better/worse/inconclusive criteria, and a merge recommendation. Apply its
+     approach while benchmarking #171 and fold what is learned back in.
+3. [#207 — derive catalog cache keys from the filter](https://github.com/deverman/FocusRelayMCP/issues/207)
+   - No live bug: `CacheKey` and the `shouldBypassCache` list agree by
+     inspection, not construction. #88 nearly shipped a `rootOnly` key omission
+     that would have served filed projects to an unfiled-projects query with no
+     error. Derive the key so the gap cannot recur.
+4. [#173 — atomic heterogeneous task edit plans](https://github.com/deverman/FocusRelayMCP/issues/173)
    - Design the larger approved-workflow batch only after #172 and #171 reduce
      its read-before-write query cost.
-4. [#94 — discoverable MCP workflows](https://github.com/deverman/FocusRelayMCP/issues/94)
+5. [#94 — discoverable MCP workflows](https://github.com/deverman/FocusRelayMCP/issues/94)
    - Continue measured client research after the shipped `process_inbox`
      vertical; add another prompt only when UAT demonstrates a reliable benefit.
-5. [#82 — task/subtask creation](https://github.com/deverman/FocusRelayMCP/issues/82), then
+6. [#82 — task/subtask creation](https://github.com/deverman/FocusRelayMCP/issues/82), then
    [#83 — project creation/conversion](https://github.com/deverman/FocusRelayMCP/issues/83)
    - Build on the consolidated edit surface, support safe project folder
      destinations, and retain duplicate/write safety.
-6. [#93 — repetition support](https://github.com/deverman/FocusRelayMCP/issues/93)
+7. [#93 — repetition support](https://github.com/deverman/FocusRelayMCP/issues/93)
    - After task creation and truthful drop behavior stabilize, establish complete
      schedule readback before adding create, edit, and lifecycle mutation slices.
-7. [#130 — project tag membership and filtering](https://github.com/deverman/FocusRelayMCP/issues/130), then
+8. [#130 — project tag membership and filtering](https://github.com/deverman/FocusRelayMCP/issues/130), then
    [#128 — create and assign missing tags](https://github.com/deverman/FocusRelayMCP/issues/128)
    - Query direct project membership by stable ID before creating missing root
      or nested tags during assignment.
-8. [#87 — project-health filters](https://github.com/deverman/FocusRelayMCP/issues/87)
+9. [#87 — project-health filters](https://github.com/deverman/FocusRelayMCP/issues/87)
    - Reduce context before expanding project-review workflows. #88 moved to
      the front of the order; this is the intended home for stalled/health
      questions rather than widening batch resolution.
-9. [#85 — safe Forecast contract](https://github.com/deverman/FocusRelayMCP/issues/85), then
+10. [#85 — safe Forecast contract](https://github.com/deverman/FocusRelayMCP/issues/85), then
    [#125 — Forecast-based attention](https://github.com/deverman/FocusRelayMCP/issues/125), then
    [#126 — broader ranked task search](https://github.com/deverman/FocusRelayMCP/issues/126)
    - Reuse one documented task-only Forecast classifier for attention ranking.
    - Keep search independent, broad, relevance-ranked, and lightweight.
-10. [#92 — guided Homebrew setup](https://github.com/deverman/FocusRelayMCP/issues/92)
+11. [#92 — guided Homebrew setup](https://github.com/deverman/FocusRelayMCP/issues/92)
     - Reduce installation friction after the next product capabilities settle.
     - Covers the plug-in directory discovery and partial-install reporting
       left open by #200.
-11. [#90 — command/session latency](https://github.com/deverman/FocusRelayMCP/issues/90)
+12. [#90 — command/session latency](https://github.com/deverman/FocusRelayMCP/issues/90)
     - The remaining measured command experiment.
-12. Small independent query improvements: #11, #22, #18, #59, #62, #65,
+13. Small independent query improvements: #11, #22, #18, #59, #62, #65,
     #66, #67, and #68.
-13. Feasibility work for #10 custom perspectives and #16 planned-date writes.
+14. Feasibility work for #10 custom perspectives and #16 planned-date writes.
 
 ## Standing Decisions
 
@@ -87,6 +94,9 @@ which #171 now depends on.
 - #95 established the current development and release flow; #90 owns the
   remaining command/session latency investigation.
 - Raw benchmark artifacts are not roadmap content and belong under `.build`.
+- Benchmark a change on the path it changed. A suite that does not exercise the
+  changed tool cannot clear it, and a single stalled call on a noisy host is one
+  observation rather than a verdict. #206 owns turning this into tooling.
 
 ## Release Reference
 


### PR DESCRIPTION
Docs-only. Impact: `docs` (validation passes).

#88 merged, so #171 becomes the next slice.

**#206** comes directly from validating #88: four 10-minute smoke suites ran against a gate that never benchmarks `list_projects`, host variance ran 3-4x uncorrelated with load, and the pass/fail flipped twice on noise — while the actual question was answered by a ten-minute interleaved A/B. It covers benchmark coverage checks, interleaved baseline comparison, explicit better/worse/inconclusive criteria, and an emitted merge recommendation. Sequenced immediately after #171 so its approach gets exercised while benchmarking #171, then refined from that experience.

**#207** records a near miss, not a live bug: `CacheKey` and the `shouldBypassCache` list agree by inspection rather than construction, and #88 nearly shipped a `rootOnly` omission that would have served filed projects to an unfiled-projects query with no error.

Also adds a standing decision: benchmark a change on the path it changed, and treat a single stalled call as one observation rather than a verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)