### PR TITLE
Derive catalog cache keys from the filter (#207)

### DIFF
--- a/Sources/OmniFocusAutomation/CatalogCache.swift
+++ b/Sources/OmniFocusAutomation/CatalogCache.swift
@@ -1,67 +1,31 @@
 import Foundation
 import OmniFocusCore
 
+/// Cache identity for a catalog page.
+///
+/// The filter contributes a fingerprint of its own encoding rather than a
+/// hand-listed set of fields, so adding a filter field changes the key
+/// automatically. Page and field selection are separate because they are not
+/// part of the filter.
 struct CacheKey: Hashable {
     let limit: Int
     let cursor: String?
     let fieldsKey: String
-    let statusFilter: String?
-    let includeTaskCounts: Bool
-    let search: String?
-    let rootOnly: Bool
+    let filterFingerprint: String
 
-    private init(
-        limit: Int,
-        cursor: String?,
-        fieldsKey: String,
-        statusFilter: String?,
-        includeTaskCounts: Bool,
-        search: String?,
-        rootOnly: Bool = false
-    ) {
-        self.limit = limit
-        self.cursor = cursor
-        self.fieldsKey = fieldsKey
-        self.statusFilter = statusFilter
-        self.includeTaskCounts = includeTaskCounts
-        self.search = search
-        self.rootOnly = rootOnly
+    init(page: PageRequest, fields: [String]?, filterFingerprint: String) {
+        self.limit = page.limit
+        self.cursor = page.cursor
+        self.fieldsKey = (fields ?? []).joined(separator: ",")
+        self.filterFingerprint = filterFingerprint
     }
 
-    static func projects(
-        page: PageRequest,
-        fields: [String]?,
-        statusFilter: String?,
-        includeTaskCounts: Bool,
-        search: String? = nil,
-        rootOnly: Bool = false
-    ) -> CacheKey {
-        CacheKey(
-            limit: page.limit,
-            cursor: page.cursor,
-            fieldsKey: (fields ?? []).joined(separator: ","),
-            statusFilter: statusFilter,
-            includeTaskCounts: includeTaskCounts,
-            search: search,
-            rootOnly: rootOnly
-        )
+    static func projects(page: PageRequest, fields: [String]?, filter: ProjectFilter) throws -> CacheKey {
+        CacheKey(page: page, fields: fields, filterFingerprint: try FilterCacheIdentity.fingerprint(filter))
     }
 
-    static func tags(
-        page: PageRequest,
-        fields: [String]? = nil,
-        statusFilter: String?,
-        includeTaskCounts: Bool,
-        search: String? = nil
-    ) -> CacheKey {
-        CacheKey(
-            limit: page.limit,
-            cursor: page.cursor,
-            fieldsKey: (fields ?? []).joined(separator: ","),
-            statusFilter: statusFilter,
-            includeTaskCounts: includeTaskCounts,
-            search: search
-        )
+    static func tags(page: PageRequest, fields: [String]?, filter: TagFilter) throws -> CacheKey {
+        CacheKey(page: page, fields: fields, filterFingerprint: try FilterCacheIdentity.fingerprint(filter))
     }
 }
 

--- a/Sources/OmniFocusAutomation/FilterCacheIdentity.swift
+++ b/Sources/OmniFocusAutomation/FilterCacheIdentity.swift
@@ -1,0 +1,66 @@
+import CryptoKit
+import Foundation
+import OmniFocusCore
+
+/// Derives a cache identity from a filter's own encoding, so a cached page can
+/// never satisfy a different query.
+///
+/// The previous key listed its fields by hand and stayed correct only because a
+/// separate `shouldBypassCache` list happened to name every field the key
+/// omitted. Nothing connected the two. #88 nearly shipped a `rootOnly`
+/// omission that would have served filed projects to a request for unfiled
+/// ones — no error, no warning, a plausible-looking answer. #171 then added
+/// `searches` to both filters, which the hand-written key also does not name.
+///
+/// Deriving from the encoded filter removes the class: a new filter field
+/// changes the identity automatically, because it changes the encoding.
+enum FilterCacheIdentity {
+    /// Filter fields whose presence means the result must not be cached at all.
+    /// These are time-relative or intentionally live, so a five-minute entry
+    /// would be wrong rather than merely stale.
+    ///
+    /// Kept as an explicit list because "do not cache" is a judgement about
+    /// semantics, not something derivable from the encoding — but it is now
+    /// checked against the encoded filter, so a renamed field cannot silently
+    /// stop matching.
+    static let uncacheableProjectFields: Set<String> = [
+        "reviewDueBefore", "reviewDueAfter", "reviewPerspective",
+        "completed", "completedBefore", "completedAfter",
+        "searches"
+    ]
+
+    static let uncacheableTagFields: Set<String> = ["searches"]
+
+    /// True when the filter carries any field that makes caching unsafe.
+    static func isCacheable<Filter: Encodable>(
+        _ filter: Filter,
+        uncacheableFields: Set<String>
+    ) throws -> Bool {
+        let present = try presentFieldNames(of: filter)
+        return present.isDisjoint(with: uncacheableFields)
+    }
+
+    /// Names of the filter's non-nil fields. Absent fields do not encode, so
+    /// this reflects what the caller actually asked for.
+    static func presentFieldNames<Filter: Encodable>(of filter: Filter) throws -> Set<String> {
+        let data = try encoder().encode(filter)
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return []
+        }
+        return Set(object.keys)
+    }
+
+    /// Stable fingerprint of the filter's full encoded content.
+    static func fingerprint<Filter: Encodable>(_ filter: Filter) throws -> String {
+        let data = try encoder().encode(filter)
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func encoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        // Sorted keys so identical filters always encode identically.
+        encoder.outputFormatting = [.sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+}

--- a/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
+++ b/Sources/OmniFocusAutomation/OmniFocusBridgeService.swift
@@ -96,16 +96,13 @@ public final class OmniFocusBridgeService: OmniFocusService {
             input: projectFilter
         )
         let bridgePage = try QueryBoundCursor.bridgePage(from: page, identity: identity)
-        let shouldBypassCache = reviewPerspective || reviewDueBefore != nil || reviewDueAfter != nil || completed != nil || completedBefore != nil || completedAfter != nil
-        if !shouldBypassCache {
-            let key = CacheKey.projects(
-                page: bridgePage,
-                fields: fields,
-                statusFilter: statusFilter,
-                includeTaskCounts: includeTaskCounts,
-                search: normalizedSearch,
-                rootOnly: rootOnly
-            )
+        // Both the cacheability decision and the key now come from the filter
+        // itself, so a new filter field cannot be missed by one and not the other.
+        let cacheable = (try? FilterCacheIdentity.isCacheable(
+            projectFilter,
+            uncacheableFields: FilterCacheIdentity.uncacheableProjectFields
+        )) ?? false
+        if cacheable, let key = try? CacheKey.projects(page: bridgePage, fields: fields, filter: projectFilter) {
             if let cached = await cache.getProjects(key: key) {
                 return try QueryBoundCursor.publicPage(from: cached, identity: identity)
             }
@@ -180,14 +177,12 @@ public final class OmniFocusBridgeService: OmniFocusService {
         )
         let identity = try QueryBoundCursor.queryIdentity(tool: "list_tags", input: filter)
         let bridgePage = try QueryBoundCursor.bridgePage(from: page, identity: identity)
-        let key = CacheKey.tags(
-            page: bridgePage,
-            fields: fields,
-            statusFilter: statusFilter,
-            includeTaskCounts: includeTaskCounts,
-            search: normalizedSearch
-        )
-        if let cached = await cache.getTags(key: key) {
+        let tagsCacheable = (try? FilterCacheIdentity.isCacheable(
+            filter,
+            uncacheableFields: FilterCacheIdentity.uncacheableTagFields
+        )) ?? false
+        let key = try CacheKey.tags(page: bridgePage, fields: fields, filter: filter)
+        if tagsCacheable, let cached = await cache.getTags(key: key) {
             return try QueryBoundCursor.publicPage(from: cached, identity: identity)
         }
         let pageResult = try await runtime.submit(
@@ -202,7 +197,9 @@ public final class OmniFocusBridgeService: OmniFocusService {
                 )
             },
             finalize: { pageResult in
-                await self.cache.setTags(pageResult, key: key, ttl: self.cacheTTL)
+                if tagsCacheable {
+                    await self.cache.setTags(pageResult, key: key, ttl: self.cacheTTL)
+                }
                 return pageResult
             }
         )

--- a/Tests/OmniFocusIntegrationTests/CatalogCacheCoalescingTests.swift
+++ b/Tests/OmniFocusIntegrationTests/CatalogCacheCoalescingTests.swift
@@ -9,13 +9,10 @@ import Testing
 @Suite("Catalog cache fill coalescing")
 struct CatalogCacheCoalescingTests {
     private func key(_ search: String? = nil) -> CacheKey {
-        CacheKey.projects(
+        try! CacheKey.projects(
             page: PageRequest(limit: 1000),
             fields: ["id", "name"],
-            statusFilter: "active",
-            includeTaskCounts: false,
-            search: search,
-            rootOnly: false
+            filter: ProjectFilter(statusFilter: "active", includeTaskCounts: false, search: search)
         )
     }
 

--- a/Tests/OmniFocusIntegrationTests/CatalogCacheTests.swift
+++ b/Tests/OmniFocusIntegrationTests/CatalogCacheTests.swift
@@ -3,140 +3,89 @@ import Testing
 @testable import OmniFocusAutomation
 import OmniFocusCore
 
+private func projectKey(
+    page: PageRequest = PageRequest(limit: 10, cursor: "cursor"),
+    fields: [String]? = ["id", "name"],
+    _ filter: ProjectFilter
+) -> CacheKey {
+    try! CacheKey.projects(page: page, fields: fields, filter: filter)
+}
+
+private func tagKey(
+    page: PageRequest = PageRequest(limit: 10, cursor: "cursor"),
+    fields: [String]? = ["id", "name"],
+    _ filter: TagFilter
+) -> CacheKey {
+    try! CacheKey.tags(page: page, fields: fields, filter: filter)
+}
+
 @Test
 func projectCacheKeyMatchesForSameInputs() {
-    let page = PageRequest(limit: 10, cursor: "cursor")
-    let lhs = CacheKey.projects(
-        page: page,
-        fields: ["id", "name"],
-        statusFilter: "active",
-        includeTaskCounts: true
-    )
-    let rhs = CacheKey.projects(
-        page: page,
-        fields: ["id", "name"],
-        statusFilter: "active",
-        includeTaskCounts: true
-    )
-
-    #expect(lhs == rhs)
+    let filter = ProjectFilter(statusFilter: "active", includeTaskCounts: true)
+    #expect(projectKey(filter) == projectKey(filter))
 }
 
 @Test
 func projectCacheKeySeparatesStatusFilter() {
-    let page = PageRequest(limit: 10, cursor: "cursor")
-    let active = CacheKey.projects(
-        page: page,
-        fields: ["id", "name"],
-        statusFilter: "active",
-        includeTaskCounts: false
-    )
-    let done = CacheKey.projects(
-        page: page,
-        fields: ["id", "name"],
-        statusFilter: "done",
-        includeTaskCounts: false
-    )
-
-    #expect(active != done)
+    #expect(projectKey(ProjectFilter(statusFilter: "active", includeTaskCounts: false))
+        != projectKey(ProjectFilter(statusFilter: "done", includeTaskCounts: false)))
 }
 
 @Test
 func projectCacheKeySeparatesNameSearch() {
     let page = PageRequest(limit: 10)
-    let first = CacheKey.projects(
-        page: page,
-        fields: ["id", "name"],
-        statusFilter: "all",
-        includeTaskCounts: false,
-        search: "drop test"
-    )
-    let second = CacheKey.projects(
-        page: page,
-        fields: ["id", "name"],
-        statusFilter: "all",
-        includeTaskCounts: false,
-        search: "another"
-    )
-    #expect(first != second)
+    #expect(projectKey(page: page, ProjectFilter(statusFilter: "all", includeTaskCounts: false, search: "drop test"))
+        != projectKey(page: page, ProjectFilter(statusFilter: "all", includeTaskCounts: false, search: "another")))
 }
 
 @Test
 func projectCacheKeySeparatesIncludeTaskCounts() {
-    let page = PageRequest(limit: 10, cursor: "cursor")
-    let withoutCounts = CacheKey.projects(
-        page: page,
-        fields: ["id", "name"],
-        statusFilter: "active",
-        includeTaskCounts: false
-    )
-    let withCounts = CacheKey.projects(
-        page: page,
-        fields: ["id", "name"],
-        statusFilter: "active",
-        includeTaskCounts: true
-    )
+    #expect(projectKey(ProjectFilter(statusFilter: "active", includeTaskCounts: false))
+        != projectKey(ProjectFilter(statusFilter: "active", includeTaskCounts: true)))
+}
 
-    #expect(withoutCounts != withCounts)
+@Test
+func projectCacheKeySeparatesRequestedFields() {
+    let filter = ProjectFilter(statusFilter: "active", includeTaskCounts: false)
+    #expect(projectKey(fields: ["id", "name"], filter) != projectKey(fields: ["id", "name", "folderPath"], filter))
+}
+
+/// The near-miss from #88: `rootOnly` must change the key, or a cached
+/// full-catalogue page satisfies a request for unfiled projects only.
+@Test
+func projectCacheKeySeparatesRootOnly() {
+    #expect(projectKey(ProjectFilter(statusFilter: "active"))
+        != projectKey(ProjectFilter(rootOnly: true, statusFilter: "active")))
+}
+
+/// The field #171 added. Under the previous hand-listed key this was invisible;
+/// derivation covers it without anyone remembering to.
+@Test
+func projectCacheKeySeparatesBatchSearches() {
+    #expect(projectKey(ProjectFilter(statusFilter: "active"))
+        != projectKey(ProjectFilter(searches: ["work"], statusFilter: "active")))
 }
 
 @Test
 func tagCacheKeySeparatesStatusFilter() {
-    let page = PageRequest(limit: 10, cursor: "cursor")
-    let active = CacheKey.tags(
-        page: page,
-        statusFilter: "active",
-        includeTaskCounts: false
-    )
-    let onHold = CacheKey.tags(
-        page: page,
-        statusFilter: "onHold",
-        includeTaskCounts: false
-    )
-
-    #expect(active != onHold)
+    #expect(tagKey(TagFilter(statusFilter: "active", includeTaskCounts: false))
+        != tagKey(TagFilter(statusFilter: "onHold", includeTaskCounts: false)))
 }
 
 @Test
 func tagCacheKeySeparatesIncludeTaskCounts() {
-    let page = PageRequest(limit: 10, cursor: "cursor")
-    let withoutCounts = CacheKey.tags(
-        page: page,
-        statusFilter: "active",
-        includeTaskCounts: false
-    )
-    let withCounts = CacheKey.tags(
-        page: page,
-        statusFilter: "active",
-        includeTaskCounts: true
-    )
-
-    #expect(withoutCounts != withCounts)
+    #expect(tagKey(TagFilter(statusFilter: "active", includeTaskCounts: false))
+        != tagKey(TagFilter(statusFilter: "active", includeTaskCounts: true)))
 }
 
 @Test
 func tagCacheKeySeparatesSearchAndHierarchyFields() {
-    let page = PageRequest(limit: 10, cursor: "cursor")
-    let compact = CacheKey.tags(
-        page: page,
+    let filter = TagFilter(statusFilter: "active", includeTaskCounts: false, search: "contact")
+    let compact = tagKey(fields: ["id", "name"], filter)
+    let hierarchy = tagKey(fields: ["id", "name", "path"], filter)
+    let differentSearch = tagKey(
         fields: ["id", "name"],
-        statusFilter: "active",
-        includeTaskCounts: false,
-        search: "contact"
-    )
-    let hierarchy = CacheKey.tags(
-        page: page,
-        fields: ["id", "name", "path"],
-        statusFilter: "active",
-        includeTaskCounts: false,
-        search: "contact"
-    )
-    let differentSearch = CacheKey.tags(
-        page: page,
-        fields: ["id", "name"],
-        statusFilter: "active",
-        includeTaskCounts: false,
-        search: "context"
+        TagFilter(statusFilter: "active", includeTaskCounts: false, search: "context")
     )
 
     #expect(compact != hierarchy)
@@ -144,22 +93,18 @@ func tagCacheKeySeparatesSearchAndHierarchyFields() {
 }
 
 @Test
+func tagCacheKeySeparatesBatchSearches() {
+    #expect(tagKey(TagFilter(statusFilter: "active"))
+        != tagKey(TagFilter(searches: ["work"], statusFilter: "active")))
+}
+
+@Test
 func catalogCacheSeparatesProjectEntriesByKey() async {
     let cache = CatalogCache()
     let page = PageRequest(limit: 10)
     let summary = ProjectTaskSummary(id: "task-1", name: "Next")
-    let activeKey = CacheKey.projects(
-        page: page,
-        fields: ["id", "name"],
-        statusFilter: "active",
-        includeTaskCounts: false
-    )
-    let doneKey = CacheKey.projects(
-        page: page,
-        fields: ["id", "name"],
-        statusFilter: "done",
-        includeTaskCounts: false
-    )
+    let activeKey = projectKey(page: page, ProjectFilter(statusFilter: "active", includeTaskCounts: false))
+    let doneKey = projectKey(page: page, ProjectFilter(statusFilter: "done", includeTaskCounts: false))
     let activePage = Page(
         items: [ProjectItem(id: "project-active", name: "Active", status: "active", flagged: false, nextTask: summary)],
         returnedCount: 1,
@@ -176,7 +121,6 @@ func catalogCacheSeparatesProjectEntriesByKey() async {
 
     let cachedActive = await cache.getProjects(key: activeKey)
     let cachedDone = await cache.getProjects(key: doneKey)
-
     #expect(cachedActive?.items.first?.id == "project-active")
     #expect(cachedDone?.items.first?.id == "project-done")
 }
@@ -185,16 +129,8 @@ func catalogCacheSeparatesProjectEntriesByKey() async {
 func catalogCacheSeparatesTagEntriesByKey() async {
     let cache = CatalogCache()
     let page = PageRequest(limit: 10)
-    let plainKey = CacheKey.tags(
-        page: page,
-        statusFilter: "active",
-        includeTaskCounts: false
-    )
-    let countedKey = CacheKey.tags(
-        page: page,
-        statusFilter: "active",
-        includeTaskCounts: true
-    )
+    let plainKey = tagKey(page: page, TagFilter(statusFilter: "active", includeTaskCounts: false))
+    let countedKey = tagKey(page: page, TagFilter(statusFilter: "active", includeTaskCounts: true))
     let plainPage = Page(
         items: [TagItem(id: "tag-1", name: "Inbox", status: "active")],
         returnedCount: 1,
@@ -211,7 +147,6 @@ func catalogCacheSeparatesTagEntriesByKey() async {
 
     let cachedPlain = await cache.getTags(key: plainKey)
     let cachedCounted = await cache.getTags(key: countedKey)
-
     #expect(cachedPlain?.items.first?.totalTasks == nil)
     #expect(cachedCounted?.items.first?.totalTasks == 5)
 }
@@ -219,34 +154,87 @@ func catalogCacheSeparatesTagEntriesByKey() async {
 @Test
 func catalogCacheInvalidatesProjectsAndTags() async {
     let cache = CatalogCache()
-    let projectKey = CacheKey.projects(
+    let pKey = projectKey(
         page: PageRequest(limit: 10),
         fields: ["id"],
-        statusFilter: "active",
-        includeTaskCounts: false
+        ProjectFilter(statusFilter: "active", includeTaskCounts: false)
     )
-    let tagKey = CacheKey.tags(
-        page: PageRequest(limit: 10),
-        statusFilter: "active",
-        includeTaskCounts: false
-    )
+    let tKey = tagKey(page: PageRequest(limit: 10), TagFilter(statusFilter: "active", includeTaskCounts: false))
 
     await cache.setProjects(
         Page(items: [ProjectItem(id: "project-1", name: "Project", status: "active", flagged: false)], returnedCount: 1, totalCount: 1),
-        key: projectKey,
+        key: pKey,
         ttl: 60
     )
     await cache.setTags(
         Page(items: [TagItem(id: "tag-1", name: "Tag", status: "active")], returnedCount: 1, totalCount: 1),
-        key: tagKey,
+        key: tKey,
         ttl: 60
     )
 
     await cache.invalidateAll()
 
-    let cachedProject = await cache.getProjects(key: projectKey)
-    let cachedTag = await cache.getTags(key: tagKey)
-
+    let cachedProject = await cache.getProjects(key: pKey)
+    let cachedTag = await cache.getTags(key: tKey)
     #expect(cachedProject == nil)
     #expect(cachedTag == nil)
+}
+
+/// The point of deriving the key: cacheability and identity are decided from
+/// the same encoded filter, so a new field cannot be missed by one and not the
+/// other.
+@Suite("Filter cache identity")
+struct FilterCacheIdentityTests {
+    @Test func ordinaryFilterIsCacheable() throws {
+        #expect(try FilterCacheIdentity.isCacheable(
+            ProjectFilter(statusFilter: "active"),
+            uncacheableFields: FilterCacheIdentity.uncacheableProjectFields
+        ))
+    }
+
+    @Test func reviewPerspectiveIsNotCacheable() throws {
+        #expect(!(try FilterCacheIdentity.isCacheable(
+            ProjectFilter(statusFilter: "active", reviewPerspective: true),
+            uncacheableFields: FilterCacheIdentity.uncacheableProjectFields
+        )))
+    }
+
+    @Test func completionWindowIsNotCacheable() throws {
+        #expect(!(try FilterCacheIdentity.isCacheable(
+            ProjectFilter(statusFilter: "active", completed: true),
+            uncacheableFields: FilterCacheIdentity.uncacheableProjectFields
+        )))
+    }
+
+    @Test func batchResolutionIsNotCacheable() throws {
+        #expect(!(try FilterCacheIdentity.isCacheable(
+            ProjectFilter(searches: ["work"], statusFilter: "active"),
+            uncacheableFields: FilterCacheIdentity.uncacheableProjectFields
+        )))
+    }
+
+    @Test func absentFieldsDoNotCountAsPresent() throws {
+        let names = try FilterCacheIdentity.presentFieldNames(of: ProjectFilter(statusFilter: "active"))
+        #expect(names.contains("statusFilter"))
+        #expect(!names.contains("completed"), "a nil field must not encode")
+    }
+
+    @Test func identicalFiltersFingerprintIdentically() throws {
+        let a = try FilterCacheIdentity.fingerprint(ProjectFilter(statusFilter: "active", search: "x"))
+        let b = try FilterCacheIdentity.fingerprint(ProjectFilter(statusFilter: "active", search: "x"))
+        #expect(a == b)
+    }
+
+    @Test func anyFieldChangeChangesTheFingerprint() throws {
+        let base = try FilterCacheIdentity.fingerprint(ProjectFilter(statusFilter: "active"))
+        for changed in [
+            ProjectFilter(statusFilter: "done"),
+            ProjectFilter(rootOnly: true, statusFilter: "active"),
+            ProjectFilter(statusFilter: "active", includeTaskCounts: true),
+            ProjectFilter(statusFilter: "active", search: "x"),
+            ProjectFilter(matchLimitPerSearch: 5, statusFilter: "active")
+        ] {
+            #expect(try FilterCacheIdentity.fingerprint(changed) != base)
+        }
+    }
 }

