### PR TITLE
Record the added caution #173 carries as the first mutation slice

### DIFF
--- a/docs/roadmap-execution-plan.md
+++ b/docs/roadmap-execution-plan.md
@@ -14,13 +14,19 @@ the mutation surface is unchanged since the release.
 
 The next slice is [#173 — atomic heterogeneous task edit
 plans](https://github.com/deverman/FocusRelayMCP/issues/173), whose
-read-before-write cost #172 and #171 were sequenced to reduce.
+read-before-write cost #172 and #171 were sequenced to reduce. It is also the
+first mutation work in the queue, and it deserves more caution than the
+read-path slices behind it: a wrong query returns bad data the caller can
+discard, while a wrong write changes the user's database.
 
 ## Delivery Order
 
 1. [#173 — atomic heterogeneous task edit plans](https://github.com/deverman/FocusRelayMCP/issues/173)
    - Design the larger approved-workflow batch only after #172 and #171 reduce
      its read-before-write query cost.
+   - First mutation slice since the release. Establish the failure and rollback
+     story before the convenience of the batch: what a partially applied plan
+     leaves behind, and how the caller learns which edits landed.
 2. [#94 — discoverable MCP workflows](https://github.com/deverman/FocusRelayMCP/issues/94)
    - Continue measured client research after the shipped `process_inbox`
      vertical; add another prompt only when UAT demonstrates a reliable benefit.


### PR DESCRIPTION
#173 is the next slice and the first mutation work in the queue. The roadmap already noted that the mutation surface is unchanged since the release, but not why that raises the bar for the next slice: a wrong query returns bad data the caller can discard, while a wrong write changes the user's database.

Adds two things to `docs/roadmap-execution-plan.md`:

- **Current Focus** now states the added caution directly, rather than leaving it implied by "all of that is read-path work".
- **Delivery order item 1** names the question to settle before the convenience of the batch: what a partially applied plan leaves behind, and how the caller learns which edits landed.

Docs only; no code paths touched.

Companion change on GitHub: #206 has been retitled to "Benchmark the path a change actually touches", dropping the merge-verdict half that #213 deleted. Its original body is preserved in full with a status section appended recording what shipped (#211), what was removed (#213), and what remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhJNEmLXYL5x4M7xJJWVFP