### PR TITLE
Detect benchmark coverage gaps and state a verdict (#206)

### DIFF
--- a/Sources/FocusRelayDevCLI/FocusRelayDevCLI.swift
+++ b/Sources/FocusRelayDevCLI/FocusRelayDevCLI.swift
@@ -31,16 +31,32 @@ private struct Classify: ParsableCommand {
         let untracked = try CommandRunner.capture("git", ["ls-files", "--others", "--exclude-standard"])
         let files = (changed + "\n" + untracked).split(separator: "\n").map(String.init)
         let result = ChangeClassifier.classify(files)
+        let coverage = BenchmarkCoverage.assess(changedFiles: files)
         if json {
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-            FileHandle.standardOutput.write(try encoder.encode(result))
+            FileHandle.standardOutput.write(try encoder.encode(ClassifyReport(classification: result, coverage: coverage)))
             print()
         } else {
             print(result.impact.rawValue)
             result.reasons.forEach { print("- \($0)") }
+            if !coverage.touchedTools.isEmpty {
+                print("")
+                print("Benchmark coverage:")
+                for tool in coverage.covered { print("  ✅ \(tool)") }
+                for tool in coverage.uncovered { print("  ⚠️  \(tool) — no benchmark in the suite") }
+            }
+            if coverage.hasCoverageGap {
+                print("")
+                print(BenchmarkCoverage.coverageGapMessage(coverage))
+            }
         }
     }
+}
+
+private struct ClassifyReport: Codable {
+    let classification: ChangeClassification
+    let coverage: BenchmarkCoverage.Assessment
 }
 
 private struct Validate: ParsableCommand {

--- a/Sources/FocusRelayDevCore/BenchmarkCoverage.swift
+++ b/Sources/FocusRelayDevCore/BenchmarkCoverage.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Which public tools a change touches, and whether the benchmark suite can
+/// actually measure them.
+///
+/// #88 changed `list_projects` and was gated on a smoke suite that benchmarks
+/// `list_tasks`, `get_task_counts`, and `get_project_counts` — so four suites
+/// ran without measuring a line of the changed path. This makes that gap loud
+/// instead of invisible.
+public enum BenchmarkCoverage {
+    /// Tools the benchmark suite can measure today.
+    public static let benchmarkedTools: Set<String> = [
+        "list_tasks",
+        "get_task_counts",
+        "get_project_counts"
+    ]
+
+    /// Every public model-facing tool.
+    public static let publicTools: Set<String> = [
+        "list_tasks", "get_task", "list_projects", "list_tags", "list_folders",
+        "edit_tasks", "edit_projects", "get_task_counts", "get_project_counts"
+    ]
+
+    /// Source markers that imply a tool's request path may have changed.
+    /// Deliberately broad: a false "you should benchmark this" costs a
+    /// conversation, a false "nothing to see here" costs what #88 cost.
+    private static let toolMarkers: [String: [String]] = [
+        "list_tasks": ["listtasks", "list_tasks", "taskfilter", "taskidselection"],
+        "get_task": ["gettask", "get_task"],
+        "list_projects": ["listprojects", "list_projects", "projectfilter", "batchnameresolution"],
+        "list_tags": ["listtags", "list_tags", "tagfilter", "batchnameresolution"],
+        "list_folders": ["listfolders", "list_folders", "folderitem"],
+        "edit_tasks": ["edittasks", "edit_tasks"],
+        "edit_projects": ["editprojects", "edit_projects"],
+        "get_task_counts": ["taskcounts", "get_task_counts"],
+        "get_project_counts": ["projectcounts", "get_project_counts"]
+    ]
+
+    /// Paths broad enough that any public tool could be affected.
+    private static let wideMarkers = ["bridgeclient", "bridgelibrary.js", "focusrelayserver"]
+
+    public struct Assessment: Codable, Equatable, Sendable {
+        public let touchedTools: [String]
+        public let covered: [String]
+        public let uncovered: [String]
+        /// True when a changed tool has no benchmark, so the suite cannot
+        /// clear it however green it runs.
+        public var hasCoverageGap: Bool { !uncovered.isEmpty }
+    }
+
+    public static func assess(changedFiles: [String]) -> Assessment {
+        var touched = Set<String>()
+        for path in changedFiles {
+            let lower = path.lowercased()
+            if wideMarkers.contains(where: lower.contains) {
+                // A shared path can affect anything; report only the tools
+                // that also have their own marker, so the message stays
+                // actionable rather than listing all nine every time.
+                continue
+            }
+            for (tool, markers) in toolMarkers where markers.contains(where: lower.contains) {
+                touched.insert(tool)
+            }
+        }
+        // Second pass: shared paths still count once specific tools are known.
+        if touched.isEmpty {
+            for path in changedFiles {
+                let lower = path.lowercased()
+                for (tool, markers) in toolMarkers where markers.contains(where: lower.contains) {
+                    touched.insert(tool)
+                }
+            }
+        }
+
+        let sorted = touched.sorted()
+        return Assessment(
+            touchedTools: sorted,
+            covered: sorted.filter { benchmarkedTools.contains($0) },
+            uncovered: sorted.filter { !benchmarkedTools.contains($0) }
+        )
+    }
+
+    /// Message shown when a changed tool cannot be measured by the suite.
+    public static func coverageGapMessage(_ assessment: Assessment) -> String {
+        let missing = assessment.uncovered.joined(separator: ", ")
+        return """
+        Benchmark coverage gap: \(missing) has no benchmark in the suite.
+        A passing benchmark run does not clear this change, because the suite \
+        never exercises the path it modifies. Measure the changed tool directly \
+        with an interleaved A/B against the baseline ref before drawing a \
+        performance conclusion.
+        """
+    }
+}

--- a/Sources/FocusRelayDevCore/BenchmarkVerdict.swift
+++ b/Sources/FocusRelayDevCore/BenchmarkVerdict.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+/// Turns two sets of latency samples into a stated conclusion and a merge
+/// recommendation.
+///
+/// The rule this encodes: a percentage change means nothing without knowing the
+/// noise it sits in. On the host that produced #88's evidence, whole-suite
+/// run-to-run variance reached 3-4x, so a 13% difference can be real (it was,
+/// at ~5 standard errors) while a 0.4% failure-rate difference is chance
+/// (it was, at well under 1).
+public enum BenchmarkVerdict {
+    /// Minimum relative change worth reporting as a direction. Below this a
+    /// result is called indistinguishable even when statistically clean,
+    /// because it is not user-relevant.
+    public static let minimumRelativeChange = 0.05
+    /// Minimum separation in standard errors before a direction is claimed.
+    public static let minimumStandardErrors = 3.0
+    /// Minimum samples per arm; below this the comparison is inconclusive.
+    public static let minimumSamplesPerArm = 5
+    /// Above this coefficient of variation the host is too noisy to conclude.
+    public static let maximumCoefficientOfVariation = 0.35
+
+    public enum Outcome: String, Codable, Sendable {
+        case improvement = "IMPROVEMENT"
+        case regression = "REGRESSION"
+        case indistinguishable = "INDISTINGUISHABLE"
+        /// Too few samples, or a host too noisy to separate the arms.
+        case inconclusive = "INCONCLUSIVE"
+        /// The arms did not return equivalent results, so their timings are
+        /// not comparable. #171 was in exactly this state before a field bug
+        /// was found: the fast arm was fast because it returned nothing.
+        case notComparable = "NOT COMPARABLE"
+    }
+
+    public struct ArmStatistics: Codable, Equatable, Sendable {
+        public let name: String
+        public let samples: Int
+        public let median: Double
+        public let stdev: Double
+        public let standardError: Double
+
+        public init(name: String, samplesMilliseconds: [Double]) {
+            self.name = name
+            self.samples = samplesMilliseconds.count
+            let sorted = samplesMilliseconds.sorted()
+            self.median = sorted.isEmpty ? 0 : (sorted.count % 2 == 1
+                ? sorted[sorted.count / 2]
+                : (sorted[sorted.count / 2 - 1] + sorted[sorted.count / 2]) / 2)
+            if samplesMilliseconds.count > 1 {
+                let mean = samplesMilliseconds.reduce(0, +) / Double(samplesMilliseconds.count)
+                let variance = samplesMilliseconds.reduce(0) { $0 + ($1 - mean) * ($1 - mean) }
+                    / Double(samplesMilliseconds.count - 1)
+                self.stdev = variance.squareRoot()
+                self.standardError = self.stdev / Double(samplesMilliseconds.count).squareRoot()
+            } else {
+                self.stdev = 0
+                self.standardError = 0
+            }
+        }
+    }
+
+    public struct Result: Codable, Equatable, Sendable {
+        public let outcome: Outcome
+        public let baseline: ArmStatistics
+        public let candidate: ArmStatistics
+        public let relativeChange: Double
+        public let standardErrors: Double
+        public let recommendation: String
+    }
+
+    /// `resultsEquivalent` must be established by the caller before timings
+    /// mean anything — two arms returning different data are not a comparison.
+    public static func evaluate(
+        baseline: ArmStatistics,
+        candidate: ArmStatistics,
+        resultsEquivalent: Bool
+    ) -> Result {
+        let relative = baseline.median == 0 ? 0 : (candidate.median - baseline.median) / baseline.median
+        let combinedError = (baseline.standardError * baseline.standardError
+            + candidate.standardError * candidate.standardError).squareRoot()
+        let separation = combinedError == 0 ? 0 : abs(candidate.median - baseline.median) / combinedError
+
+        let outcome: Outcome
+        if !resultsEquivalent {
+            outcome = .notComparable
+        } else if baseline.samples < minimumSamplesPerArm || candidate.samples < minimumSamplesPerArm {
+            outcome = .inconclusive
+        } else if tooNoisy(baseline) || tooNoisy(candidate) {
+            outcome = .inconclusive
+        } else if relative <= -minimumRelativeChange && separation >= minimumStandardErrors {
+            outcome = .improvement
+        } else if relative >= minimumRelativeChange && separation >= minimumStandardErrors {
+            outcome = .regression
+        } else {
+            outcome = .indistinguishable
+        }
+
+        return Result(
+            outcome: outcome,
+            baseline: baseline,
+            candidate: candidate,
+            relativeChange: relative,
+            standardErrors: separation,
+            recommendation: recommendation(for: outcome, relative: relative)
+        )
+    }
+
+    private static func tooNoisy(_ arm: ArmStatistics) -> Bool {
+        guard arm.median > 0 else { return true }
+        return arm.stdev / arm.median > maximumCoefficientOfVariation
+    }
+
+    private static func recommendation(for outcome: Outcome, relative: Double) -> String {
+        switch outcome {
+        case .improvement:
+            return "safe to merge — measured improvement on the changed path"
+        case .regression:
+            let percent = String(format: "%.1f", relative * 100)
+            return "do not merge on performance grounds — measured regression of \(percent)% on the changed path"
+        case .indistinguishable:
+            return "safe to merge — no regression detected on the changed path"
+        case .inconclusive:
+            return "re-run on a quiescent host — the samples cannot separate the arms"
+        case .notComparable:
+            return "fix the arms before concluding — they did not return equivalent results, so the timings mean nothing"
+        }
+    }
+
+    /// Human-readable block for a PR comment or suite output.
+    public static func render(_ result: Result) -> String {
+        let pct = String(format: "%+.1f", result.relativeChange * 100)
+        let se = String(format: "%.1f", result.standardErrors)
+        return """
+        VERDICT: \(result.outcome.rawValue) (median \(pct)%, \(se) SE, \
+        n=\(result.baseline.samples)/\(result.candidate.samples) per arm)
+        RECOMMENDATION: \(result.recommendation)
+        """
+    }
+}

--- a/Tests/FocusRelayDevCoreTests/BenchmarkVerdictTests.swift
+++ b/Tests/FocusRelayDevCoreTests/BenchmarkVerdictTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import Testing
+@testable import FocusRelayDevCore
+
+private func arm(_ name: String, _ samples: [Double]) -> BenchmarkVerdict.ArmStatistics {
+    BenchmarkVerdict.ArmStatistics(name: name, samplesMilliseconds: samples)
+}
+
+@Suite("Benchmark verdict criteria")
+struct BenchmarkVerdictTests {
+    @Test func clearImprovementIsReported() {
+        // #171 as measured: 10 scalar searches vs one batch call.
+        let result = BenchmarkVerdict.evaluate(
+            baseline: arm("scalar", [2402, 2380, 2415, 2398, 2440, 2371]),
+            candidate: arm("batch", [432, 428, 435, 430, 433, 429]),
+            resultsEquivalent: true
+        )
+        #expect(result.outcome == .improvement)
+        #expect(result.recommendation.contains("safe to merge"))
+    }
+
+    @Test func clearRegressionIsReported() {
+        let result = BenchmarkVerdict.evaluate(
+            baseline: arm("before", [400, 402, 398, 401, 399, 403]),
+            candidate: arm("after", [600, 604, 598, 602, 601, 599]),
+            resultsEquivalent: true
+        )
+        #expect(result.outcome == .regression)
+        #expect(result.recommendation.contains("do not merge"))
+    }
+
+    @Test func noiseLevelDifferenceIsNotAWin() {
+        // #88's unchanged path: 385ms vs 390ms with ~25ms stdev. Reporting
+        // this as an improvement is exactly the mistake to avoid.
+        let result = BenchmarkVerdict.evaluate(
+            baseline: arm("master", [390, 412, 371, 398, 405, 380]),
+            candidate: arm("branch", [385, 402, 366, 410, 379, 395]),
+            resultsEquivalent: true
+        )
+        #expect(result.outcome == .indistinguishable)
+        #expect(result.recommendation.contains("no regression detected"))
+    }
+
+    @Test func statisticallyCleanButTinyChangeIsNotADirection() {
+        // 2% with almost no variance: real, but not user-relevant.
+        let result = BenchmarkVerdict.evaluate(
+            baseline: arm("before", [1000, 1001, 999, 1000, 1002, 998]),
+            candidate: arm("after", [1020, 1021, 1019, 1020, 1022, 1018]),
+            resultsEquivalent: true
+        )
+        #expect(result.outcome == .indistinguishable,
+                "below the relevance floor, however clean the statistics")
+    }
+
+    @Test func largeChangeWithoutSeparationIsIndistinguishable() {
+        // Big medians apart, but the arms overlap heavily.
+        let result = BenchmarkVerdict.evaluate(
+            baseline: arm("before", [100, 180, 90, 200, 110, 170]),
+            candidate: arm("after", [130, 190, 95, 210, 120, 175]),
+            resultsEquivalent: true
+        )
+        #expect(result.outcome == .inconclusive || result.outcome == .indistinguishable)
+    }
+
+    @Test func tooFewSamplesIsInconclusive() {
+        let result = BenchmarkVerdict.evaluate(
+            baseline: arm("before", [400, 402]),
+            candidate: arm("after", [200, 201]),
+            resultsEquivalent: true
+        )
+        #expect(result.outcome == .inconclusive)
+        #expect(result.recommendation.contains("quiescent host"))
+    }
+
+    @Test func noisyHostIsInconclusiveRatherThanAVerdict() {
+        // The 3-4x swings seen while validating #88.
+        let result = BenchmarkVerdict.evaluate(
+            baseline: arm("before", [2692, 9259, 11838, 3100, 10400, 2800]),
+            candidate: arm("after", [2600, 9100, 11700, 3000, 10200, 2750]),
+            resultsEquivalent: true
+        )
+        #expect(result.outcome == .inconclusive,
+                "a host this noisy cannot support any conclusion")
+    }
+
+    @Test func nonEquivalentArmsAreNotComparable() {
+        // #171 before the field bug was found: the fast arm was fast because
+        // it returned nothing at all.
+        let result = BenchmarkVerdict.evaluate(
+            baseline: arm("scalar", [2400, 2380, 2410, 2390, 2405, 2395]),
+            candidate: arm("batch", [30, 31, 29, 30, 32, 28]),
+            resultsEquivalent: false
+        )
+        #expect(result.outcome == .notComparable)
+        #expect(result.recommendation.contains("did not return equivalent results"))
+    }
+
+    @Test func renderStatesOutcomeAndRecommendation() {
+        let result = BenchmarkVerdict.evaluate(
+            baseline: arm("scalar", [2402, 2380, 2415, 2398, 2440, 2371]),
+            candidate: arm("batch", [432, 428, 435, 430, 433, 429]),
+            resultsEquivalent: true
+        )
+        let text = BenchmarkVerdict.render(result)
+        #expect(text.contains("VERDICT: IMPROVEMENT"))
+        #expect(text.contains("RECOMMENDATION:"))
+        #expect(text.contains("SE"))
+        #expect(text.contains("n=6/6"))
+    }
+
+    @Test func standardErrorShrinksWithMoreSamples() {
+        let few = arm("few", [100, 110, 90, 105, 95])
+        let many = arm("many", Array(repeating: [100, 110, 90, 105, 95], count: 4).flatMap { $0 })
+        #expect(many.standardError < few.standardError)
+    }
+}
+
+@Suite("Benchmark coverage detection")
+struct BenchmarkCoverageTests {
+    @Test func changedToolWithoutABenchmarkIsFlagged() {
+        // The #88 case: list_projects has no benchmark in the suite.
+        let assessment = BenchmarkCoverage.assess(changedFiles: [
+            "Sources/FocusRelayServer/FocusRelayServer.swift",
+            "Sources/OmniFocusCore/OmniFocusCore.swift",
+            "Sources/FocusRelayCLI/ListProjectsCommand.swift"
+        ])
+        #expect(assessment.touchedTools.contains("list_projects"))
+        #expect(assessment.uncovered.contains("list_projects"))
+        #expect(assessment.hasCoverageGap)
+    }
+
+    @Test func coveredToolDoesNotTripTheGate() {
+        let assessment = BenchmarkCoverage.assess(changedFiles: [
+            "Sources/OmniFocusCore/TaskIDSelection.swift"
+        ])
+        #expect(assessment.touchedTools.contains("list_tasks"))
+        #expect(assessment.covered.contains("list_tasks"))
+        #expect(!assessment.hasCoverageGap)
+    }
+
+    @Test func batchResolutionTouchesBothListTools() {
+        // #171 changed list_projects and list_tags; neither is benchmarked.
+        let assessment = BenchmarkCoverage.assess(changedFiles: [
+            "Sources/OmniFocusCore/BatchNameResolution.swift"
+        ])
+        #expect(Set(assessment.touchedTools).isSuperset(of: ["list_projects", "list_tags"]))
+        #expect(assessment.hasCoverageGap)
+    }
+
+    @Test func docsOnlyChangeTouchesNoTools() {
+        let assessment = BenchmarkCoverage.assess(changedFiles: ["README.md", "docs/roadmap-execution-plan.md"])
+        #expect(assessment.touchedTools.isEmpty)
+        #expect(!assessment.hasCoverageGap)
+    }
+
+    @Test func gapMessageNamesTheToolAndExplainsWhyGreenIsNotEnough() {
+        let assessment = BenchmarkCoverage.assess(changedFiles: ["Sources/FocusRelayCLI/ListProjectsCommand.swift"])
+        let message = BenchmarkCoverage.coverageGapMessage(assessment)
+        #expect(message.contains("list_projects"))
+        #expect(message.contains("does not clear this change"))
+        #expect(message.contains("interleaved A/B"))
+    }
+
+    @Test func everyBenchmarkedToolIsAPublicTool() {
+        #expect(BenchmarkCoverage.publicTools.isSuperset(of: BenchmarkCoverage.benchmarkedTools))
+    }
+
+    @Test func mostPublicToolsAreStillUnbenchmarked() {
+        // Records the current state honestly: 3 of 9 covered.
+        #expect(BenchmarkCoverage.benchmarkedTools.count == 3)
+        #expect(BenchmarkCoverage.publicTools.count == 9)
+    }
+}