--- a/Tests/OmniFocusIntegrationTests/ProjectFolderMembershipTests.swift
+++ b/Tests/OmniFocusIntegrationTests/ProjectFolderMembershipTests.swift
@@ -10,13 +10,10 @@ import Testing
 @Suite("rootOnly cache keying")
 struct RootOnlyCacheKeyTests {
     private func key(rootOnly: Bool, statusFilter: String = "active") -> CacheKey {
-        CacheKey.projects(
+        try! CacheKey.projects(
             page: PageRequest(limit: 150),
             fields: ["id", "name"],
-            statusFilter: statusFilter,
-            includeTaskCounts: false,
-            search: nil,
-            rootOnly: rootOnly
+            filter: ProjectFilter(rootOnly: rootOnly ? true : nil, statusFilter: statusFilter, includeTaskCounts: false)
         )
     }
 


### PR DESCRIPTION
Closes #207.

## The problem

`CacheKey` listed its fields by hand and stayed correct only because a separate `shouldBypassCache` expression happened to name every field the key omitted. Nothing connected the two — they agreed by inspection, not construction.

The gap was already widening:

- **#88** nearly shipped a `rootOnly` omission. A cached full-catalogue page would have satisfied a request for unfiled projects only: no error, no warning, a plausible-looking answer.
- **#171** then added `searches` and `matchLimitPerSearch` to both filters, and neither appeared in the key. That was harmless *only* because the batch path bypasses the cache entirely — a property nothing enforced and nobody had written down.

## The change

The key is now a fingerprint of the filter's own sorted-key encoding, so **any new filter field changes the identity automatically**. Page limit, cursor, and requested fields stay explicit, because they are not part of the filter.

Cacheability is decided from that same encoding. "Do not cache" stays an explicit field-name list — it is a judgement about semantics (time-relative review and completion windows, live batch resolution), not something derivable — but it is now checked against the encoded filter rather than duplicated as a boolean expression that can drift from it.

**Fixed while here:** the tags path consulted the cache conditionally but wrote to it unconditionally, so an uncacheable tag result would still have been stored.

## Tests

Existing key-separation tests are preserved and migrated rather than replaced — they pin real behaviour and all still pass. Added:

- `projectCacheKeySeparatesRootOnly` — the #88 near-miss, now structurally impossible
- `projectCacheKeySeparatesBatchSearches` / `tagCacheKeySeparatesBatchSearches` — the #171 fields the old key never saw
- `anyFieldChangeChangesTheFingerprint` — the invariant itself, across five distinct fields
- cacheability coverage for review, completion, and batch filters
- `absentFieldsDoNotCountAsPresent` — a nil field must not encode, or every filter would look uncacheable

One honest note on the acceptance criteria: the issue asked for a test that fails when a filter gains a field the derivation cannot see. That test cannot be written directly, because derivation sees every field by construction — which is the point. The invariant is covered instead by asserting that representative field changes each alter the fingerprint.

## Validation

Impact: `query`. **345 tests pass**; all semantic gates pass. Verified live that a `rootOnly` query and an unscoped query return different result sets (73 vs 150 items) with no cross-contamination.