### PR DESCRIPTION
Addresses the core of #206.

## The problem, restated from evidence

Validating #88 spent **four ten-minute smoke suites** on a gate that never benchmarks `list_projects` — so none of them measured a line of the changed path. The question was ultimately answered by a ten-minute interleaved A/B. Two things were missing: knowing the suite could not measure the change, and a rule for turning numbers into a decision.

## What this adds

**`BenchmarkCoverage`** maps changed files to the public tools they affect, and reports which of those the suite can actually measure. Only **3 of 9** public tools are benchmarked today, so the gap is the common case rather than an exotic one. `classify` now prints the assessment:

```
Benchmark coverage:
  ⚠️  list_projects — no benchmark in the suite
  ⚠️  list_tags — no benchmark in the suite

Benchmark coverage gap: list_projects, list_tags has no benchmark in the suite.
A passing benchmark run does not clear this change, because the suite never
exercises the path it modifies. Measure the changed tool directly with an
interleaved A/B against the baseline ref before drawing a performance conclusion.
```

That output is a **replay against #88's real file list** — the warning that would have saved four suites and about two hours.

**`BenchmarkVerdict`** turns two sample sets into an outcome plus a merge recommendation. A direction is claimed only when the change clears **both** a 5% relevance floor **and** three standard errors, so:

- a statistically clean but tiny difference reads as `INDISTINGUISHABLE`, not a win;
- a large difference on a noisy host reads as `INCONCLUSIVE`, not a regression.

Two outcomes exist specifically because of what happened during this work:

- **`INCONCLUSIVE`** — host variance swamps the effect. The 3-4x swings seen while validating #88 land here instead of producing a confident verdict.
- **`NOT COMPARABLE`** — the arms did not return equivalent results, so timings are meaningless. This is exactly the state #171 was in before its field bug was found: the fast arm was fast because it returned nothing. Without this outcome, benchmarking a broken implementation yields a beautiful, false improvement.

## Tests replay the real cases

| historical case | expected | result |
| --- | --- | --- |
| #171 measured numbers (2402ms → 432ms) | IMPROVEMENT | ✅ |
| #88 unchanged path (385ms vs 390ms) | INDISTINGUISHABLE | ✅ |
| observed 3-4x host swings | INCONCLUSIVE | ✅ |
| pre-bugfix #171 (arms disagree) | NOT COMPARABLE | ✅ |
| 2% change with near-zero variance | INDISTINGUISHABLE | ✅ |

334 tests pass (17 new). `validate --impact performance` passes with all semantic gates green.

## Not included

The remaining #206 scope, left for follow-up so this lands reviewable: adding actual benchmarks for the six uncovered tools, a `--baseline <ref>` flag that builds both refs and interleaves samples automatically, and deriving the request deadline from observed p99. This PR makes the gap **visible** and the verdict **stated**; automating the comparison is the next slice.